### PR TITLE
#739 - Fix incorrect idents causing file overwrites

### DIFF
--- a/src/views/Exercises/Edit/Downloads.vue
+++ b/src/views/Exercises/Edit/Downloads.vue
@@ -60,7 +60,7 @@
 
         <RepeatableFields
           v-model="exercise.downloads.pensionsInformation"
-          ident="candidate-assessement-forms"
+          ident="pensions-information"
           :component="repeatableFields.MultiFileUpload"
           :path="uploadPath"
         />
@@ -71,7 +71,7 @@
 
         <RepeatableFields
           v-model="exercise.downloads.competencyFramework"
-          ident="candidate-assessement-forms"
+          ident="competency-framework"
           :component="repeatableFields.MultiFileUpload"
           :path="uploadPath"
         />
@@ -82,7 +82,7 @@
 
         <RepeatableFields
           v-model="exercise.downloads.welshTranslation"
-          ident="candidate-assessement-forms"
+          ident="welsh-translation"
           :component="repeatableFields.MultiFileUpload"
           :path="uploadPath"
         />
@@ -119,6 +119,7 @@ export default {
         candidateAssessementForms: [],
         pensionsInformation: [],
         competencyFramework: [],
+        welshTranslation: [],
       },
     };
     const data = this.$store.getters['exerciseDocument/data']();


### PR DESCRIPTION
This fixes a bug where files were being uploaded with identical idents (ie. file names) and so uploading one of: 
- Pensions Information
- Competency Framework
- Welsh Translation 
would overwrite the Candidate Assessment Form, and all 4 would download the same file.

@warrensearle please could we roll this as a hotfix to admin? We'll also need to communicate this to teams I think @ClaireTroughtonJAC - any ideas?