### PR TITLE
#1201 Include version number in UI and Sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "apply-admin",
-  "version": "0.54.2",
+  "name": "admin",
+  "version": "0.59.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2452,9 +2452,9 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "0.0.25",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.0.25/3c1ee5ca3e3298cd519a2423a7a9951ca36e127a7416faff3353812ce1cecd05",
-      "integrity": "sha512-JbUnzXweZNsgJyHu0iTDuTnFTZjwOCt/DECYCWQ09KrK3KXtpOPxd1p7wruy8Cd0GBVSunljrl90vFZ0fGYajw=="
+      "version": "0.0.31",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.0.31/a1de9bb5586fcedb7948ffeb073c5957ebfc6a46d5b25268f4e4a4e01b457150",
+      "integrity": "sha512-0SmaVOB6SEhHOUDJBs5ZZlharnadJgdz4wBq81Nqph2wpQddVblUmskOasKFi3nPF5cG+uugwdXay5oZHn1xZA=="
     },
     "@jest/console": {
       "version": "24.9.0",
@@ -14858,7 +14858,7 @@
       "integrity": "sha512-J9X76xnncMw+wIqb15HeWfPMqPwYxSpPY8yWPJ7rAZN/ZDzFkjCSZObryCyUe8zbrVRNiuCnIeQteCzMn7GnWw==",
       "requires": {
         "canvg": "1.5.3",
-        "file-saver": "github:eligrey/FileSaver.js#1.3.8",
+        "file-saver": "file-saver@github:eligrey/FileSaver.js#1.3.8",
         "html2canvas": "1.0.0-alpha.12",
         "omggif": "1.0.7",
         "promise-polyfill": "8.1.0",
@@ -14879,8 +14879,8 @@
           }
         },
         "file-saver": {
-          "version": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
-          "from": "github:eligrey/FileSaver.js#1.3.8"
+          "version": "git+ssh://git@github.com/eligrey/FileSaver.js.git#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
+          "from": "file-saver@github:eligrey/FileSaver.js#1.3.8"
         },
         "html2canvas": {
           "version": "1.0.0-alpha.12",

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@
           >
             JAC Digital Platform
           </a>
+          <span class="govuk-body-xs govuk-!-padding-left-2">{{ $store.getters.appVersion }}</span>
 
           <nav class="float-right">
             <ul class="govuk-header__navigation user-menu">

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,7 @@ if (process.env.NODE_ENV !== 'development') {
   Sentry.init({
     dsn: 'https://ab99abfef6294bc5b564e635d7b7cb4b@sentry.io/1792541',
     environment: parts[0] == 'admin' ? 'production' : 'staging',
-    release: process.env.npm_package_version,
+    release: process.env.PACKAGE_VERSION, // made available in vue.config.js
     integrations: [new Integrations.Vue({ Vue, attachProps: true })],
   });
 }

--- a/src/store.js
+++ b/src/store.js
@@ -61,12 +61,18 @@ const store = new Vuex.Store({
     qualifyingTestReport,
     panels,
   },
-  state: {},
+  state: {
+    packageVersion: process.env.PACKAGE_VERSION || '0',
+  },
   mutations: {
     ...vuexfireMutations,
   },
   actions: {},
-  getters: {},
+  getters: {
+    appVersion: (state) => {
+      return state.packageVersion;
+    },
+  },
 });
 
 export default store;

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,18 @@
+const fs = require('fs');
+const packageJson = fs.readFileSync('./package.json');
+const version = JSON.parse(packageJson).version || 0;
+const webpack = require('webpack');
+
 module.exports = {
+  configureWebpack: {
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env': {
+          PACKAGE_VERSION: `"${version}"`,
+        },
+      }),
+    ],
+  },
   css: {
     loaderOptions: {
       sass: {


### PR DESCRIPTION
This PR grabs the version number from `package.json` and injects it into our app as follows:
 - Sends the version number to Sentry. This will help track which versions introduce or fix errors 😄 
 - Makes version number available in `$store.getters.appVersion`
 - Displays the version number in the header

**Testing**
On develop (or localhost) check that version number is displayed in the header
On staging please check that errors in Sentry now come through with the version number

**Expected**
<img width="358" alt="Screenshot 2021-03-09 at 22 36 05" src="https://user-images.githubusercontent.com/8524401/110550893-6c45f400-812c-11eb-9431-8f55d8ca1802.png">
