### PR TITLE
#1054 Added a new component to enable change of candidates login address

### DIFF
--- a/src/views/Candidates/Actions.vue
+++ b/src/views/Candidates/Actions.vue
@@ -41,7 +41,7 @@
             :errors="errors"
           />
           <h2
-            class="govuk-heading-m govuk-!-margin-top-9 govuk-!-margin-bottom-6"
+            class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-6"
           >
             Current email address: {{ currentEmail }}
           </h2>

--- a/src/views/Candidates/Actions.vue
+++ b/src/views/Candidates/Actions.vue
@@ -147,7 +147,7 @@ export default {
           },5000);
           setTimeout(() => {
             this.status = null;
-          },10000);
+          },5000);
         } else {
           this.setMessage('Unauthorised to perform action.', 'warning');
         }

--- a/src/views/Candidates/Actions.vue
+++ b/src/views/Candidates/Actions.vue
@@ -51,7 +51,6 @@
             required
           />
           <button
-            :disabled="authorisedToPerformAction || status === 'warning'"
             class="govuk-button govuk-!-margin-bottom-4"
             @click="save"
           >
@@ -112,10 +111,10 @@ export default {
         const response = await functions.httpsCallable('getUserEmailByID')({
           candidateId: this.candidateId });
 
-        if (response.result === false) {
+        if (response.data === false) {
           this.setMessage('Current email address could not be retrieved.', 'warning');
         } else {
-          this.currentEmailAddress = response.result;
+          this.currentEmailAddress = response.data;
         }
       }
       catch (error) {
@@ -132,11 +131,11 @@ export default {
               currentEmailAddress: this.currentEmailAddress,
               newEmailAddress: this.newEmailAddress });
 
-            if (response.result === false) {
+            if (response.data === false) {
               this.setMessage('Failed to update email address.', 'warning');
             } else {
               this.setMessage('Email address was updated.', 'success');
-              this.currentEmailAddress = response.result;
+              this.currentEmailAddress = response.data;
             }
           }
           catch (error) {
@@ -149,6 +148,8 @@ export default {
           setTimeout(() => {
             this.status = null;
           },10000);
+        } else {
+          this.setMessage('Unauthorised to perform action.', 'warning');
         }
       }
     },

