### PR TITLE
1017 Mop up test won't start if the test is open before candidates added

### DIFF
--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -219,7 +219,7 @@
 
       <ActionButton
         v-if="isInitialised"
-        :disabled="false"
+        :disabled="!isUserAdded"
         class="govuk-!-margin-right-3"
         @click="btnActivate"
       >
@@ -335,6 +335,9 @@ export default {
     },
     isInitialised() {
       return this.qualifyingTest.status === QUALIFYING_TEST.STATUS.INITIALISED;
+    },
+    isUserAdded() {
+      return this.qualifyingTest.counts.initialised > 0;
     },
     isActivated() {
       return this.qualifyingTest.status === QUALIFYING_TEST.STATUS.ACTIVATED;


### PR DESCRIPTION
## What's included?
Disabled OPEN TEST button if there is no candidates on the test

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

1. Create a MOP UP test
2. GO to the Qualifying test detail page and verify that the OPEN TEST button is disabled
3. Go to the original test where the mopup was created from, select a user and transfer it to the new mopup
4. Return to the MOPUP qualifying test detail page and check that the OPEN TEST button is enabled allowing the user to OPEN the test for users.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
![image](https://user-images.githubusercontent.com/15261814/117692893-606ec080-b1b5-11eb-9abe-47954e70516c.png)
![image](https://user-images.githubusercontent.com/15261814/117692958-711f3680-b1b5-11eb-8f0d-3e832a5a9a89.png)
![image](https://user-images.githubusercontent.com/15261814/117693072-8a27e780-b1b5-11eb-93b5-98f8269211ab.png)


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_