### PR TITLE
admin#1203 Ability to copy a QT test

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -73,6 +73,7 @@ import QualifyingTestsCover from '@/views/Exercises/Tasks/QualifyingTests/Cover'
 // QTs
 import QualifyingTest from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest';
 import QualifyingTestNew from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/New';
+import QualifyingTestNewFromClipboard from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/NewFromClipboard';
 import QualifyingTestEdit from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Edit';
 import QualifyingTestView from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View';
 import QualifyingTestQuestionBuilder from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/TestBuilder';
@@ -481,6 +482,15 @@ const router = new Router({
               meta: {
                 requiresAuth: true,
                 title: 'Qualifying Tests | New',
+              },
+            },
+            {
+              path: 'qualifying-tests/new-from-clipboard',
+              component: QualifyingTestNewFromClipboard,
+              name: 'qualifying-test-new-from-clipboard',
+              meta: {
+                requiresAuth: true,
+                title: 'Qualifying Tests | New from Clipboard',
               },
             },
             {

--- a/src/views/Exercises/Tasks/QualifyingTests/Cover.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/Cover.vue
@@ -41,6 +41,13 @@
     >
       Create New
     </button>
+    <button
+      v-if="exercise.exercisePhoneNumber && exercise.emailSignatureName"
+      class="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+      @click="btnCreateFromClipboard"
+    >
+      Create New from Clipboard
+    </button>
     <div v-else>
       <Banner
         :message="warningMessage"
@@ -100,6 +107,9 @@ export default {
   methods: {
     btnCreate() {
       this.$router.push({ name: 'qualifying-test-new' });
+    },
+    btnCreateFromClipboard() {
+      this.$router.push({ name: 'qualifying-test-new-from-clipboard' });
     },
     getViewName(qualifyingTest) {
       if (

--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/NewFromClipboard.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/NewFromClipboard.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="govuk-grid-column-two-thirds">
+    <form @submit.prevent="validateAndSave">
+      <h2 class="govuk-heading-l">
+        Create a qualifying test from Clipboard
+      </h2>
+
+      <ErrorSummary
+        :errors="errors"
+        :show-save-button="false"
+        @save="save"
+      />
+
+      <TextareaInput
+        id="statutory-consultation-waived-details"
+        v-model="copiedTest"
+        hint="Paste the copied qualifying test from the clipboard: (Ctrl + V)"
+        label="Clipboard text"
+        rows="15"
+        required
+      />
+
+      <Checkbox
+        id="is-dry-run"
+        v-model="isDryRun"
+        label="Dry run"
+      >
+        Yes, this is a dry run
+      </Checkbox>
+
+      <button class="govuk-button">
+        Save and continue
+      </button>
+    </form>
+  </div>
+</template>
+
+<script>
+import Form from '@jac-uk/jac-kit/draftComponents/Form/Form';
+import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox';
+import ErrorSummary from '@jac-uk/jac-kit/draftComponents/Form/ErrorSummary';
+import TextareaInput from '@jac-uk/jac-kit/draftComponents/Form/TextareaInput';
+import { QUALIFYING_TEST } from '@jac-uk/jac-kit/helpers/constants';
+
+export default {
+  components: {
+    ErrorSummary,
+    TextareaInput,
+    Checkbox,
+  },
+  extends: Form,
+  data(){
+    const exercise = this.$store.state.exerciseDocument.record;
+
+    const defaults = {
+      type: null,
+      vacancy: {
+        mailbox: exercise.exerciseMailbox,
+        contactPhone: exercise.exercisePhoneNumber,
+        id: exercise.id,
+        referenceNumber: exercise.referenceNumber,
+        name: exercise.name,
+      },
+    };
+    const data = this.$store.getters['qualifyingTest/data']();
+
+    const qualifyingTest = { ...defaults, ...data };
+
+    return {
+      qualifyingTest: qualifyingTest,
+      copiedTest: null,
+      isDryRun: false,
+    };
+  },
+  computed: {
+    testTypes() {
+      return QUALIFYING_TEST.TYPE;
+    },
+  },
+  methods: {
+    async save() {
+      if (this.isDryRun) {
+        this.qualifyingTest.mode = QUALIFYING_TEST.MODE.DRY_RUN;
+      }
+      const data = { ...this.qualifyingTest, ...JSON.parse(this.copiedTest) };
+      const qualifyingTestId = await this.$store.dispatch('qualifyingTest/create', data);
+
+      this.$router.push({
+        name: 'qualifying-test-edit',
+        params: {
+          qualifyingTestId: qualifyingTestId,
+        },
+      });
+    },
+  },
+};
+</script>

--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/NewFromClipboard.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/NewFromClipboard.vue
@@ -79,10 +79,10 @@ export default {
   },
   methods: {
     async save() {
-      if (this.isDryRun) {
-        this.qualifyingTest.mode = QUALIFYING_TEST.MODE.DRY_RUN;
-      }
       const data = { ...this.qualifyingTest, ...JSON.parse(this.copiedTest) };
+      if (this.isDryRun) {
+        data.mode = QUALIFYING_TEST.MODE.DRY_RUN;
+      }
       const qualifyingTestId = await this.$store.dispatch('qualifyingTest/create', data);
 
       this.$router.push({

--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -251,6 +251,14 @@
         Create Mop Up Test
       </button>
 
+      <button
+        ref="btnCopyToClipboard"
+        class="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+        @click="btnCopyToClipboard"
+      >
+        Copy QT to clipboard
+      </button>
+
       <ActionButton
         v-if="isInitialised"
         type="secondary"
@@ -347,6 +355,23 @@ export default {
         this.isCompleted
       );
     },
+    testQuestionsJson() {
+      const clipboardQT = { ...this.qualifyingTest };
+
+      delete clipboardQT.counts;
+      delete clipboardQT.created; 
+      delete clipboardQT.endDate;
+      if (clipboardQT.invitedEmails) delete clipboardQT.invitedEmails;
+      delete clipboardQT.lastUpdated;
+      if (clipboardQT.mode) delete clipboardQT.mode;
+      if (clipboardQT.relationship) delete clipboardQT.relationship;
+      delete clipboardQT.startDate;
+      delete clipboardQT.status;
+      delete clipboardQT.vacancy;
+
+      const returnValue = JSON.stringify(clipboardQT);
+      return returnValue;
+    },
   },
   watch: {
     exerciseStage: function (valueNow, valueBefore) {
@@ -416,7 +441,21 @@ export default {
           qualifyingTestId: newTestId,
         },
       });
+    },
+    btnCopyToClipboard() {
+      this.$refs.btnCopyToClipboard.innerText = 'Copying to clipboard ...';
+      this.$refs.btnCopyToClipboard.disabled = 'disabled';
+      const el = document.createElement('textarea');
+      el.value = this.testQuestionsJson;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
 
+      setTimeout(() => {
+        this.$refs.btnCopyToClipboard.innerText = 'QT Copied to clipboard';
+        this.$refs.btnCopyToClipboard.disabled = false;
+      },3000);
     },
   },
 };

--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -356,18 +356,29 @@ export default {
       );
     },
     testQuestionsJson() {
-      const clipboardQT = { ...this.qualifyingTest };
+      const {
+        additionalInstructions,
+        feedbackSurvey,
+        maxScore,
+        responsesReport,
+        results,
+        testDuration,
+        testQuestions,
+        title,
+        type,
+      } = this.qualifyingTest;
 
-      delete clipboardQT.counts;
-      delete clipboardQT.created; 
-      delete clipboardQT.endDate;
-      if (clipboardQT.invitedEmails) delete clipboardQT.invitedEmails;
-      delete clipboardQT.lastUpdated;
-      if (clipboardQT.mode) delete clipboardQT.mode;
-      if (clipboardQT.relationship) delete clipboardQT.relationship;
-      delete clipboardQT.startDate;
-      delete clipboardQT.status;
-      delete clipboardQT.vacancy;
+      const clipboardQT = { 
+        additionalInstructions,
+        feedbackSurvey,
+        maxScore,
+        responsesReport,
+        results,
+        testDuration,
+        testQuestions,
+        title,
+        type,
+      };
 
       const returnValue = JSON.stringify(clipboardQT);
       return returnValue;


### PR DESCRIPTION
## What's included?
This PR adds a button to allow:
1.  the copy of a QT test to the clipboard
2. the paste of the clipboard when creating a new QT test

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to any QT test, and a button "Copy QT to clipboard"
> when clicked, it will show as copying and then the success message will show up

2. On the QT list, a button with the text "Create new from clipboard" is showing up
> Paste the content of the clipboard and follow the instructions

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas
---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_