### PR TITLE
#1212 Enable leadership judge assessment

### DIFF
--- a/src/components/ModalViews/LeadershipJudgeDetails.vue
+++ b/src/components/ModalViews/LeadershipJudgeDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="modal__title govuk-!-padding-2 govuk-heading-m">
-      Independent Assessor Change
+      Leadership Judge Details
     </div>
     <div class="modal__content govuk-!-margin-6">
       <div class="govuk-grid-row">
@@ -23,14 +23,14 @@
               required
             />
             <TextField
-              id="first-assessor-email"
+              id="email"
               v-model="email"
               label="Email"
               type="email"
               required
             />
             <TextField
-              id="first-assessor-Phone"
+              id="phone"
               v-model="phone"
               label="Phone"
               type="tel"
@@ -59,7 +59,7 @@
 import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField';
 
 export default {
-  name: 'IndependentAssessorChange',
+  name: 'LeadershipJudgeDetails',
   components: {
     TextField,
   },
@@ -72,9 +72,8 @@ export default {
     };
   },
   computed: {
-    userId() {
-      const assessorId = this.$attrs.assessor.id;
-      return assessorId ? assessorId : this.$attrs.uuid;
+    applicationId() {
+      return this.$attrs['application-id'];
     },
   },
   created() {
@@ -93,24 +92,15 @@ export default {
       document.body.style.overflow = '';
     },
     async save() {
-      let data = {};
-      if (this.$attrs.AssessorNr == 1) {
-        data = {
-          firstAssessorEmail: this.email,
-          firstAssessorFullName: this.fullName,
-          firstAssessorPhone: this.phone,
-          firstAssessorTitle: this.title,
-        };
-      } else if (this.$attrs.AssessorNr == 2) {
-        data = {
-          secondAssessorEmail: this.email,
-          secondAssessorFullName: this.fullName,
-          secondAssessorPhone: this.phone,
-          secondAssessorTitle: this.title,
-        };
-      }
-      this.$store.dispatch('application/update', { data: data, id: this.$attrs.applicationId });
-      this.$store.dispatch('assessment/update', { data: data, id: this.$attrs.applicationId, AssessorNr: this.$attrs.AssessorNr });
+      const data = {
+        leadershipJudgeDetails: {
+          email: this.email,
+          fullName: this.fullName,
+          phone: this.phone,
+          title: this.title,
+        },
+      };
+      await this.$store.dispatch('application/update', { data: data, id: this.applicationId });
       this.closeModal();
     },
   },

--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -1745,7 +1745,7 @@
           class="govuk-!-margin-top-9"
         >
           <h2 class="govuk-heading-l govuk-!-margin-bottom-0">
-            Leadership judge details
+            Leadership Judge details
           </h2>
 
           <dl

--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -671,7 +671,7 @@
                 Location preferences
               </h2>
 
-              <dl 
+              <dl
                 v-if="application.locationPreferences"
                 class="govuk-summary-list"
               >
@@ -1348,7 +1348,7 @@
                   Law-related tasks
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <ul 
+                  <ul
                     v-if="item.tasks && item.tasks.length"
                     class="govuk-list"
                   >
@@ -1368,7 +1368,7 @@
                     </li>
                   </ul>
                   <div v-else>
-                    No Answers provided 
+                    No Answers provided
                   </div>
                 </dd>
               </div>
@@ -1569,8 +1569,11 @@
           </dl>
         </div>
 
-        <div class="govuk-!-margin-top-9">
-          <h2 class="govuk-heading-l">
+        <div
+          v-if="assessmentMethods.independentAssessments"
+          class="govuk-!-margin-top-9"
+        >
+          <h2 class="govuk-heading-l govuk-!-margin-bottom-0">
             Independent assessors
           </h2>
 
@@ -1631,7 +1634,7 @@
             </div>
           </dl>
           <dl
-            v-else 
+            v-else
             class="govuk-summary-list"
           >
             <dt
@@ -1735,7 +1738,103 @@
               @close="closeModal('modalRef')"
             />
           </Modal>
+        </div>
 
+        <div
+          v-if="assessmentMethods.leadershipJudgeAssessment"
+          class="govuk-!-margin-top-9"
+        >
+          <h2 class="govuk-heading-l govuk-!-margin-bottom-0">
+            Leadership judge details
+          </h2>
+
+          <dl
+            v-if="application.leadershipJudgeDetails"
+            class="govuk-summary-list"
+          >
+            <div class="govuk-summary-list__row text-right print-none button-right">
+              <dt class="govuk-summary-list__key" />
+              <dd class="govuk-summary-list__value">
+                <button
+                  class="govuk-button btn-unlock"
+                  @click="editLeadershipJudgeDetails"
+                >
+                  Edit
+                </button>
+              </dd>
+            </div>
+
+            <div
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Full name
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ application.leadershipJudgeDetails.fullName }}
+              </dd>
+            </div>
+
+            <div
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Title or position
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ application.leadershipJudgeDetails.title }}
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row print-none">
+              <dt class="govuk-summary-list__key">
+                Email
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ application.leadershipJudgeDetails.email }}
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row print-none">
+              <dt class="govuk-summary-list__key">
+                Telephone
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ application.leadershipJudgeDetails.phone }}
+              </dd>
+            </div>
+          </dl>
+          <dl
+            v-else
+            class="govuk-summary-list"
+          >
+            <dt
+              class="govuk-summary-list__key"
+            >
+              No information for Leadership Judge
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <button
+                class="govuk-button btn-unlock"
+                @click="editLeadershipJudgeDetails"
+              >
+                Add
+              </button>
+            </dd>
+          </dl>
+          <Modal
+            ref="modalLeadershipJudgeDetails"
+          >
+            <component
+              :is="`LeadershipJudgeDetails`"
+              v-bind="application.leadershipJudgeDetails"
+              :application-id="applicationId"
+              @close="closeModal('modalLeadershipJudgeDetails')"
+            />
+          </Modal>
+        </div>
+
+        <div>
           <div
             v-if="exercise.aSCApply"
             class="govuk-!-margin-top-9"
