### PR TITLE
#1355 Updated Application page to correctly show information in Welsh posts section

### DIFF
--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -791,7 +791,10 @@
               </h2>
 
               <dl class="govuk-summary-list">
-                <div class="govuk-summary-list__row">
+                <div
+                  v-if="application.applyingForWelshPost != null"
+                  class="govuk-summary-list__row"
+                >
                   <dt class="govuk-summary-list__key">
                     Applying for a Welsh post
                   </dt>
@@ -802,7 +805,7 @@
                   </dd>
                 </div>
                 <div
-                  v-if="application.applyingForWelshPost"
+                  v-if="application.canSpeakWelsh != null"
                   class="govuk-summary-list__row"
                 >
                   <dt class="govuk-summary-list__key">
@@ -815,7 +818,7 @@
                   </dd>
                 </div>
                 <div
-                  v-if="application.applyingForWelshPost"
+                  v-if="application.canReadAndWriteWelsh != null"
                   class="govuk-summary-list__row"
                 >
                   <dt class="govuk-summary-list__key">
@@ -825,7 +828,7 @@
                     class="govuk-summary-list__value"
                   >
                     <p
-                      v-if="application.canReadAndWriteWelsh == false "
+                      v-if="application.canReadAndWriteWelsh == false"
                     >
                       {{ application.canReadAndWriteWelsh | toYesNo | showAlternative('Answer not provided') }}
                     </p>


### PR DESCRIPTION
## What's included?
Updated Application page to show correctly information provided by candidate in Welsh posts section.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- Create an exercise. In Website listing section tick 'Are there Welsh posts?' option. In Vacancy information section select 'Yes' for 'Is there a Welsh requirement?' question and choose desired type(s) of requirement.
- [Apply as a candidate on Apply platform here](https://jac-apply-develop--pr797-feature-1355-update-y13hdqlf.web.app).
- View candidate application and ensure all information entered by candidate is displayed in Welsh posts section.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
[Video recording of functionality is available here.](https://drive.google.com/file/d/1DM1BQ9U4jKcoTE1VwDX7rwwt4nxUySE3/view?usp=sharing)

Exercise settings:

Website listing:
![Sc2](https://user-images.githubusercontent.com/40855898/122072577-9c69f680-cdef-11eb-923f-25f3c7cf030e.png)

Vacancy information:
![Sc3](https://user-images.githubusercontent.com/40855898/122072579-9d9b2380-cdef-11eb-8ebe-47be1c4b5d52.png)

Applications->Applied->(select desired candidate)->Full information->Welsh posts section:
![Sc4](https://user-images.githubusercontent.com/40855898/122073170-22863d00-cdf0-11eb-95d6-43152d91368d.png)

---
PREVIEW:DEVELOP
