### PR TITLE
#206 - Restrict file uploads to certain extensions

### DIFF
--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -131,11 +131,15 @@ export default {
     validFileExtension(originalName){
       const parts = originalName.split('.');
 
-      if (parts.length < 2 || !this.acceptableExtensions.includes(parts[parts.length - 1])){
+      if (parts.length < 2){
         return false;
       }
 
-      return true;
+      if (this.acceptableExtensions.includes(parts.pop())){
+        return true;
+      }
+
+      return false;
     },
     resetFile() {
       this.$refs.file = null;
@@ -146,7 +150,8 @@ export default {
       if (!file) {
         this.setError('File upload failed, please try again');
         return false;
-      } else if (!this.validFileExtension(file.name)) {
+      } 
+      if (!this.validFileExtension(file.name)) {
         this.setError(`Invalid file type. Choose from: ${this.acceptableExtensions}`);
         return false;
       }

--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -85,6 +85,7 @@ export default {
       file: '',
       isReplacing: false,
       isUploading: false,
+      acceptableExtensions: ['pdf', 'docx', 'doc', 'odf', 'pages'],
     };
   },
   computed: {
@@ -127,15 +128,26 @@ export default {
 
       return [this.name, parts.pop()].join('.');
     },
+    validFileExtension(originalName){
+      const parts = originalName.split('.');
+
+      if (parts.length < 2 || !this.acceptableExtensions.includes(parts[parts.length - 1])){
+        return false;
+      }
+
+      return true;
+    },
     resetFile() {
       this.$refs.file = null;
       this.isUploading = false;
     },
     async upload(file) {
       // @todo return more useful error messages
-
       if (!file) {
         this.setError('File upload failed, please try again');
+        return false;
+      } else if (!this.validFileExtension(file.name)) {
+        this.setError(`Invalid file type. Choose from: ${this.acceptableExtensions}`);
         return false;
       }
 

--- a/tests/unit/components/Form/FileUpload.spec.js
+++ b/tests/unit/components/Form/FileUpload.spec.js
@@ -201,7 +201,12 @@ describe('components/Form/FileUpload', () => {
     const mockFile = {
       name: `mock file.${  mockFileExtension}`,
     };
+    const invalidMockFileExtension = 'png';
+    const invalidMockFile = {
+      name: `mock file.${  invalidMockFileExtension}`,
+    };
     const errorMessage = 'File upload failed, please try again';
+    const invalidExtensionErrorMessage = 'Invalid file type. Choose from: pdf,docx,doc,odf,pages';
 
     describe('replaceFile()', () => {
       it('sets `isReplacing` property', () => {
@@ -257,6 +262,78 @@ describe('components/Form/FileUpload', () => {
       });
     });
 
+    describe('validFileExtension()', () => {
+      it('accepts .docx files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.docx')).toBeTruthy();
+      });
+
+      it('accepts .pdf files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.pdf')).toBeTruthy();
+      });
+
+      it('accepts .odf files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.pdf')).toBeTruthy();
+      });
+
+      it('accepts .doc files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.doc')).toBeTruthy();
+      });
+
+      it('accepts .odf files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.odf')).toBeTruthy();
+      });
+
+      it('accepts .pages files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.pages')).toBeTruthy();
+      });
+
+      it('accepts layers.of.indirection.docx files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.layers.of.indirection.pdf')).toBeTruthy();
+      });
+      
+      it('rejects .png files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.png')).toBeFalsy();
+      });
+
+      it('rejects .invalid files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name.invalid')).toBeFalsy();
+      });
+
+      it('rejects no extension files', () => {
+        const setName = 'filename';
+        wrapper.setProps({ name: setName });
+
+        expect(wrapper.vm.validFileExtension('original name')).toBeFalsy();
+      });
+    });
+
     describe('resetFile()', () => {
       it('clears reference to file', () => {
         wrapper.vm.resetFile();
@@ -281,6 +358,14 @@ describe('components/Form/FileUpload', () => {
 
         const result = await wrapper.vm.upload(mockFile);
         expect(wrapper.vm.setError).toHaveBeenCalledWith(errorMessage);
+        expect(result).toBeFalsy();
+      });
+
+      it('sets error and returns false if called with invalid file extension', async () => {
+        expect.assertions(2);
+
+        const result = await wrapper.vm.upload(invalidMockFile);
+        expect(wrapper.vm.setError).toHaveBeenCalledWith(invalidExtensionErrorMessage);
         expect(result).toBeFalsy();
       });
 

--- a/tests/unit/components/Form/FileUpload.spec.js
+++ b/tests/unit/components/Form/FileUpload.spec.js
@@ -281,7 +281,7 @@ describe('components/Form/FileUpload', () => {
         const setName = 'filename';
         wrapper.setProps({ name: setName });
 
-        expect(wrapper.vm.validFileExtension('original name.pdf')).toBeTruthy();
+        expect(wrapper.vm.validFileExtension('original name.odf')).toBeTruthy();
       });
 
       it('accepts .doc files', () => {
@@ -291,13 +291,6 @@ describe('components/Form/FileUpload', () => {
         expect(wrapper.vm.validFileExtension('original name.doc')).toBeTruthy();
       });
 
-      it('accepts .odf files', () => {
-        const setName = 'filename';
-        wrapper.setProps({ name: setName });
-
-        expect(wrapper.vm.validFileExtension('original name.odf')).toBeTruthy();
-      });
-
       it('accepts .pages files', () => {
         const setName = 'filename';
         wrapper.setProps({ name: setName });
@@ -305,14 +298,14 @@ describe('components/Form/FileUpload', () => {
         expect(wrapper.vm.validFileExtension('original name.pages')).toBeTruthy();
       });
 
-      it('accepts layers.of.indirection.docx files', () => {
+      it('accepts files with multiple extensions if last one is valid', () => {
         const setName = 'filename';
         wrapper.setProps({ name: setName });
 
         expect(wrapper.vm.validFileExtension('original name.layers.of.indirection.pdf')).toBeTruthy();
       });
       
-      it('rejects .png files', () => {
+      it('rejects file with unrecognised extension', () => {
         const setName = 'filename';
         wrapper.setProps({ name: setName });
 


### PR DESCRIPTION
Changes the `FileUpload` component in admin to restrict the type of extensions that can be uploaded. This automatically works for anything that imports `FileUpload` eg. `MultiFileUpload`. 

Includes tests for the new functionality. 

Notes: 
- This is not enforced on the backend/in the bucket. (https://github.com/jac-uk/digital-platform/issues/327)
- This only checks the declared extension, not what the file content actually is 
- This only affects admin. I'll replicate the changes once approved (please monorepo soon!) 

Please let me know your thoughts :smile: 
