### PR TITLE
Fix reference number in qt score download

### DIFF
--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Responses.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Responses.vue
@@ -125,7 +125,7 @@ export default {
       const data = this.sortedByScoresArr.map(element => {
         const row = [
           element.id,
-          'element.application.referenceNumber',
+          element.application.referenceNumber || '',
           element.candidate.fullName,
           element.duration.testDurationAdjusted,
           element.duration.reasonableAdjustment,

--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Responses.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Responses.vue
@@ -126,7 +126,7 @@ export default {
         const row = [
           element.id,
           element.application.referenceNumber || '',
-          element.candidate.fullName,
+          element.candidate.fullName || element.candidate.email,
           element.duration.testDurationAdjusted,
           element.duration.reasonableAdjustment,
           this.timeTaken(element),


### PR DESCRIPTION
Ref num for QT downloads is sometimes missing and when working on a feature i hardcoded it to a string, ive now added a fallback default empty string which will show when the field isn't present and the same thing for the fullName field which will default to the name field