### PR TITLE
1141/rename admin app

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,7 @@
             href="/"
             class="govuk-link govuk-link--no-visited-state govuk-!-font-size-24 govuk-!-font-weight-bold"
           >
-            Internal service name
+            JAC Digital Platform
           </a>
 
           <nav class="float-right">


### PR DESCRIPTION
changed 'internal service name' to 'JAC Digital Platform' in app.vue