### PR TITLE
677: Don't show pagination for a single page

### DIFF
--- a/src/components/Page/Pagination.vue
+++ b/src/components/Page/Pagination.vue
@@ -1,5 +1,6 @@
 <template>
   <nav
+    v-if="lowIndex != highIndex"
     class="moj-pagination"
   >
     <p

--- a/tests/unit/components/Page/Pagination.spec.js
+++ b/tests/unit/components/Page/Pagination.spec.js
@@ -106,7 +106,6 @@ describe('components/Page/Pagination', () => {
     });
 
     describe('single page', () => {
-        const numberOfPages =  1;
         const lowIndexNew = 1;
         const highIndexNew = 1;
 

--- a/tests/unit/components/Page/Pagination.spec.js
+++ b/tests/unit/components/Page/Pagination.spec.js
@@ -105,6 +105,20 @@ describe('components/Page/Pagination', () => {
         });
     });
 
+    describe('single page', () => {
+        const numberOfPages =  1;
+        const lowIndexNew = 1;
+        const highIndexNew = 1;
+
+        beforeEach(() => {
+            wrapper = createTestSubject({ highIndex: highIndexNew, lowIndex: lowIndexNew });
+        }); 
+
+        it('does not render any elements', () => {
+            expect(wrapper.findAll('li')).toHaveLength(0);
+        });
+    });
+
     describe('change page', () => {
 
         it('page forward', async () => {


### PR DESCRIPTION
Hide the pagination component when we only have a single page to show, and thus don't need to display any page controls. 