### PR TITLE
Feature/636: Table Pagination

### DIFF
--- a/src/components/Page/Table/Table.vue
+++ b/src/components/Page/Table/Table.vue
@@ -80,34 +80,28 @@
         <li class="moj-pagination__item  moj-pagination__item--prev">
           <a
             class="moj-pagination__link"
-            href=""
+            @click.prevent="changePage('previous')"
           >Previous<span class="govuk-visually-hidden"> set of pages</span></a>
         </li> 
-        <li class="moj-pagination__item">
+        
+        <li
+          v-for="number in calculatePages"
+          :key="number"
+          scope="col"
+          class="moj-pagination__item"
+        >
           <a
             class="moj-pagination__link"
-            href="#"
-          >9</a>
+          >{{ number }}</a>
         </li> 
-        <li class="moj-pagination__item moj-pagination__item--active">
-          10
-        </li> 
-        <li class="moj-pagination__item">
-          <a
-            class="moj-pagination__link"
-            href="#"
-          >11</a>
-        </li> 
+
         <li class="moj-pagination__item  moj-pagination__item--next">
           <a
             class="moj-pagination__link"
-            href=""
+            @click.prevent="changePage('next')"
           >Next<span class="govuk-visually-hidden"> set of pages</span></a>
         </li>
       </ul>
-      <p class="moj-pagination__results">
-        Showing <b>10</b> to <b>20</b> of <b>30</b> results
-      </p>
     </nav>
   </div>
 </template>
@@ -140,13 +134,13 @@ export default {
     pageSize: {
       type: Number, 
       required: false, 
-      default: 2,
+      default: 25,
     },
-    pageNumber: {
-      type: Number,
-      required: false, 
-      default: 1,
-    },
+  },
+  data(){
+    return {
+      pageNumber: 1,
+    };
   },
   computed: {
     selectAll: {
@@ -183,21 +177,39 @@ export default {
     },
     getPaginatedItems(){
       const numberOfPages = this.calculatePages;
+      if(numberOfPages){
+        if(this.pageNumber > numberOfPages) throw `Page ${this.pageNumber} exceeds page size of ${this.numberOfPages}`;
 
-      if(this.pageNumber > numberOfPages) throw 'Page {0} exceeds page size of {1}'.format(this.pageNumber, numberOfPages);
+        const sliceFrom = (this.pageNumber * this.pageSize -1);
+        const sliceTo = sliceFrom + this.pageSize; 
 
-      const sliceFrom = (this.pageNumber * this.pageSize) - 1;
-      const sliceTo = sliceFrom + this.pageSize; 
+        const sliced = this.data.slice(sliceFrom, sliceTo);
+        
+        return sliced;
+      } else {
+        return {};
+      }
+    },
+  },
+  methods: {
+    changePage(direction){
+      const numberOfPages = this.calculatePages;
+      var newPageNumber = this.pageNumber;
 
-      const sliced = this.data.slice(sliceFrom, sliceTo);
+      if(direction == 'next'){
+        newPageNumber++;
+      } else if (direction == 'previous'){
+        newPageNumber--;
+      } else {
+        throw `Invalid direction: '${direction}'`;
+      }
 
-      console.log(this.pageSize);
-      console.log(numberOfPages);
-      console.log(sliceFrom);
-      console.log(sliceTo);
-      console.log(sliced);
-
-      return sliced;
+      if(newPageNumber <= 0 || newPageNumber >= numberOfPages){
+        return false;
+      } else {
+        this.pageNumber = newPageNumber;
+        return true;
+      }
     },
   },
 };

