### PR TITLE
Remove .npmrc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,8 @@ jobs:
       - run:
           name: 'Setup'
           command: |
-            echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}" > ~/.npmrc
+            echo "registry=https://npm.pkg.github.com/jac-uk" > ~/.npmrc
+            echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}" >> ~/.npmrc
             npm ci
       - persist_to_workspace:
           root: .

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://npm.pkg.github.com/jac-uk


### PR DESCRIPTION
CircleCI config has been updated to create the whole `.npmrc` on the fly.

This means we no longer need `.npmrc` in our codebase therefore we should be able to install the project without the `npm login` shenanigans. 🤞 

Please test by logging out of npm and trying a fresh install.