### PR TITLE
Feature/agency report fix

### DIFF
--- a/src/views/Exercises/Show/Reports/Agency.vue
+++ b/src/views/Exercises/Show/Reports/Agency.vue
@@ -513,22 +513,22 @@ export default {
       return activeTab;
     },
     sraRows() {
-      return this.report.rows.filter((e) => e.sraDate);
+      return this.report ? this.report.rows.filter((e) => e.sraDate) : [];
     },
     bsbRows() {
-      return this.report.rows.filter((e) => e.bsbDate);
+      return this.report ? this.report.rows.filter((e) => e.bsbDate) : [];
     },
     jcioRows() {
-      return this.report.rows.filter((e) => e.jcioOffice);
+      return this.report ? this.report.rows.filter((e) => e.jcioOffice) : [];
     },
     hmrcRows() {
-      return this.report.rows.filter((e) => e.hmrcVATNumbers);
+      return this.report ? this.report.rows.filter((e) => e.hmrcVATNumbers) : [];
     },
     gmcRows() {
-      return this.report.rows.filter((e) => e.gmcDate);
+      return this.report ? this.report.rows.filter((e) => e.gmcDate) : [];
     },
     riscRows() {
-      return this.report.rows.filter((e) => e.riscDate);
+      return this.report ? this.report.rows.filter((e) => e.riscDate) : [];
     },
   },
   created() {

--- a/src/views/Exercises/Show/Reports/Agency.vue
+++ b/src/views/Exercises/Show/Reports/Agency.vue
@@ -15,6 +15,7 @@
             <button
               class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
               data-module="govuk-button"
+              :disabled="hasReportData ? '' : disabled"
               @click="exportData()"
             >
               Export data
@@ -541,6 +542,9 @@ export default {
     if (this.unsubscribe) {
       this.unsubscribe();
     }
+  },
+  hasReportData() {
+    return this.report && this.report.headers;
   },
   methods: {
     async refreshReport() {

--- a/src/views/Exercises/Show/Reports/Diversity.vue
+++ b/src/views/Exercises/Show/Reports/Diversity.vue
@@ -22,6 +22,7 @@
               <button
                 class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
                 data-module="govuk-button"
+                :disabled="showTabs ? '' : disabled"
                 @click="exportData(activeTab)"
               >
                 Export stage data
@@ -29,6 +30,7 @@
               <button
                 class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
                 data-module="govuk-button"
+                :disabled="showTabs ? '' : disabled"
                 @click="exportData()"
               >
                 Export all data

--- a/src/views/Exercises/Show/Reports/Handover.vue
+++ b/src/views/Exercises/Show/Reports/Handover.vue
@@ -15,6 +15,7 @@
             <button
               class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
               data-module="govuk-button"
+              :disabled="hasReportData ? '' : disabled"
               @click="exportData()"
             >
               Export data
@@ -141,6 +142,9 @@ export default {
     if (this.unsubscribe) {
       this.unsubscribe();
     }
+  },
+  hasReportData() {
+    return this.report && this.report.headers;
   },
   methods: {
     async transferHandoverData() {

--- a/src/views/Exercises/Show/Reports/Outreach.vue
+++ b/src/views/Exercises/Show/Reports/Outreach.vue
@@ -22,6 +22,7 @@
               <button
                 class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
                 data-module="govuk-button"
+                :disabled="showTabs ? '' : disabled"
                 @click="exportData(activeTab)"
               >
                 Export stage data
@@ -29,6 +30,7 @@
               <button
                 class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
                 data-module="govuk-button"
+                :disabled="showTabs ? '' : disabled"
                 @click="exportData()"
               >
                 Export all data
@@ -93,8 +95,8 @@
         Summary report coming soon
       </p>
 
-      <div 
-        v-else 
+      <div
+        v-else
       >
         <table class="govuk-table table-with-border">
           <caption class="govuk-table__caption hidden">
@@ -117,8 +119,8 @@
             </tr>
           </thead>
           <tbody class="govuk-table__body">
-            <tr 
-              v-for="(answer, key, answerIndex) in reduceReport(report[activeTab].outreach)" 
+            <tr
+              v-for="(answer, key, answerIndex) in reduceReport(report[activeTab].outreach)"
               :key="answerIndex"
               class="govuk-table__row"
             >

--- a/src/views/Exercises/Show/Reports/ReasonableAdjustments.vue
+++ b/src/views/Exercises/Show/Reports/ReasonableAdjustments.vue
@@ -15,6 +15,7 @@
             <button
               class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
               data-module="govuk-button"
+              :disabled="hasReportData ? '' : disabled"
               @click="exportData()"
             >
               Export data
@@ -153,6 +154,9 @@ export default {
     if (this.unsubscribe) {
       this.unsubscribe();
     }
+  },
+  hasReportData() {
+    return this.report && this.report.headers;
   },
   methods: {
     async refreshReport() {


### PR DESCRIPTION
This merge request fixes a bug where you would get an error if you clicked on any of the tabs before clicking the Refresh button.

I also made a change to the report pages so that the Export buttons are disabled if no report has been generated yet.