### PR TITLE
#1237 Configure npm to use github packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://npm.pkg.github.com/jac-uk
+@jac-uk:registry=https://npm.pkg.github.com


### PR DESCRIPTION
This change helps to solve the npm install issue experienced when installing JAC Kit.

It ensures the `@jac-uk` scope is directed to the Github Packages registry.

(at least it fixed it for me 😄)