--- a/src/views/Candidates/Actions.vue
+++ b/src/views/Candidates/Actions.vue
@@ -1,0 +1,165 @@
+<template>
+  <div>
+    <form
+      ref="form"
+      @submit.prevent="validateAndSave"
+    >
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+          <h1
+            class="govuk-heading-l govuk-!-margin-top-9 govuk-!-margin-bottom-6"
+          >
+            Update candidate login email address
+          </h1>
+        </div>
+      </div>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+          <Banner
+            v-if="status"
+            :message="message"
+            :status="status"
+          />
+        </div>
+      </div>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+          <span
+            v-if="submitted && !status"
+            class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-2"
+          >
+            Please wait... Your request is being processed.
+          </span>
+        </div>
+      </div>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <ErrorSummary
+            :errors="errors"
+          />
+          <h2
+            class="govuk-heading-m govuk-!-margin-top-9 govuk-!-margin-bottom-6"
+          >
+            Current email address: {{ currentEmail }}
+          </h2>
+          <TextField
+            id="new-login-email-address"
+            v-model="newEmailAddress"
+            label="New email address"
+            type="email"
+            required
+          />
+          <button
+            :disabled="authorisedToPerformAction && status === 'warning'"
+            class="govuk-button govuk-!-margin-bottom-1"
+            @click="save"
+          >
+            Update
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import firebase from '@firebase/app';
+import { functions } from '@/firebase';
+import { authorisedToPerformAction }  from '@/helpers/authUsers';
+import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField';
+import Banner from '@jac-uk/jac-kit/draftComponents/Banner';
+import Form from '@jac-uk/jac-kit/draftComponents/Form/Form';
+import ErrorSummary from '@jac-uk/jac-kit/draftComponents/Form/ErrorSummary';
+
+export default {
+  name: 'Actions',
+  components: {
+    TextField,
+    Banner,
+    ErrorSummary,
+  },
+  extends: Form,
+  props: {
+    candidateId: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      authorisedToPerformAction: false,
+      currentEmailAddress: 'unknown',
+      newEmailAddress: null,
+      message: '',
+      status: null,
+      submitted: false,
+    };
+  },
+  computed: {
+    currentEmail() {
+      return this.currentEmailAddress;
+    },
+  },
+  async created() {
+    const email = firebase.auth().currentUser.email;
+    this.authorisedToPerformAction = await authorisedToPerformAction(email);
+    if (this.authorisedToPerformAction) {
+      this.getCurrentEmailAddress(this.candidateId);
+    }
+  },
+  methods: {
+    async getCurrentEmailAddress() {
+      try {
+        const response = await functions.httpsCallable('getUserEmailByID')({
+          candidateId: this.candidateId });
+
+        if (response.result === false) {
+          this.setMessage('Current email address could not be retrieved.', 'warning');
+        } else {
+          this.currentEmailAddress = response.result;
+        }
+      }
+      catch (error) {
+        this.setMessage('Failed to perform action.', 'warning');
+      }
+    },
+    async save() {
+      this.validate();
+      if (this.isValid()) {
+        if (this.authorisedToPerformAction) {
+          this.submitted = true;
+          try {
+            const response = await functions.httpsCallable('updateEmailAddress')({
+              currentEmailAddress: this.currentEmailAddress,
+              newEmailAddress: this.newEmailAddress });
+
+            if (response.result === false) {
+              this.setMessage('Failed to update email address.', 'warning');
+            } else {
+              this.setMessage('Email address was updated.', 'success');
+              this.currentEmailAddress = response.result;
+            }
+          }
+          catch (error) {
+            this.setMessage('Failed to perform action.', 'warning');
+          }
+          this.$refs.form.reset();
+          setTimeout(() => {
+            this.submitted = false;
+          },5000);
+          setTimeout(() => {
+            this.status = null;
+          },10000);
+        }
+      }
+    },
+    setMessage(message, status) {
+      this.status = status;
+      this.message = message;
+    },
+  },
+};
+</script>

--- a/src/views/Candidates/Actions.vue
+++ b/src/views/Candidates/Actions.vue
@@ -15,7 +15,7 @@
       </div>
 
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters">
+        <div class="govuk-grid-column-one-half">
           <Banner
             v-if="status"
             :message="message"

--- a/src/views/Candidates/Actions.vue
+++ b/src/views/Candidates/Actions.vue
@@ -36,10 +36,7 @@
       </div>
 
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-          <ErrorSummary
-            :errors="errors"
-          />
+        <div class="govuk-grid-column-three-quarters">
           <h2
             class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-6"
           >
@@ -48,13 +45,14 @@
           <TextField
             id="new-login-email-address"
             v-model="newEmailAddress"
-            label="New email address"
+            class="govuk-!-width-one-half"
+            label="New email address:"
             type="email"
             required
           />
           <button
-            :disabled="authorisedToPerformAction && status === 'warning'"
-            class="govuk-button govuk-!-margin-bottom-1"
+            :disabled="authorisedToPerformAction || status === 'warning'"
+            class="govuk-button govuk-!-margin-bottom-4"
             @click="save"
           >
             Update
@@ -72,14 +70,12 @@ import { authorisedToPerformAction }  from '@/helpers/authUsers';
 import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField';
 import Banner from '@jac-uk/jac-kit/draftComponents/Banner';
 import Form from '@jac-uk/jac-kit/draftComponents/Form/Form';