--- a/src/components/Page/Table/Table.vue
+++ b/src/components/Page/Table/Table.vue
@@ -1,70 +1,115 @@
 <template>
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th
-          v-if="multiSelect"
-          scope="col"
-          class="govuk-table__header govuk-!-padding-top-0"
-        >
-          <div class="govuk-checkboxes govuk-checkboxes--small">
-            <div class="govuk-checkboxes__item">
-              <input
-                id="selectAll"
-                v-model="selectAll"
-                class="govuk-checkboxes__input"
-                type="checkbox"
-              >
-              <label
-                class="govuk-label govuk-checkboxes__label"
-                for="checkboxes"
-              />
+  <div>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th
+            v-if="multiSelect"
+            scope="col"
+            class="govuk-table__header govuk-!-padding-top-0"
+          >
+            <div class="govuk-checkboxes govuk-checkboxes--small">
+              <div class="govuk-checkboxes__item">
+                <input
+                  id="selectAll"
+                  v-model="selectAll"
+                  class="govuk-checkboxes__input"
+                  type="checkbox"
+                >
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="checkboxes"
+                />
+              </div>
             </div>
-          </div>
-        </th>        
-        <th
-          v-for="(column, index) in columns"
-          :key="index"
-          scope="col"
-          class="govuk-table__header"          
+          </th>        
+          <th
+            v-for="(column, index) in columns"
+            :key="index"
+            scope="col"
+            class="govuk-table__header"          
+          >
+            {{ column.title }}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr
+          v-for="row in getPaginatedItems"
+          :key="row[dataKey]"
+          class="govuk-table__row"
         >
-          {{ column.title }}
-        </th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <tr
-        v-for="row in data"
-        :key="row[dataKey]"
-        class="govuk-table__row"
+          <td 
+            v-if="multiSelect"
+            class="govuk-table__cell govuk-!-padding-top-0"
+          >
+            <div class="govuk-checkboxes govuk-checkboxes--small">
+              <div class="govuk-checkboxes__item">
+                <input
+                  :id="`item-${row[dataKey]}`"
+                  v-model="selectedItems"
+                  :value="row[dataKey]"
+                  class="govuk-checkboxes__input"
+                  type="checkbox"
+                >
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  :for="`item-${row[dataKey]}`"
+                />
+              </div>
+            </div>
+          </td>      
+          <slot 
+            name="row" 
+            :row="row"
+          />
+        </tr>
+      </tbody>
+    </table>
+    <nav
+      v-if="pagination"
+      class="moj-pagination"
+    >
+      <p
+        class="govuk-visually-hidden"
+        aria-labelledby="pagination-label"
       >
-        <td 
-          v-if="multiSelect"
-          class="govuk-table__cell govuk-!-padding-top-0"
-        >
-          <div class="govuk-checkboxes govuk-checkboxes--small">
-            <div class="govuk-checkboxes__item">
-              <input
-                :id="`item-${row[dataKey]}`"
-                v-model="selectedItems"
-                :value="row[dataKey]"
-                class="govuk-checkboxes__input"
-                type="checkbox"
-              >
-              <label
-                class="govuk-label govuk-checkboxes__label"
-                :for="`item-${row[dataKey]}`"
-              />
-            </div>
-          </div>
-        </td>      
-        <slot 
-          name="row" 
-          :row="row"
-        />
-      </tr>
-    </tbody>
-  </table>  
+        Pagination navigation
+      </p>
+      <ul class="moj-pagination__list">
+        <li class="moj-pagination__item  moj-pagination__item--prev">
+          <a
+            class="moj-pagination__link"
+            href=""
+          >Previous<span class="govuk-visually-hidden"> set of pages</span></a>
+        </li> 
+        <li class="moj-pagination__item">
+          <a
+            class="moj-pagination__link"
+            href="#"
+          >9</a>
+        </li> 
+        <li class="moj-pagination__item moj-pagination__item--active">
+          10
+        </li> 
+        <li class="moj-pagination__item">
+          <a
+            class="moj-pagination__link"
+            href="#"
+          >11</a>
+        </li> 
+        <li class="moj-pagination__item  moj-pagination__item--next">
+          <a
+            class="moj-pagination__link"
+            href=""
+          >Next<span class="govuk-visually-hidden"> set of pages</span></a>
+        </li>
+      </ul>
+      <p class="moj-pagination__results">
+        Showing <b>10</b> to <b>20</b> of <b>30</b> results
+      </p>
+    </nav>
+  </div>
 </template>
 
 <script>
