### PR TITLE
#860 Fix DateInput component not allowing datetime

### DIFF
--- a/src/components/Form/DateInput.vue
+++ b/src/components/Form/DateInput.vue
@@ -206,9 +206,8 @@ export default {
       const day = this.type === 'month' ? 1 : this.day;
       const month = this.month;
       const year = this.year;
-      const hour = this.type === 'datetime' ? this.hour : 0;
+      const hour = this.type === 'datetime' ? this.hour : 13; // default time to 1pm. this avoids BST issue we would have if we defaulted to 0
       const minute = this.type === 'datetime' ? this.minute : 0;
-
       if (!day || !month || !year) {
         return null;
       }
@@ -219,7 +218,7 @@ export default {
         if (this.dateConstructor === null) {
           return null;
         } else {
-          return new Date(Date.UTC(...this.dateConstructor));
+          return new Date(...this.dateConstructor);
         }
       },
       set(value) {


### PR DESCRIPTION
This removes again the `Date.UTC` call that was added in #848 and removed in #831.

Instead I have changed the default time to 13:00. Partly because JAC tends to use 13:00 as default time for launching an exercise, for example. Mainly because this means we bypass the BST daylight saving issue that was being experienced where a default time of 0:00 was (when in BST) being converted to 23:00 the previous day.