-import ErrorSummary from '@jac-uk/jac-kit/draftComponents/Form/ErrorSummary';
 
 export default {
   name: 'Actions',
   components: {
     TextField,
     Banner,
-    ErrorSummary,
   },
   extends: Form,
   props: {

--- a/src/views/Candidates/CandidatesView.vue
+++ b/src/views/Candidates/CandidatesView.vue
@@ -77,10 +77,16 @@
     >
       <Applications :candidate-id="candidateId" />
     </div>
+    <div
+      v-if="activeTab === 'actions' && authorisedUser"
+    >
+      <Actions :candidate-id="getUserId" />
+    </div>
   </div>
 </template>
 
 <script>
+import firebase from '@firebase/app';
 import TabsList from '@jac-uk/jac-kit/draftComponents/TabsList';
 import PersonalDetails from '@jac-uk/jac-kit/draftComponents/Candidates/PersonalDetails';
 import EqualityAndDiversity from '@jac-uk/jac-kit/draftComponents/Candidates/EqualityAndDiversity';
@@ -94,6 +100,8 @@ import ProfessionalConductSummary from '@/views/InformationReview/ProfessionalCo
 import FurtherInformationSummary from '@/views/InformationReview/FurtherInformationSummary';
 import CharacterDeclarationSummary from '@/views/InformationReview/CharacterDeclarationSummary';
 import CharacterInformationSummaryV1 from '@/views/Exercises/Applications/CharacterInformationSummaryV1.vue';
+import Actions from '@/views/Candidates/Actions';
+import { authorisedToPerformAction }  from '@/helpers/authUsers';
 
 export default {
   components: {
@@ -110,9 +118,11 @@ export default {
     FurtherInformationSummary,
     CharacterDeclarationSummary,
     CharacterInformationSummaryV1,
+    Actions,
   },
   data() {
     return {
+      authorisedToPerformAction: false,
       tabs: [
         {
           ref: 'details',
@@ -126,12 +136,19 @@ export default {
           ref: 'applications',
           title: 'Applications',
         },
+        {
+          ref: 'actions',
+          title: 'Actions',
+        },
       ],
       activeTab: 'details',
       candidateId: '',
     };
   },
   computed: {
+    authorisedUser(){
+      return this.authorisedToPerformAction;
+    },
     candidateRecord() {
       return this.$store.state.candidates.record;
     },
@@ -157,10 +174,12 @@ export default {
       return this.characterInformation._versionNumber === 2;
     },
   },
-  created() {
+  async created() {
     this.candidateId = this.getUserId;
     this.$store.dispatch('candidates/bindDoc', this.candidateId);
     this.$store.dispatch('candidates/bindDocs', this.candidateId);
+    const email = firebase.auth().currentUser.email;
+    this.authorisedToPerformAction = await authorisedToPerformAction(email);
   },
   destroyed() {
     this.$store.dispatch('candidates/unbindDoc');


### PR DESCRIPTION
**Author checklist**

- ✅  Include primary ticket number in title - e.g. "#000 New styling for widget" - and any additional tickets in description
- ✅  Fill in the details below and delete as appropriate
- [ ] Be proactive in getting your work approved 💪

---
## What's included (and how it works)

I've created a new tab called 'Actions' in the Candidate view which only superadmins can see. When a superadmin goes to the tab, a callable function is called to retrieve the candidate's current login email address. When a superadmin enters the new address and clicks 'Update', a callable function is called and candidate's email address is updated.

## Who should test?
✅ Product owner
✅ Developers

## How to test?

- Login to Admin,
- Select a candidate from Applications->Applied(any candidate)
- Go to Candidate view to Actions tab. The current email address will be visible.
- Enter a new email address and click Update.
- Please login in a role other than Superadmin (create a test account on Admin). You should not be able to see Actions tab/update email address.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
![Email](https://user-images.githubusercontent.com/40855898/122434336-ea693080-cf8e-11eb-9368-1410b9424998.png)


---
PREVIEW:STAGING