### PR TITLE
#647 Enforce single file upload on IAs

### DIFF
--- a/src/views/Exercises/Edit/Downloads.vue
+++ b/src/views/Exercises/Edit/Downloads.vue
@@ -40,6 +40,7 @@
           ident="independent-assessors"
           :component="repeatableFields.MultiFileUpload"
           :path="uploadPath"
+          :max="1"
         />
 
         <h2 class="govuk-heading-l">


### PR DESCRIPTION
Prevents more than one IA document being uploaded. 

Have confirmed with @ClaireTroughtonJAC that this is the expected behaviour. `assessments` cannot display more than one file (there is no "error" here - just that any more than a single file will be ignored) 

We'll leave the logic in to display multiple files in `admin` and `apply`, to avoid breaking anything on existing exercises. 