### PR TITLE
Display location preferences

### DIFF
--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -719,11 +719,14 @@
                   class="govuk-summary-list__value"
                 >
                   <p
-                    v-for="item in application.locationPreferences"
+                    v-for="(item, index) in application.locationPreferences"
                     :key="item.name"
                     class="govuk-body"
                   >
-                    {{ item }}
+                    <strong>
+                      {{ `${index + 1}:` }}
+                    </strong>
+                    {{ `${item}` }}
                   </p>
                 </dd>
               </dl>

--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -358,7 +358,7 @@
               </h2>
 
               <dl
-                v-if="Object.keys(application.equalityAndDiversitySurvey).length"
+                v-if="application.equalityAndDiversitySurvey"
                 class="govuk-summary-list"
               >
                 <div class="govuk-summary-list__row">


### PR DESCRIPTION
## What's included?
Added numbers for location preferences, so order of preference is clearer to admins.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Ensure location question is RANKED choice 
- Observe a candidates application
- Check numbers display next to correct location preference 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
![image](https://user-images.githubusercontent.com/44227249/117798579-2ea73980-b249-11eb-9c46-618ac0c8443e.png)

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_