### PR TITLE
#595 - Add null check for application submitted/created dates

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -3,6 +3,12 @@ import { APPLICATION_STATUS } from '@/helpers/constants';
 const formatDate = (value, type) => {
   if (value) {
     const objDate = new Date(Date.parse(value));
+
+    // If not a valid date
+    if (!(objDate instanceof Date)){
+      return null;
+    }
+
     switch (type) {
       case 'month':
         return `${objDate.toLocaleString('en-GB', { month: 'long' })} ${objDate.getUTCFullYear()}`;

--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -69,7 +69,7 @@
               <h2 
                 class="govuk-heading-m govuk-!-margin-bottom-0"
               >
-                {{ application.createdAt ? $options.filters.formatDate(application.createdAt) : "Unknown" }}
+                {{ application.createdAt | showAlternative("Unknown") | formatDate }}
               </h2>
             </div>
           </div>
@@ -81,7 +81,7 @@
                 v-if="isApplied"
                 class="govuk-heading-m govuk-!-margin-bottom-0"
               >
-                {{ application.appliedAt ? $options.filters.formatDate(application.appliedAt) : "Unknown" }}
+                {{ application.createdAt | showAlternative("Unknown") | formatDate }}
               </h2>
               <h2
                 v-else

--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -76,7 +76,7 @@
               <h2 
                 class="govuk-heading-m govuk-!-margin-bottom-0"
               >
-                {{ application.createdAt | showAlternative("Unknown") | formatDate }}
+                {{ application.createdAt | formatDate | showAlternative("Unknown")}}
               </h2>
             </div>
           </div>
@@ -88,7 +88,7 @@
                 v-if="isApplied"
                 class="govuk-heading-m govuk-!-margin-bottom-0"
               >
-                {{ application.createdAt | showAlternative("Unknown") | formatDate }}
+                {{ application.appliedAt | formatDate | showAlternative("Unknown") }}
               </h2>
               <h2
                 v-else

--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -66,8 +66,10 @@
           <div class="govuk-grid-column-one-half">
             <div class="panel govuk-!-margin-bottom-9 govuk-!-padding-4 background-light-grey">
               <span class="govuk-caption-m">Created on</span>
-              <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-                {{ new Date(application.createdAt) | formatDate('longdatetime') }}
+              <h2 
+                class="govuk-heading-m govuk-!-margin-bottom-0"
+              >
+                {{ application.createdAt ? $options.filters.formatDate(application.createdAt) : "Unknown" }}
               </h2>
             </div>
           </div>
@@ -79,7 +81,7 @@
                 v-if="isApplied"
                 class="govuk-heading-m govuk-!-margin-bottom-0"
               >
-                {{ application.appliedAt | formatDate('longdatetime') }}
+                {{ application.appliedAt ? $options.filters.formatDate(application.appliedAt) : "Unknown" }}
               </h2>
               <h2
                 v-else


### PR DESCRIPTION
This adds a couple of turnery checks to see if `application.createdAt` and `application.appliedAt` are null. 

The behaviour is now:
- If there is a valid date, the date is formatted and displayed
- If there is no date, we display "unknown" (new behaviour)
- If there is data in the field but it is not a valid date, "Invalid Date" will be shown (I think this is expected) 

The reason this took so long is Vue weirdness in it's overloading of bitwise-OR: https://github.com/vuejs/vue/issues/5449#issuecomment-294337677

Very much a TIL moment. 