@@ -92,6 +137,16 @@ export default {
       required: false,
       default: () => [],
     },
+    pageSize: {
+      type: Number, 
+      required: false, 
+      default: 2,
+    },
+    pageNumber: {
+      type: Number,
+      required: false, 
+      default: 1,
+    },
   },
   computed: {
     selectAll: {
@@ -115,7 +170,35 @@ export default {
       set(value) {
         this.$emit('update:selection', value);
       },
-    },    
+    },
+    pagination() {
+      return true; 
+    },
+    calculatePages(){
+      if(this.data.length > this.pageSize){
+        return Math.round(this.data.length / this.pageSize);
+      } else {
+        return this.data.length;
+      }
+    },
+    getPaginatedItems(){
+      const numberOfPages = this.calculatePages;
+
+      if(this.pageNumber > numberOfPages) throw 'Page {0} exceeds page size of {1}'.format(this.pageNumber, numberOfPages);
+
+      const sliceFrom = (this.pageNumber * this.pageSize) - 1;
+      const sliceTo = sliceFrom + this.pageSize; 
+
+      const sliced = this.data.slice(sliceFrom, sliceTo);
+
+      console.log(this.pageSize);
+      console.log(numberOfPages);
+      console.log(sliceFrom);
+      console.log(sliceTo);
+      console.log(sliced);
+
+      return sliced;
+    },
   },
 };
 </script>

--- a/src/components/Page/Table/Table.vue
+++ b/src/components/Page/Table/Table.vue
@@ -85,12 +85,14 @@
         </li> 
         
         <li
-          v-for="number in calculatePages"
+          v-for="number in (calculatePages)"
           :key="number"
           scope="col"
           class="moj-pagination__item"
+          v-bind:class="{ 'moj-pagination__item--active': number == pageNumber }" 
         >
           <a
+            @click.prevent="changePage(number)"
             class="moj-pagination__link"
           >{{ number }}</a>
         </li> 
@@ -169,22 +171,21 @@ export default {
       return true; 
     },
     calculatePages(){
-      if(this.data.length > this.pageSize){
-        return Math.round(this.data.length / this.pageSize);
-      } else {
-        return this.data.length;
-      }
+      return Math.ceil(this.data.length / this.pageSize);
     },
     getPaginatedItems(){
       const numberOfPages = this.calculatePages;
-      if(numberOfPages){
-        if(this.pageNumber > numberOfPages) throw `Page ${this.pageNumber} exceeds page size of ${this.numberOfPages}`;
+      // Zero-index
+      const pageNumber = this.pageNumber - 1;
 
-        const sliceFrom = (this.pageNumber * this.pageSize -1);
+      if(numberOfPages){
+        if(pageNumber > numberOfPages) throw `Page ${pageNumber} exceeds page size of ${this.numberOfPages}`;
+
+        const sliceFrom = (pageNumber * this.pageSize);
         const sliceTo = sliceFrom + this.pageSize; 
 
         const sliced = this.data.slice(sliceFrom, sliceTo);
-        
+
         return sliced;
       } else {
         return {};
@@ -193,6 +194,7 @@ export default {
   },
   methods: {
     changePage(direction){
+      // Direction can either be: next, previous, {{jump page number}}
       const numberOfPages = this.calculatePages;
       var newPageNumber = this.pageNumber;
 
@@ -200,11 +202,13 @@ export default {
         newPageNumber++;
       } else if (direction == 'previous'){
         newPageNumber--;
+      } else if (Number.isInteger(direction)){
+        newPageNumber = direction;
       } else {
         throw `Invalid direction: '${direction}'`;
       }
-
-      if(newPageNumber <= 0 || newPageNumber >= numberOfPages){
+      // + 1 as we're zero indexed 
+      if(newPageNumber <= 0 || newPageNumber >= numberOfPages + 1){
         return false;
       } else {
         this.pageNumber = newPageNumber;

--- a/src/components/Page/Table/Table.vue
+++ b/src/components/Page/Table/Table.vue
@@ -89,11 +89,11 @@
           :key="number"
           scope="col"
           class="moj-pagination__item"
-          v-bind:class="{ 'moj-pagination__item--active': number == pageNumber }" 
+          :class="{ 'moj-pagination__item--active': number == pageNumber }" 
         >
           <a
-            @click.prevent="changePage(number)"
             class="moj-pagination__link"
+            @click.prevent="changePage(number)"
           >{{ number }}</a>
         </li> 
 

--- a/src/store/stage/handover.js
+++ b/src/store/stage/handover.js
@@ -10,11 +10,12 @@ const collectionRef = firestore.collection('applicationRecords');
 export default {
   namespaced: true,
   actions: {
-    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId } ) => {
+    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId, limit } ) => {
       let firestoreRef = collectionRef
         .where('exercise.id', '==', exerciseId)
         .where('stage', '==', EXERCISE_STAGE.HANDOVER)
-        .where('active', '==', true);
+        .where('active', '==', true)
+        .limit(limit);
 
       return bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
     }),

--- a/src/store/stage/recommended.js
+++ b/src/store/stage/recommended.js
@@ -22,12 +22,12 @@ export default {
     },
   },
   actions: {
-    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId } ) => {
+    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId, limit } ) => {
       let firestoreRef = collectionRef
         .where('exercise.id', '==', exerciseId)
         .where('stage', '==', EXERCISE_STAGE.RECOMMENDED)
         .where('active', '==', true)
-        .limit(50);
+        .limit(limit);
 
       return bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
     }),

--- a/src/store/stage/review.js
+++ b/src/store/stage/review.js
@@ -69,12 +69,12 @@ export default {
     },
   },
   actions: {
-    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId } ) => {
+    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId, limit } ) => {
       let firestoreRef = collectionRef
         .where('exercise.id', '==', exerciseId)
         .where('stage', '==', EXERCISE_STAGE.REVIEW)
-        .where('active', '==', true);
-        // .limit(50);
+        .where('active', '==', true)
+        .limit(limit);
 
       return bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
     }),

