### PR TITLE
#605 Handle Google sign in errors

### DIFF
--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -38,7 +38,7 @@ const module = {
           });  
         } else {
           auth().signOut();
-          commit('setAuthError', 'This site is restricted to employees of Judicial Appointments Commission');
+          commit('setAuthError', 'This site is restricted to employees of the Judicial Appointments Commission');
         }
       }
     },

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -31,15 +31,22 @@
 import { auth } from '@/firebase';
 
 export default {
+  data: function() {
+    return {
+      signInError: null,
+    };
+  },
   computed: {
     authError() {
-      return this.$store.state.auth.authError;
+      return this.$store.state.auth.authError || this.signInError;
     },
   },
   methods: {
     loginWithGoogle() {
       const provider = new auth.GoogleAuthProvider();
-      auth().signInWithPopup(provider);
+      auth().signInWithPopup(provider).catch(err => {
+        this.signInError = err.message;
+      });
     },
   },
 };


### PR DESCRIPTION
Catch and handle errors that occur within the "sign in with Google" frontend process. 

This is most commonly caused by people mashing the button (which generates an exception as only one pop up will be opened). 

We now handle the exception and display it to the user, unless there is a more important `authError` which comes from the Store  (eg. not a valid Google account). 