### PR TITLE
#1279 Disable the button ‘Create dry run tests’ if there are no candidates

### DIFF
--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/TestBuilder.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/TestBuilder.vue
@@ -115,7 +115,11 @@ export default {
           }
         }
         await this.$store.dispatch('qualifyingTest/save', this.qualifyingTest);
-        this.$router.push({ name: 'qualifying-test-review' });
+        if (this.qualifyingTest.mode === QUALIFYING_TEST.MODE.DRY_RUN) {
+          this.$router.push({ name: 'qualifying-test-dry-run' });  
+        } else {
+          this.$router.push({ name: 'qualifying-test-review' });
+        }
       }
     },
   },

--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -137,11 +137,19 @@
         <div v-if="isDryRun">
           <ActionButton
             type="primary"
+            :disabled="!isDryRunCandidates"
             class="govuk-!-margin-right-3"
             @click="btnInitialise"
           >
             Create dry run tests
           </ActionButton>
+          <router-link
+            v-if="!isDryRunCandidates"
+            :to="{ name: 'qualifying-test-dry-run' }"
+            class="govuk-hint"
+          >
+            Please add emails before creating
+          </router-link>
         </div>
         <div v-else-if="isMopUp">
           <ActionButton
@@ -318,6 +326,9 @@ export default {
     },
     isDryRun() {
       return this.qualifyingTest && this.qualifyingTest.mode && this.qualifyingTest.mode === 'dry-run';
+    },
+    isDryRunCandidates() {
+      return this.qualifyingTest && this.qualifyingTest.invitedEmails && this.qualifyingTest.invitedEmails.length > 0;
     },
     isMopUp() {
       return this.qualifyingTest && this.qualifyingTest.mode && this.qualifyingTest.mode === 'mop-up';


### PR DESCRIPTION

## What's included?
- redirect the user to add emails after creating the questions and before the review page
- disable the CREATE DRY RUN button when there are no emails, and add a link to add email as a hint message

Please check the ticket for images

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Create a DRY RUN TEST without adding emails at the end
2. Check that, after adding the questions you are redirected to add emails before being redirected to the review stage
2. Approve the test and check that the link is disabled and a message is a link to add emails
3. Add emails
4. Go back and check that the link is enabled

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Please check the ticket number
