### PR TITLE
#730 QT response reset and confirmation modal

### DIFF
--- a/src/store/qualifyingTest/qualifyingTestResponses.js
+++ b/src/store/qualifyingTest/qualifyingTestResponses.js
@@ -117,13 +117,15 @@ export default {
       await context.dispatch('update', { data: data, id: qualifyingTestResponse.id });
     },
     resetTest: async (context) => {
+      const timestamp = firebase.firestore.FieldValue.serverTimestamp();
       const email = firebase.auth().currentUser.email;
       const canReset = await authorisedToPerformAction(email);
       if (canReset) {
         const rec = context.state.record;
         const data = {
-              'status': 'activated',
-            };
+          'status': 'activated',
+          'statusLog.reset': timestamp,
+        };
         if (rec.isOutOfTime === true) {
           data.isOutOfTime = false;
         }

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
@@ -181,7 +181,7 @@
           </div>
           <div class="modal__content govuk-!-padding-4">
             <p class="modal__message govuk-body-l">
-              Reseting this candidates test will overwrite their
+              Reseting this candidate's test will overwrite their
               'started', 'completed' and 'time taken' fields.
               <br>
               Please ensure there is a record of these before continuing.
@@ -653,50 +653,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @mixin mobile-view {
-    @media (max-width: 599px) { @content; }
-  }
-
-  @include mobile-view { 
-    .modal {
-      min-width: 100%;
-      min-height: 100%;
-    }
-  }
-
-  .modal {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    width: 30%;
-    transform: translate(-50%, -50%);
-    border: solid 2px #b1b4b6;
-    background-color: #ffffff;
-  }
-  .modal__title {
-    text-align: center;
-    vertical-align: middle;
-    border: solid 2px #1d70b8;
-    background-color: #1d70b8;
-    color: white;
-  }
-  .modal__message {
-    vertical-align: middle;
-  }
   .deny {
     background-color: #f3f2f1;
-  }
-  .modal-mask {
-    position: fixed;
-    z-index: 9998;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    display: table;
-    transition: opacity 0.3s ease;
-    overflow: hidden;
   }
   .answer--right {
     font-weight: bold;

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
@@ -25,15 +25,15 @@
           </dt>
           <dd class="govuk-summary-list__value">
             {{ response.status | lookup }} {{ response.isOutOfTime ? 'DNF' : '' }}
-            <ActionButton
+            <button
               v-if="authorisedToPerformAction"
               :disabled="hasActivated"
               type="secondary"
-              class="float-right govuk-!-margin-bottom-1"
+              class="govuk-button govuk-button--secondary float-right govuk-!-margin-bottom-1"
               @click="resetTest"
             >
               Reset
-            </ActionButton>
+            </button>
             <ActionButton
               v-if="authorisedToPerformAction"
               :disabled="hasCompleted"
@@ -172,7 +172,38 @@
           </dd>
         </div>
       </dl>
+      <Modal
+        ref="confirmResetModal"
+      >
+        <div class="container">
+          <div class="modal__title govuk-!-padding-2 govuk-heading-m">
+            Caution
+          </div>
+          <div class="modal__content govuk-!-padding-4">
+            <p class="modal__message govuk-body-l">
+              Reseting this candidates test will overwrite their
+              'started', 'completed' and 'time taken' fields.
+              <br>
+              Please ensure there is a record of these before continuing.
+            </p>
 
+            <span>
+              <button
+                class="govuk-button govuk-button--secondary govuk-!-margin-right-3 deny info-btn--modal--cancel"
+                @click="$refs['confirmResetModal'].closeModal()"
+              >
+                Cancel
+              </button>
+            </span>
+            <ActionButton
+              class="govuk-button govuk-button--warning"
+              @click="confirmReset"
+            >
+              Reset Test
+            </ActionButton>
+          </div>
+        </div>
+      </Modal>
       <div v-if="hasStarted">
         <TabsList
           :tabs="tabs"
@@ -334,12 +365,14 @@ import TabsList from '@jac-uk/jac-kit/draftComponents/TabsList';
 import QuestionDuration from '@/components/Micro/QuestionDuration';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton';
 import { authorisedToPerformAction }  from '@/helpers/authUsers';
+import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 
 export default {
   components: {
     EditableField,
     Select,
     TabsList,
+    Modal,
     QuestionDuration,
     ActionButton,
   },
@@ -497,10 +530,14 @@ export default {
     this.authorisedToPerformAction = await authorisedToPerformAction(email);
   },
   methods: {
-    resetTest() {
+    confirmReset() {
       if (this.authorisedToPerformAction && this.authorisedToPerformAction === true) {
         this.$store.dispatch('qualifyingTestResponses/resetTest');
+        this.$refs['confirmResetModal'].closeModal();
       }
+    },
+    resetTest() {
+      this.$refs['confirmResetModal'].openModal();
     },
     markAsCompleted() {
       if (this.authorisedToPerformAction && this.authorisedToPerformAction === true) {
@@ -615,7 +652,52 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+  @mixin mobile-view {
+    @media (max-width: 599px) { @content; }
+  }
+
+  @include mobile-view { 
+    .modal {
+      min-width: 100%;
+      min-height: 100%;
+    }
+  }
+
+  .modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    width: 30%;
+    transform: translate(-50%, -50%);
+    border: solid 2px #b1b4b6;
+    background-color: #ffffff;
+  }
+  .modal__title {
+    text-align: center;
+    vertical-align: middle;
+    border: solid 2px #1d70b8;
+    background-color: #1d70b8;
+    color: white;
+  }
+  .modal__message {
+    vertical-align: middle;
+  }
+  .deny {
+    background-color: #f3f2f1;
+  }
+  .modal-mask {
+    position: fixed;
+    z-index: 9998;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: table;
+    transition: opacity 0.3s ease;
+    overflow: hidden;
+  }
   .answer--right {
     font-weight: bold;
     text-decoration: underline;
@@ -639,4 +721,3 @@ export default {
     padding: 5px;
   }
 </style>
-


### PR DESCRIPTION
## What's included?
The ability to reset a QT response via the admin portal

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- Find an exercise with a past QT, which has responses.
- Select completed (finished) response.
- Observe the 'reset' button on the response page (only available for authorised digital accounts)
- Clicking the reset button should open a modal
- Warning appears in modal
⎿Clicking cancel closes the modal and prevents reset
⎿Clicking confirm resets the QT
- Once reset, a QT will be able to be marked as completed.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas.

---
![image](https://user-images.githubusercontent.com/44227249/126511048-7eff1c8a-c747-481f-944b-bbd8b34850ad.png)

video: [here](https://drive.google.com/drive/u/1/folders/1-kkQ1_ArvpIiHIid7NBPDzwnPoss0TPR)

https://user-images.githubusercontent.com/44227249/126502388-b66c928d-a5e4-4dde-9a21-c132936f9360.mov

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_

