### PR TITLE
669: try out pagination on ShortlistList

### DIFF
--- a/src/views/Exercises/Stages/HandoverList.vue
+++ b/src/views/Exercises/Stages/HandoverList.vue
@@ -27,7 +27,7 @@
       </div>
       <Table 
         data-key="id"
-        :data="applicationRecords"
+        :data="getPaginated"
         :columns="[
           { title: 'Reference number' },
           { title: 'Name' },
@@ -58,6 +58,10 @@
           <TableCell>{{ row.flags.empApplied | toYesNo }}</TableCell>
         </template>
       </Table>   
+    <Pagination 
+        :high-index="numberOfPages"
+        @pageChanged="updatePage($event)"
+      />
     </form>
   </div>
 </template>
@@ -66,17 +70,21 @@
 import Banner from '@/components/Page/Banner';
 import Table from '@/components/Page/Table/Table'; 
 import TableCell from '@/components/Page/Table/TableCell'; 
+import Pagination from '@/components/Page/Pagination';
 
 export default {
   components: {
     Banner,
     Table,
     TableCell,
+    Pagination,
   },
   data() {
     return {
       message: null,
       selectedItems: [],
+      page: 1,
+      pageSize: 25,
     };
   },
   computed: {
@@ -93,6 +101,22 @@ export default {
       const isDisabled = this.selectedItems && this.selectedItems.length;
       return !isDisabled;
     },
+    numberOfPages() {
+      return Math.ceil(this.totalApplicationRecords / this.pageSize);
+    },
+    getPaginated() {
+      if(this.numberOfPages){
+        if(this.page > this.numberOfPages) throw `Page ${this.page} exceeds page size of ${this.numberOfPages}`;
+
+        const sliceFrom = ((this.page - 1) * this.pageSize);
+        const sliceTo = sliceFrom + this.pageSize; 
+        const sliced = this.applicationRecords.slice(sliceFrom, sliceTo);
+
+        return sliced;
+      } else {
+        return this.applicationRecords;
+      }
+    },
   },
   async created() {
     this.$store.dispatch('stageHandover/bind', { exerciseId: this.exercise.id });
@@ -102,6 +126,9 @@ export default {
     moveBack() {
       this.$store.dispatch('stageHandover/storeItems', { items: this.selectedItems });
       this.$router.push({ name: 'exercise-stages-handover-back' });
+    },
+    updatePage(pageChanged){
+      this.page = pageChanged;
     },
   },
 };

--- a/src/views/Exercises/Stages/HandoverList.vue
+++ b/src/views/Exercises/Stages/HandoverList.vue
@@ -58,7 +58,7 @@
           <TableCell>{{ row.flags.empApplied | toYesNo }}</TableCell>
         </template>
       </Table>   
-    <Pagination 
+      <Pagination 
         :high-index="numberOfPages"
         @pageChanged="updatePage($event)"
       />

--- a/src/views/Exercises/Stages/RecommendedList.vue
+++ b/src/views/Exercises/Stages/RecommendedList.vue
@@ -34,7 +34,7 @@
       </div>
       <Table 
         data-key="id"
-        :data="applicationRecords"
+        :data="getPaginated"
         :columns="[
           { title: 'Reference number' },
           { title: 'Name' },
@@ -64,7 +64,11 @@
           <TableCell>{{ row.status | lookup }}</TableCell>
           <TableCell>{{ row.flags.empApplied | toYesNo }}</TableCell>
         </template>
-      </Table>   
+      </Table>
+      <Pagination 
+        :high-index="numberOfPages"
+        @pageChanged="updatePage($event)"
+      />   
     </form>
   </div>
 </template>
@@ -73,17 +77,21 @@
 import Banner from '@/components/Page/Banner';
 import Table from '@/components/Page/Table/Table'; 
 import TableCell from '@/components/Page/Table/TableCell'; 
+import Pagination from '@/components/Page/Pagination';
 
 export default {
   components: {
     Banner,
     Table,
     TableCell,
+    Pagination,
   },
   data() {
     return {
       message: null,
       selectedItems: [],
+      page: 1,
+      pageSize: 25,
     };
   },
   computed: {
@@ -101,6 +109,22 @@ export default {
       const isDisabled = this.selectedItems && this.selectedItems.length;
       return !isDisabled;
     },
+    numberOfPages() {
+      return Math.ceil(this.totalApplicationRecords / this.pageSize);
+    },
+    getPaginated() {
+      if(this.numberOfPages){
+        if(this.page > this.numberOfPages) throw `Page ${this.page} exceeds page size of ${this.numberOfPages}`;
+
+        const sliceFrom = ((this.page - 1) * this.pageSize);
+        const sliceTo = sliceFrom + this.pageSize; 
+        const sliced = this.applicationRecords.slice(sliceFrom, sliceTo);
+
+        return sliced;
+      } else {
+        return this.applicationRecords;
+      }
+    },
   },
   async created() {
     this.$store.dispatch('stageRecommended/bind', { exerciseId: this.exercise.id });
@@ -117,6 +141,9 @@ export default {
     setStatus() {
       this.$store.dispatch('stageRecommended/storeItems', { items: this.selectedItems });
       this.$router.push({ name: 'exercise-stages-recommended-edit' });
+    },
+    updatePage(pageChanged){
+      this.page = pageChanged;
     },
   },
 };

--- a/src/views/Exercises/Stages/ReviewList.vue
+++ b/src/views/Exercises/Stages/ReviewList.vue
@@ -125,7 +125,7 @@ export default {
       if(this.numberOfPages){
         if(this.page > this.numberOfPages) throw `Page ${this.page} exceeds page size of ${this.numberOfPages}`;
 
-        const sliceFrom = (this.page * this.pageSize);
+        const sliceFrom = ((this.page - 1) * this.pageSize);
         const sliceTo = sliceFrom + this.pageSize; 
         const sliced = this.applicationRecords.slice(sliceFrom, sliceTo);
 

--- a/src/views/Exercises/Stages/ReviewList.vue
+++ b/src/views/Exercises/Stages/ReviewList.vue
@@ -26,7 +26,7 @@
       </div>
       <Table 
         data-key="id"
-        :data="applicationRecords"
+        :data="getPaginated"
         :columns="[
           { title: 'Reference number' },
           { title: 'Name' },
@@ -57,6 +57,10 @@
           <TableCell>{{ row.flags.empApplied | toYesNo }}</TableCell>
         </template>
       </Table>   
+      <Pagination 
+        :high-index="numberOfPages"
+        @pageChanged="updatePage($event)"
+      />
     </form>
   </div>
 </template>
@@ -65,17 +69,21 @@
 import Banner from '@/components/Page/Banner';
 import Table from '@/components/Page/Table/Table'; 
 import TableCell from '@/components/Page/Table/TableCell'; 
+import Pagination from '@/components/Page/Pagination';
 
 export default {
   components: {
     Banner,
     Table,
     TableCell,
+    Pagination,
   },
   data() {
     return {
       message: null,
       selectedItems: [],
+      page: 1,
+      pageSize: 25,
     };
   },
   computed: {
@@ -109,7 +117,23 @@ export default {
         }
         this.selectedItems = selectedItems;
       },
-    }, 
+    },
+    numberOfPages() {
+      return Math.ceil(this.totalApplicationRecords / this.pageSize);
+    },
+    getPaginated() {
+      if(this.numberOfPages){
+        if(this.page > this.numberOfPages) throw `Page ${this.page} exceeds page size of ${this.numberOfPages}`;
+
+        const sliceFrom = (this.page * this.pageSize);
+        const sliceTo = sliceFrom + this.pageSize; 
+        const sliced = this.applicationRecords.slice(sliceFrom, sliceTo);
+
+        return sliced;
+      } else {
+        return this.applicationRecords;
+      }
+    },
   },
   async created() {
     this.$store.dispatch('stageReview/bind', { exerciseId: this.exercise.id });
@@ -120,6 +144,9 @@ export default {
     checkForm() {
       this.$store.dispatch('stageReview/storeItems', { items: this.selectedItems });
       this.$router.push({ name: 'exercise-stages-review-edit' });
+    },
+    updatePage(pageChanged){
+      this.page = pageChanged;
     },
   },
 };

--- a/src/views/Exercises/Stages/ShortlistList.vue
+++ b/src/views/Exercises/Stages/ShortlistList.vue
@@ -119,7 +119,7 @@ export default {
       if(this.numberOfPages){
         if(this.page > this.numberOfPages) throw `Page ${this.page} exceeds page size of ${this.numberOfPages}`;
 
-        const sliceFrom = (this.page * this.pageSize);
+        const sliceFrom = ((this.page - 1) * this.pageSize);
         const sliceTo = sliceFrom + this.pageSize; 
         const sliced = this.applicationRecords.slice(sliceFrom, sliceTo);
 

--- a/src/views/Exercises/Stages/ShortlistList.vue
+++ b/src/views/Exercises/Stages/ShortlistList.vue
@@ -34,7 +34,7 @@
       </div>
       <Table 
         data-key="id"
-        :data="applicationRecords"
+        :data="getPaginated"
         :columns="[
           { title: 'Reference number' },
           { title: 'Name' },
@@ -64,7 +64,11 @@
           <TableCell>{{ row.status | lookup }}</TableCell>
           <TableCell>{{ row.flags.empApplied | toYesNo }}</TableCell>
         </template>
-      </Table>   
+      </Table>
+      <Pagination 
+        :high-index="numberOfPages"
+        @pageChanged="updatePage($event)"
+      />
     </form>
   </div>
 </template>
@@ -73,17 +77,21 @@
 import Banner from '@/components/Page/Banner';
 import Table from '@/components/Page/Table/Table'; 
 import TableCell from '@/components/Page/Table/TableCell'; 
+import Pagination from '@/components/Page/Pagination';
 
 export default {
   components: {
     Banner,
     Table,
     TableCell,
+    Pagination,
   },
   data() {
     return {
       message: null,
       selectedItems: [],
+      page: 1,
+      pageSize: 25,
     };
   },
   computed: {
@@ -104,6 +112,22 @@ export default {
     exercise() {
       return this.$store.state.exerciseDocument.record;
     },
+    numberOfPages() {
+      return Math.ceil(this.applicationRecords.length / this.pageSize);
+    },
+    getPaginated() {
+      if(this.numberOfPages){
+        if(this.page > this.numberOfPages) throw `Page ${this.page} exceeds page size of ${this.numberOfPages}`;
+
+        const sliceFrom = (this.page * this.pageSize);
+        const sliceTo = sliceFrom + this.pageSize; 
+        const sliced = this.applicationRecords.slice(sliceFrom, sliceTo);
+
+        return sliced;
+      } else {
+        return this.applicationRecords;
+      }
+    },
   },
   async created() {
     this.$store.dispatch('stageShortlisted/bind', { exerciseId: this.exercise.id });
@@ -117,6 +141,9 @@ export default {
     setStatus() {
       this.$store.dispatch('stageShortlisted/storeItems', { items: this.selectedItems });
       this.$router.push({ name: 'exercise-stages-shortlist-edit' });
+    },
+    updatePage(pageChanged){
+      this.page = pageChanged;
     },
   },
 };

--- a/src/views/Exercises/Stages/ShortlistList.vue
+++ b/src/views/Exercises/Stages/ShortlistList.vue
@@ -113,7 +113,7 @@ export default {
       return this.$store.state.exerciseDocument.record;
     },
     numberOfPages() {
-      return Math.ceil(this.applicationRecords.length / this.pageSize);
+      return Math.ceil(this.totalApplicationRecords / this.pageSize);
     },
     getPaginated() {
       if(this.numberOfPages){


### PR DESCRIPTION
Draft PR for comments and thoughts :pray:  

Several things to note about the implementation: 
- This does not use [Firestore pagination](https://firebase.google.com/docs/firestore/query-data/query-cursors) deliberately for performance reasons. In order to paginate properly, we need to know how many records there are in the first place (ie. how many pages). As Firestore has no mechanism for us to retrieve just a count of the query, we have to load all the records any way (just to count them). It is therefore undesirable to initially request all the data, then continue making requests to Firestore each time a user changes page for the page of data we want - having loaded all of it, we might as well slice it ourselves. 
- There are no changes to the Store. It's easier to make these changes in `ShortlistList` and I would argue it is more semantic. It does mean the slice function, for example. will be replicated. If we consolidate stores we should look at bringing this into the store, but it does add complexity (as the store then has to keep track of how many records it is going to load, before anything has asked it to load them, and also issues with caching the loaded data). If there are strong feelings, I am happy to look further into putting this into the store :+1: 

I would just note, that this would have been much easier with `COUNT()` :smile:  

