### PR TITLE
Make footer stay at bottom of page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,9 @@
 <template>
-  <div>
+  <div class="page-container">
     <header
       class="govuk-width-container"
     >
       <div
-        id="header"
         class="header-background clearfix"
       >
         <div class="header-title govuk-!-margin-bottom-2">
@@ -63,9 +62,13 @@
           </nav>
         </div>
       </div>
-      <div class="govuk-phase-banner govuk-!-margin-bottom-4 print-none">
+      <div
+        class="govuk-phase-banner govuk-!-margin-bottom-4 print-none"
+      >
         <p class="govuk-phase-banner__content">
-          <strong class="govuk-tag govuk-phase-banner__content__tag">beta</strong>
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+            beta
+          </strong>
           <span class="govuk-phase-banner__text">
             This is a new service – your 
             <a 
@@ -80,6 +83,7 @@
         </p>
       </div>
     </header>
+
     <main
       id="main-content"
       class="govuk-width-container govuk-main-wrapper govuk-main-wrapper--auto-spacing"
@@ -87,6 +91,7 @@
     >
       <RouterView />
     </main>
+
     <footer
       class="govuk-footer"
       role="contentinfo"
@@ -153,7 +158,8 @@ export default {
   },
 };
 </script>
-<style type="text/css" rel="stylesheet/scss" lang="scss" scoped>
+
+<style lang="scss">
 
   .header {
     background-color: #fafafa;
@@ -194,6 +200,18 @@ export default {
 
   .header-background span {
     color: #753880 !important;
+  }
+
+  .govuk-footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  };
+
+  .page-container {
+    // background-color: pink;
+    position: relative;
+    min-height: 100vh;
   }
   
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -209,7 +209,6 @@ export default {
   };
 
   .page-container {
-    // background-color: pink;
     position: relative;
     min-height: 100vh;
   }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -51,7 +51,6 @@ body {
   font-family: $govuk-font-family;
 }
 
-/* JAC buttons */
 /*#944 removed the overrides*/
 
 .govuk-width-container {


### PR DESCRIPTION
CSS additions to App.vue.
Previously the single child of the main template contained three elements, using positioning in the styles section within App.vue, ive now achieved the desired placements.

I coulda/shoulda/woulda extracted this CSS to the main files, this might need doing eventually. 