### PR TITLE
WIP: #1346 Exercise state should be configurable

### DIFF
--- a/src/components/ModalViews/ChangeExerciseState.vue
+++ b/src/components/ModalViews/ChangeExerciseState.vue
@@ -70,8 +70,6 @@ export default {
         state: 'review',
       },
       exerciseStates: [
-        'draft',
-        'ready',
         'approved',
         'shortlisting',
         'selection',

--- a/src/components/ModalViews/ChangeExerciseState.vue
+++ b/src/components/ModalViews/ChangeExerciseState.vue
@@ -1,0 +1,109 @@
+<template>
+  <div>
+    <div class="modal__title text-left govuk-!-padding-2 background-blue">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+        Exercise State
+      </h2>
+    </div>
+    <div class="modal__content govuk-!-margin-6">
+      <div class="govuk-grid-row">
+        <form
+          @submit.prevent="validateAndSave"
+        >
+          <ErrorSummary
+            :errors="errors"
+          />
+          <fieldset>
+            <Select
+              id="exercise-state"
+              v-model="formData.state"
+              required
+            >
+              <option
+                v-for="exerciseState in exerciseStates"
+                :key="exerciseState"
+                :value="exerciseState"
+              >
+                {{ exerciseState | lookup }}
+              </option>
+            </Select>
+          </fieldset>
+          <button
+            class="govuk-button govuk-!-margin-right-3"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            class="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+            @click="closeModal"
+          >
+            Cancel
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Form from '@jac-uk/jac-kit/draftComponents/Form/Form';
+import ErrorSummary from '@jac-uk/jac-kit/draftComponents/Form/ErrorSummary';
+import Select from '@jac-uk/jac-kit/draftComponents/Form/Select';
+
+export default {
+  name: 'PanelMemberChange',
+  components: {
+    Select,
+    ErrorSummary,
+  },
+  extends: Form,
+  props: {
+    state: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      formData: {
+        state: 'review',
+      },
+      exerciseStates: [
+        'draft',
+        'ready',
+        'approved',
+        'shortlisting',
+        'selection',
+        'recommended',
+        'handover',
+      ],
+    };
+  },
+  created() {
+    this.formData.state = this.state;
+  },
+  methods: {
+    closeModal() {
+      this.$emit('close');
+    },
+    confirmModal() {
+      this.modalOpen = false;
+      this.$emit('confirmed');
+      document.body.style.overflow = '';
+    },
+    async save() {
+      await this.$store.dispatch('exerciseDocument/save', this.formData);
+      this.closeModal();
+    },
+  },
+};
+</script>
+
+<style scoped>
+  fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+</style>

--- a/src/filters.js
+++ b/src/filters.js
@@ -27,6 +27,13 @@ const lookup = (value) => {
     statementOfEligibility: 'Statement of eligibility',
     selfAssessmentCompetencies: 'Self assessment with competencies',
     additionalInfo: 'Additional Information',
+
+    // exercise states
+    'shortlisting': 'Shortlisting',
+    'selection': 'Selection',
+    'recommended': 'Recommended',
+    'handover': 'Handover',
+
     // 'xxx': 'xxx',`
   };
   returnValue = lookup[value];

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -32,6 +32,17 @@
     <div class="govuk-grid-column-one-half">
       <div class="background-blue govuk-!-margin-bottom-6 govuk-!-padding-3">
         <span v-if="isPublished">Published</span>
+        <div
+          v-if="exercise.state"
+          class="float-right"
+        >
+          <a
+            class="govuk-link"
+            @click="changeState"
+          >
+            Change
+          </a>
+        </div>
         <span
           v-if="exercise.state"
           class="display-block govuk-!-font-size-27"
@@ -140,6 +151,14 @@
         Process late applications
       </ActionButton>
     </div>
+    <Modal
+      ref="modalChangeExerciseState"
+    >
+      <ChangeExerciseState
+        :state="exercise.state"
+        @close="$refs['modalChangeExerciseState'].closeModal()"
+      />
+    </Modal>
   </div>
 </template>
 
@@ -148,12 +167,16 @@ import Timeline from '@jac-uk/jac-kit/draftComponents/Timeline';
 import createTimeline from '@jac-uk/jac-kit/helpers/Timeline/createTimeline';
 import exerciseTimeline from '@jac-uk/jac-kit/helpers/Timeline/exerciseTimeline';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton';
+import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
+import ChangeExerciseState from '@/components/ModalViews/ChangeExerciseState';
 import { functions } from '@/firebase';
 
 export default {
   components: {
     Timeline,
     ActionButton,
+    Modal,
+    ChangeExerciseState,
   },
   computed: {
     exercise() {
@@ -287,6 +310,16 @@ export default {
       // this is temporary function to cover late applications to existing exercises. It can be removed when we automatically create applicationRecords and existing exercises have been processed
       await functions.httpsCallable('initialiseMissingApplicationRecords')({ exerciseId: this.exerciseId });
     },
+    changeState() {
+      this.$refs['modalChangeExerciseState'].openModal();
+    },
   },
 };
 </script>
+
+<style scoped>
+.background-blue .govuk-link {
+  cursor: pointer;
+
+}
+</style>

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -33,7 +33,7 @@
       <div class="background-blue govuk-!-margin-bottom-6 govuk-!-padding-3">
         <span v-if="isPublished">Published</span>
         <div
-          v-if="exercise.state"
+          v-if="isApproved"
           class="float-right"
         >
           <a


### PR DESCRIPTION
## What's included?
Enables user to change the state of an exercise. See screen grabs below.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Navigate to the Overview page for an exercise. Test that:
- It is not possible to change the state of an exercise in the 'Draft' and 'Ready for Approval' states
- It is possible to change the state of an 'Approved' exercise to any of 'Shortlisting', 'Selected', 'Recommended' or 'Handover'

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
<img width="430" alt="image" src="https://user-images.githubusercontent.com/8524401/121241174-0dab2600-c893-11eb-889f-68a4b10de44b.png">

<img width="395" alt="image" src="https://user-images.githubusercontent.com/8524401/121241459-5ebb1a00-c893-11eb-8d31-38b8efcb9c9e.png">

<img width="429" alt="image" src="https://user-images.githubusercontent.com/8524401/121241361-4519d280-c893-11eb-92da-f33a12b81bef.png">


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
