### PR TITLE
#631 Add number of queued notifciations

### DIFF
--- a/src/views/NotificationsList.vue
+++ b/src/views/NotificationsList.vue
@@ -211,20 +211,6 @@ export default {
   extends: Form,
   data() {
     return {
-      tabs: [
-        {
-          ref: 'queue',
-          title: 'Queue',
-        },
-        {
-          ref: 'sent',
-          title: 'Sent',
-        },
-        {
-          ref: 'settings',
-          title: 'Settings',
-        },
-      ],
       activeTab: 'queue',
       formData: {
         delayInMinutes: 5,
@@ -234,6 +220,25 @@ export default {
     };
   },
   computed: {
+    tabs(){
+      var tabs = [{
+                    ref: 'queue',
+                    title: 'Queue',
+                  },
+                  {
+                    ref: 'sent',
+                    title: 'Sent',
+                  },
+                  {
+                    ref: 'settings',
+                    title: 'Settings',
+                  }];
+      if(this.notificationsQueue.length){
+        tabs[0]['title'] = `Queue (${this.notificationsQueue.length})`;
+      }
+
+      return tabs;
+    },
     notificationsQueue() {
       return this.$store.state.notifications.queue;
     },


### PR DESCRIPTION
Adds the number of queued notifications to the end of the tab in brackets, to avoid manual counting (or people copying data into a spreadsheet etc.) 

This changes the `tabs` property from data to a computed prop. The length is only appended when there are queued notifications. 

![Screenshot from 2020-07-08 12-30-26](https://user-images.githubusercontent.com/5859718/86913887-3bce3600-c117-11ea-811b-cb71f8b37bc5.png)
