### PR TITLE
#711 - Identifies late IAs in admin

### DIFF
--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -20,6 +20,10 @@ const isDateInFuture = (date) => {
   return date > today;
 };
 
+const isDateGreaterThan = (dateOne, dateTwo) => {
+  return dateOne > dateTwo;
+};
+
 const formatDate = (date, type) => {
   if (!(date instanceof Date)) {
     throw 'Supplied date must be a Date object';
@@ -67,6 +71,7 @@ const validateYear = (val) => {
 export {
   isDate,
   isDateInFuture,
+  isDateGreaterThan,
   formatDate,
   parseEstimatedDate,
   validateYear

--- a/src/store.js
+++ b/src/store.js
@@ -11,6 +11,7 @@ import exerciseCreateJourney from '@/store/exercise/createJourney';
 import exerciseDocument from '@/store/exercise/document';
 import applications from '@/store/applications';
 import application from '@/store/application';
+import assessment from '@/store/assessment';
 import assessments from '@/store/assessments';
 import notifications from '@/store/notifications';
 import stageReview from '@/store/stage/review';
@@ -33,6 +34,7 @@ const store = new Vuex.Store({
     exerciseDocument,
     applications,
     application,
+    assessment,
     assessments,
     notifications,
     stageReview,

--- a/src/store/assessment.js
+++ b/src/store/assessment.js
@@ -1,0 +1,42 @@
+import { firestore } from '@/firebase';
+import { firestoreAction } from 'vuexfire';
+import vuexfireSerialize from '@/helpers/vuexfireSerialize';
+import clone from 'clone';
+
+const collection = firestore.collection('assessments');
+
+export default {
+  namespaced: true,
+  actions: {
+    bind: firestoreAction(({ bindFirestoreRef }, id) => {
+      const firestoreRef = collection.doc(id);
+
+      return bindFirestoreRef('record', firestoreRef, { serialize: vuexfireSerialize });
+    }),
+    unbind: firestoreAction(({ unbindFirestoreRef }) => {
+      return unbindFirestoreRef('record');
+    }),
+    save: async ({ state }, data) => {
+      if (data.id == null && state.record == null){
+        throw 'State null and no ID passed';
+      }
+      let docId;
+      state.record == null ? docId = data.id : docId = state.record.id;
+      const ref = collection.doc(docId);
+      return await ref.set(data, { merge: true });
+    },
+  },
+  state: {
+    record: null,
+  },
+  getters: {
+    id: (state) => {
+      if (state.record === null) return null;
+
+      return state.record.id;
+    },
+    data: (state) => () => {
+      return clone(state.record);
+    },
+  },
+};

--- a/tests/unit/helpers/date.spec.js
+++ b/tests/unit/helpers/date.spec.js
@@ -18,6 +18,25 @@ describe('@/helpers/date/formatDate', () => {
   });
 });
 
+describe('@/helpers/date/isDateGreaterThan', () => {
+  it('returns true if dateOne is greater than dateTwo', () => {
+    expect(helpers.isDateGreaterThan(Date.now(), new Date('Sun Nov 11 2012 00:00:00 GMT+0000 (Greenwich Mean Time)'))).toBeTruthy();
+  });
+
+  it('returns false if dateTwo is greater than dateOne', () => {
+    expect(helpers.isDateGreaterThan(new Date('Sun Nov 11 2012 00:00:00 GMT+0000 (Greenwich Mean Time)'), Date.now())).toBeFalsy();
+  });
+
+  it('returns false if one is not a date', () => {
+    expect(helpers.isDateGreaterThan("random", Date.now())).toBeFalsy();
+    expect(helpers.isDateGreaterThan(Date.now(), "random")).toBeFalsy();
+  });
+
+  it('returns false if neither is a date', () => {
+    expect(helpers.isDateGreaterThan("random", "random")).toBeFalsy();
+  });
+});
+
 describe('@/helpers/date/isDate', () => {
   it('returns true if the value passed is an instance of a date', () => {
     expect(helpers.isDate(new Date('Sun Nov 11 2012 00:00:00 GMT+0000 (Greenwich Mean Time)'))).toBe(true);

--- a/tests/unit/helpers/date.spec.js
+++ b/tests/unit/helpers/date.spec.js
@@ -28,12 +28,12 @@ describe('@/helpers/date/isDateGreaterThan', () => {
   });
 
   it('returns false if one is not a date', () => {
-    expect(helpers.isDateGreaterThan("random", Date.now())).toBeFalsy();
-    expect(helpers.isDateGreaterThan(Date.now(), "random")).toBeFalsy();
+    expect(helpers.isDateGreaterThan('random', Date.now())).toBeFalsy();
+    expect(helpers.isDateGreaterThan(Date.now(), 'random')).toBeFalsy();
   });
 
   it('returns false if neither is a date', () => {
-    expect(helpers.isDateGreaterThan("random", "random")).toBeFalsy();
+    expect(helpers.isDateGreaterThan('random', 'random')).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
Helper functionality:
- New `isDateGreaterThan` date helper with tests
- 'Borrowed' the `assessment` store with modification to allow updating single assessment record 
- Register `assessment` in `store.js` 

Functionality: 
- Running late IAs (ie. those not submitted but past due date) show as `LATE`
- Submitted late IAs (ie. those submitted past due date) show as `LATE`
- Needing approval IAs (ie. those submitted past due date) have download button hidden and an approval button shown/
- Allows approval for late IAs to be approved (which allows them to be downloaded)

Rejection for late IAs is implicit (can be changed - ticket isn't clear on this) 

![screenshot_2020-08-03-155509](https://user-images.githubusercontent.com/5859718/89196180-c2a0f200-d5a1-11ea-8bc7-a94f86dba829.png)