--- a/src/store/stage/selected.js
+++ b/src/store/stage/selected.js
@@ -20,12 +20,12 @@ export default {
     },
   },
   actions: {
-    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId } ) => {
+    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId, limit } ) => {
       let firestoreRef = collectionRef
         .where('exercise.id', '==', exerciseId)
         .where('stage', '==', EXERCISE_STAGE.SELECTED)
         .where('active', '==', true)
-        .limit(50);
+        .limit(limit);
 
       return bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
     }),

--- a/src/store/stage/shortlisted.js
+++ b/src/store/stage/shortlisted.js
@@ -18,12 +18,12 @@ export default {
     },
   },
   actions: {
-    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId } ) => {
+    bind: firestoreAction(({ bindFirestoreRef }, { exerciseId, limit } ) => {
       let firestoreRef = collectionRef
         .where('exercise.id', '==', exerciseId)
         .where('stage', '==', EXERCISE_STAGE.SHORTLISTED)
         .where('active', '==', true)
-        .limit(50);
+        .limit(limit);
 
       return bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
     }),

--- a/src/views/Exercises/Stages/HandoverList.vue
+++ b/src/views/Exercises/Stages/HandoverList.vue
@@ -77,6 +77,7 @@ export default {
     return {
       message: null,
       selectedItems: [],
+      limit: 500,
     };
   },
   computed: {
@@ -95,7 +96,7 @@ export default {
     },
   },
   async created() {
-    this.$store.dispatch('stageHandover/bind', { exerciseId: this.exercise.id });
+    this.$store.dispatch('stageHandover/bind', { exerciseId: this.exercise.id, limit: this.limit });
     this.message = await this.$store.dispatch('stageHandover/getMessages');
   },
   methods: {

--- a/src/views/Exercises/Stages/RecommendedList.vue
+++ b/src/views/Exercises/Stages/RecommendedList.vue
@@ -84,6 +84,7 @@ export default {
     return {
       message: null,
       selectedItems: [],
+      limit: 500,
     };
   },
   computed: {
@@ -103,7 +104,7 @@ export default {
     },
   },
   async created() {
-    this.$store.dispatch('stageRecommended/bind', { exerciseId: this.exercise.id });
+    this.$store.dispatch('stageRecommended/bind', { exerciseId: this.exercise.id, limit: this.limit });
     this.message = await this.$store.dispatch('stageRecommended/getMessages');
   },
   methods: {

--- a/src/views/Exercises/Stages/ReviewList.vue
+++ b/src/views/Exercises/Stages/ReviewList.vue
@@ -24,6 +24,7 @@
           </div>
         </div>
       </div>
+      
       <Table 
         data-key="id"
         :data="applicationRecords"
@@ -76,6 +77,7 @@ export default {
     return {
       message: null,
       selectedItems: [],
+      limit: 500,
     };
   },
   computed: {
@@ -112,7 +114,7 @@ export default {
     }, 
   },
   async created() {
-    this.$store.dispatch('stageReview/bind', { exerciseId: this.exercise.id });
+    this.$store.dispatch('stageReview/bind', { exerciseId: this.exercise.id, limit: this.limit });
     this.message = await this.$store.dispatch('stageReview/getMessages');
     this.selectedItems = this.$store.state.stageReview.selectedItems;
   },

--- a/src/views/Exercises/Stages/SelectedList.vue
+++ b/src/views/Exercises/Stages/SelectedList.vue
@@ -84,6 +84,7 @@ export default {
     return {
       message: null,
       selectedItems: [],
+      limit: 500,
     };
   },
   computed: {
@@ -102,7 +103,7 @@ export default {
     },
   },
   async created() {
-    this.$store.dispatch('stageSelected/bind', { exerciseId: this.exercise.id });
+    this.$store.dispatch('stageSelected/bind', { exerciseId: this.exercise.id, limit: this.limit });
     this.message = await this.$store.dispatch('stageSelected/getMessages');
   },
   methods: {

--- a/src/views/Exercises/Stages/ShortlistList.vue
+++ b/src/views/Exercises/Stages/ShortlistList.vue
@@ -102,7 +102,7 @@ export default {
     },
   },
   async created() {
-    this.$store.dispatch('stageShortlisted/bind', { exerciseId: this.exercise.id });
+    this.$store.dispatch('stageShortlisted/bind', { exerciseId: this.exercise.id, limit: 2 });
     this.message = await this.$store.dispatch('stageShortlisted/getMessages');
   },
   methods: {

--- a/src/views/Exercises/Stages/ShortlistList.vue
+++ b/src/views/Exercises/Stages/ShortlistList.vue
@@ -84,6 +84,7 @@ export default {
     return {
       message: null,
       selectedItems: [],
+      limit: 500,
     };
   },
   computed: {
@@ -102,7 +103,7 @@ export default {
     },
   },
   async created() {
-    this.$store.dispatch('stageShortlisted/bind', { exerciseId: this.exercise.id, limit: 2 });
+    this.$store.dispatch('stageShortlisted/bind', { exerciseId: this.exercise.id, limit: this.limit });
     this.message = await this.$store.dispatch('stageShortlisted/getMessages');
   },
   methods: {


### PR DESCRIPTION
Adds pagination to the Table component and updates store for Stages to take a `limit` parameter set in the page. 

![Screenshot from 2020-07-06 08-56-35](https://user-images.githubusercontent.com/5859718/86569703-b9067900-bf66-11ea-958c-a6c3c06d8ad0.png)

Caveats: 
- There is still a hard limit on how many items are loaded from the database (but it is now higher). We could add a dropdown in the frontend, but we should probably instead make paging dynamically load each page, improving performance and removing any arbitrary limit. 
- The "select all" checkbox literally selects all the data that has been loaded into the component (up to 500 rows). This is probably not what we want it to do, but I can't see it being used that often so we can probably live with it for now. We could add a "X rows selected", and simply by implementing the aforementioned data paging, you will get this effect for fee. 