### PR TITLE
#728 Restrict files to 2MB

### DIFF
--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -141,6 +141,10 @@ export default {
 
       return false;
     },
+    validFileSize(size){
+      const megabyteSize = size / 1024 / 1024; // in MB
+      return megabyteSize > 2 ? false : true;
+    },
     resetFile() {
       this.$refs.file = null;
       this.isUploading = false;
@@ -153,6 +157,10 @@ export default {
       } 
       if (!this.validFileExtension(file.name)) {
         this.setError(`Invalid file type. Choose from: ${this.acceptableExtensions}`);
+        return false;
+      }
+      if (!this.validFileSize(file.size)){
+        this.setError('File is too large. Limit: 2MB');
         return false;
       }
 

--- a/tests/unit/components/Form/FileUpload.spec.js
+++ b/tests/unit/components/Form/FileUpload.spec.js
@@ -334,6 +334,37 @@ describe('components/Form/FileUpload', () => {
       });
     });
 
+    describe('validFileSize()', () => {
+      it('accepts sub-2MB files', () =>  {
+        const setName = 'filename';
+        const setSize = 900 * 1024; // 900 Kb
+        wrapper.setProps({ name: setName, size: setSize });
+
+        expect(wrapper.vm.validFileSize(setSize)).toBeTruthy();
+      });
+      it('accepts 2MB files', () =>  {
+        const setName = 'filename';
+        const setSize = 2 * 1024 * 1024; // 2MB
+        wrapper.setProps({ name: setName, size: setSize });
+
+        expect(wrapper.vm.validFileSize(setSize)).toBeTruthy();
+      });
+      it('does not accept touch over 2MB files', () =>  {
+        const setName = 'filename';
+        const setSize = (2 * 1024 * 1024) + 1; // 2MB + 1 bit
+        wrapper.setProps({ name: setName, size: setSize });
+
+        expect(wrapper.vm.validFileSize(setSize)).toBeFalsy();
+      });
+      it('does not accept very over 2MB files', () =>  {
+        const setName = 'filename';
+        const setSize = (20 * 1024 * 1024); // 20MB
+        wrapper.setProps({ name: setName, size: setSize });
+
+        expect(wrapper.vm.validFileSize(setSize)).toBeFalsy();
+      });
+    });
+
     describe('resetFile()', () => {
       it('clears reference to file', () => {
         wrapper.vm.resetFile();


### PR DESCRIPTION
Component change plus tests to limit files to 2MB. 

![screenshot_2020-08-03-171819](https://user-images.githubusercontent.com/5859718/89204015-5a580d80-d5ad-11ea-9ca7-155c3d72fb9b.png)

I'll copy this across to the others once agreed.  We _could_ make size an optional prop but since it's 2MB across all of the sites and I don't really see why we'd change that, so I would suggest this can be an improvement later if needed. 
