### PR TITLE
#635 Change to checking the URL to see which environment we're in

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,9 +9,13 @@ import * as Sentry from '@sentry/browser';
 import * as Integrations from '@sentry/integrations';
 
 if (process.env.NODE_ENV !== 'development') {
+  // Split the URL
+  const host = window.location.host;
+  const parts = host.split('.');
+
   Sentry.init({
     dsn: 'https://ab99abfef6294bc5b564e635d7b7cb4b@sentry.io/1792541',
-    environment: process.env.NODE_ENV,
+    environment: parts[0] == "admin" ? "production" : "staging",
     release: process.env.npm_package_version,
     integrations: [new Integrations.Vue({ Vue, attachProps: true })],
   });

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV !== 'development') {
 
   Sentry.init({
     dsn: 'https://ab99abfef6294bc5b564e635d7b7cb4b@sentry.io/1792541',
-    environment: parts[0] == "admin" ? "production" : "staging",
+    environment: parts[0] == 'admin' ? 'production' : 'staging',
     release: process.env.npm_package_version,
     integrations: [new Integrations.Vue({ Vue, attachProps: true })],
   });


### PR DESCRIPTION
We can't use the Node running environment to determine between prod and s101 as we build for prod in both environments. 

We can determine whether the subdomain is `admin` or `admin-staging` and use that to set the Sentry environment. 