### PR TITLE
Change let to const

### DIFF
--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -1858,13 +1858,13 @@ export default {
         },
       );
 
-      let fileName = this.generateFilename;
+      const fileName = this.generateFilename;
 
       pdf.save(`${fileName}.pdf`);
     },
     downloadAsDoc() {
-      let fileName = this.generateFilename;
-      let content = document.querySelector('#panel-pack-div').outerHTML;
+      const fileName = this.generateFilename;
+      const content = document.querySelector('#panel-pack-div').outerHTML;
       const converted = htmlDocx.asBlob(content);
       saveAs(converted, `${fileName}.docx`);
     },


### PR DESCRIPTION
(i think) new ESlint rules mean that useless lets are NOT allowed, otherwise im not sure how this slipped through, regardless three offending let's have been changed to const's