@@ -1938,6 +2037,7 @@ import htmlDocx from 'html-docx-js/dist/html-docx'; //has to be imported from di
 import { saveAs } from 'file-saver';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 import IndependentAssessorChange from '@/components/ModalViews/IndependentAssessorChange';
+import LeadershipJudgeDetails from '@/components/ModalViews/LeadershipJudgeDetails';
 import SubmissionExtension from '@/components/ModalViews/SubmissionExtension';
 import Notes from '@/components/Notes/Notes';
 import CriminalOffencesSummary from '@/views/InformationReview/CriminalOffencesSummary';
@@ -1959,6 +2059,7 @@ export default {
     FileUpload,
     Modal,
     IndependentAssessorChange,
+    LeadershipJudgeDetails,
     SubmissionExtension,
     Notes,
     CriminalOffencesSummary,
@@ -2051,6 +2152,22 @@ export default {
         return this.application.equalityAndDiversitySurvey.otherEthnicGroupMixedDetails;
       default:
         return this.application.equalityAndDiversitySurvey.otherEthnicGroupDetails;
+      }
+    },
+    assessmentMethods() {
+      if (this.exercise.assessmentMethods) {
+        return this.exercise.assessmentMethods;
+      } else {
+        // TODO populate this return object based upon the _old_ `assessmentOptions` data
+        return {
+          independentAssessments: true, // always show IAs unless they've been specifically turned off
+          leadershipJudgeAssessment: false,
+        // selfAssessment: false,
+        // statementOfEligibility: false,
+        // statementOfSuitability: false,
+        // coveringLetter: false,
+        // cv: false,
+        };
       }
     },
     showStatementOfSuitability() {
@@ -2320,6 +2437,9 @@ export default {
         };
       }
       this.openModal('modalRef');
+    },
+    editLeadershipJudgeDetails() {
+      this.openModal('modalLeadershipJudgeDetails');
     },
     openModal(modalRef){
       this.$refs[modalRef].openModal();

--- a/src/views/Exercises/Edit/AssessmentOptions.vue
+++ b/src/views/Exercises/Edit/AssessmentOptions.vue
@@ -67,6 +67,19 @@
           />
         </RadioGroup>
 
+        <Checkbox
+          id="assessment-method-independent-assessments"
+          v-model="exercise.assessmentMethods.independentAssessments"
+        >
+          Independent Assessments
+        </Checkbox>
+        <Checkbox
+          id="assessment-method-leadership-judge"
+          v-model="exercise.assessmentMethods.leadershipJudgeAssessment"
+        >
+          Leadership Judge Assessment
+        </Checkbox>
+
         <button class="govuk-button">
           Save and continue
         </button>
@@ -81,6 +94,7 @@ import ErrorSummary from '@jac-uk/jac-kit/draftComponents/Form/ErrorSummary';
 import BackLink from '@jac-uk/jac-kit/draftComponents/BackLink';
 import RadioGroup from '@jac-uk/jac-kit/draftComponents/Form/RadioGroup';
 import RadioItem from '@jac-uk/jac-kit/draftComponents/Form/RadioItem';
+import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox';
 
 export default {
   components: {
@@ -88,11 +102,22 @@ export default {
     BackLink,
     RadioGroup,
     RadioItem,
+    Checkbox,
   },
   extends: Form,
   data(){
     const defaults = {
       assessmentOptions: null,
+      // TODO: `assessmentMethods` will eventually replace `assessmentOptions`
+      assessmentMethods: {
+        independentAssessments: true,
+        leadershipJudgeAssessment: false,
+        // selfAssessment: false,
+        // statementOfEligibility: false,
+        // statementOfSuitability: false,
+        // coveringLetter: false,
+        // cv: false,
+      },
     };
     const data = this.$store.getters['exerciseDocument/data']();
     const exercise = { ...defaults, ...data };

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -197,11 +197,13 @@ export default {
         },
       ];
       if (this.exercise.applicationRecords) {
-        tasks.push(
-          {
+        if (!(this.exercise.assessmentMethods && this.exercise.assessmentMethods.independentAssessments === false)) {
+          tasks.push({
             title: 'Independent Assessments',
             name: 'exercise-tasks-independent-assessments',
-          },
+          });
+        }
+        tasks.push(
           {
             title: 'Character Checks',
             name: 'exercise-tasks-character-checks',


### PR DESCRIPTION
Enables staff to turn Independent Assessments off and to select a _new_ assessment method, Leadership Judge Assessment.

**To test**
- Go to Exercise > Assessment Options > Update
- Notice two new checkboxes
- Set them on or off and save
- In the side navigation notice that Tasks > Independent Assessments link only shows when the corresponding assessment option has been selected
- In Exercise > Applications > Application notice that IAs and Leadership Judge Details only show when the corresponding option has been selected
- Can edit IAs (still)
- Can edit Leadership judge details

**Note** 
This is the minimum viable and additional effort will eventually be needed on the following:
- Replace the current Assessment Options radios with a set of checkboxes instead so staff can select from the following:
  - Self Assessment
  - Statement of suitability
  - Statement of eligibility
  - Covering letter
  - CV
  - Independent Assessments
  - Leadership Judge Assessment
- Update the Assessment Options view page to reflect choices made in the check boxes
- Update (and simplify) a lot of the existing code to decipher the chosen Assessment Options
- Include a Leadership Judge Assessment task (if needed) to support contacting assessors and obtaining their assessments
