### PR TITLE
Fixed XLSX exports being 'corrupted'

### DIFF
--- a/src/helpers/export.js
+++ b/src/helpers/export.js
@@ -1,16 +1,30 @@
 import XLSXPopulate from 'xlsx-populate';
 import { save } from 'save-file';
 
-const downloadXLSX = async (data, title, filename) => {
+const downloadXLSX = async (data, options) => {
   const workbook = await XLSXPopulate.fromBlankAsync();
+
+  workbook.property({
+    Title: options.title,
+    Author: 'JAC',
+  });
+
   const sheet = workbook.sheet(0);
-  sheet.name(title);
+
+  /* NOTE:
+   Sheet name length should not be more than 31 and not contain special characters
+   */
+  sheet.name(options.sheetName.replace(/[^\w\s-]/gi, '').substring(0, 30));
 
   sheet.cell('A1').value(data);
-  sheet.row(1).style({ bold: true, fill: 'eeeeee' });
+  sheet.row(1).style({
+    bold: true,
+    fill: 'eeeeee',
+  });
+  sheet.freezePanes(0, 1);
 
   const blob = await workbook.outputAsync();
-  await save(blob, filename);
+  await save(blob, options.fileName);
 };
 
 export {

--- a/src/views/Exercises/Show/Applications.vue
+++ b/src/views/Exercises/Show/Applications.vue
@@ -215,10 +215,17 @@ export default {
       ];
     },
     exportContacts() {
-      const title = `${this.exercise.referenceNumber} Contacts`;
-      const contacts = this.gatherContacts();
+      const title = 'Contacts';
+      const data = this.gatherContacts();
 
-      downloadXLSX(contacts, title, `${title}.xlsx`);
+      downloadXLSX(
+        data,
+        {
+          title: `${this.exercise.referenceNumber} ${title}`,
+          sheetName: title,
+          fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
+        }
+      );
     },
   },
 };

--- a/src/views/Exercises/Show/Reports/Diversity.vue
+++ b/src/views/Exercises/Show/Reports/Diversity.vue
@@ -508,33 +508,22 @@ export default {
       });
       return data;
     },
-    buildCsvFromDataTable(data) {
-      let csvContent = 'data:text/csv;charset=utf-8,';
-      for (let row = 0, totalRows = data.length; row < totalRows; ++row) {
-        for (let column = 0, totalColumns = data[row].length; column < totalColumns; ++column) {
-          if (row === 0 || column === 0) {  // first row and first column are strings
-            csvContent += `"${data[row][column]}"`;
-          } else {
-            csvContent += `${data[row][column]}`;
-          }
-          if (column < totalColumns - 1) {
-            csvContent += ';';
-          }
-        }
-        csvContent += '\n';
-      }
-      csvContent = csvContent.replace(/(^\[)|(\]$)/gm, '');
-      return encodeURI(csvContent);
-    },
     exportData(stage) {
-      let title = `${this.exercise.referenceNumber} Diversity Report`;
+      let title = 'Diversity Report';
       if (stage) {
         title = `${title} - ${stage}`;
       }
 
       const data = this.gatherReportData(stage);
 
-      downloadXLSX(data, title, `${title}.xlsx`);
+      downloadXLSX(
+        data,
+        {
+          title: `${this.exercise.referenceNumber} ${title}`,
+          sheetName: title,
+          fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
+        }
+      );
     },
   },
 };

--- a/src/views/Exercises/Show/Reports/Handover.vue
+++ b/src/views/Exercises/Show/Reports/Handover.vue
@@ -358,10 +358,17 @@ export default {
       ];
     },
     exportData() {
-      const title = `${this.exercise.referenceNumber} Handover Report`;
-      const report = this.gatherReportData();
+      const title = 'Handover Report';
+      const data = this.gatherReportData();
 
-      downloadXLSX(report, title, `${title}.xlsx`);
+      downloadXLSX(
+        data,
+        {
+          title: `${this.exercise.referenceNumber} ${title}`,
+          sheetName: title,
+          fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
+        }
+      );
     },
   },
 };

--- a/src/views/Exercises/Show/Reports/ReasonableAdjustments.vue
+++ b/src/views/Exercises/Show/Reports/ReasonableAdjustments.vue
@@ -148,10 +148,17 @@ export default {
       ];
     },
     exportData() {
-      const title = `${this.exercise.referenceNumber} Reasonable Adjustments Report`;
-      const report = this.gatherReportData();
+      const title = 'Reasonable Adjustments Report';
+      const data = this.gatherReportData();
 
-      downloadXLSX(report, title, `${title}.xlsx`);
+      downloadXLSX(
+        data,
+        {
+          title: `${this.exercise.referenceNumber} ${title}`,
+          sheetName: title,
+          fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
+        }
+      );
     },
   },
 };

--- a/tests/unit/views/Exercises/Show/Applications.spec.js
+++ b/tests/unit/views/Exercises/Show/Applications.spec.js
@@ -350,11 +350,17 @@ describe('@/views/Exercises/Show/Applications', () => {
 
       it('calls downloadXLSX', () => {
         const mockReport = 'mock report';
-        const mockTitle = `${mockExercise.referenceNumber} Contacts`;
+        const mockTitle = 'Contacts';
 
         wrapper.vm.gatherContacts = jest.fn().mockReturnValue(mockReport);
+
         wrapper.vm.exportContacts();
-        expect(downloadXLSX).toHaveBeenCalledWith(mockReport, mockTitle, `${mockTitle}.xlsx`);
+
+        expect(downloadXLSX).toHaveBeenCalledWith(mockReport, {
+          title: `${mockExercise.referenceNumber} ${mockTitle}`,
+          sheetName: mockTitle,
+          fileName: `${mockExercise.referenceNumber} - ${mockTitle}.xlsx`,
+        });
       });
     });
   });

--- a/tests/unit/views/Exercises/Show/Reports/ReasonableAdjustments.spec.js
+++ b/tests/unit/views/Exercises/Show/Reports/ReasonableAdjustments.spec.js
@@ -136,11 +136,17 @@ describe('@/views/Exercises/Show/Reports/ReasonableAdjustments', () => {
 
       it('calls downloadXLSX', () => {
         const mockReport = 'mock report';
-        const mockTitle = `${mockExercise.referenceNumber} Reasonable Adjustments Report`;
+        const mockTitle = 'Reasonable Adjustments Report';
 
         wrapper.vm.gatherReportData = jest.fn().mockReturnValue(mockReport);
+
         wrapper.vm.exportData();
-        expect(downloadXLSX).toHaveBeenCalledWith(mockReport, mockTitle, `${mockTitle}.xlsx`);
+
+        expect(downloadXLSX).toHaveBeenCalledWith(mockReport, {
+          title: `${mockExercise.referenceNumber} ${mockTitle}`,
+          sheetName: mockTitle,
+          fileName: `${mockExercise.referenceNumber} - ${mockTitle}.xlsx`,
+        });
       });
     });
   });


### PR DESCRIPTION
Turns out Excel can't deal with sheet names longer than 31 characters.
