### PR TITLE
#1122-import-scenario-test-scores

### DIFF
--- a/src/components/ModalViews/UploadScores.vue
+++ b/src/components/ModalViews/UploadScores.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <div class="modal__title govuk-!-padding-2 govuk-heading-m">
+      Upload Scenario QT Scores
+    </div>
+    <div class="modal__content govuk-!-padding-4" v-if="!fileName">
+      <p class="modal__message govuk-body-l">
+        <FileUpload
+          id="qt-scores-file"
+          v-model="fileName"
+          :name="`${$attrs.name}-${getNumericalFileName()}`"
+          :path="buildFileFolder"
+          :file-path="$attrs.filePath"
+          label="Please upload the XLSX containing the Qualifying Test Scores"
+          required
+          @input="changeFileName"
+        />
+      </p>
+      <p>
+        <button
+          class="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+          @click="closeModal"
+        >
+          Cancel
+        </button>
+      </p>
+    </div>
+
+    <div class="modal__content govuk-!-padding-4" v-if="this.fileName && !this.importResults">
+      Processing file...
+
+    </div>
+    <div class="modal__content govuk-!-padding-4" v-if="this.importResults">
+      <p>Successfully imported {{ importResults.data.successfullyImported }} records.</p>
+      <p>The following row numbers were not imported: </p>
+      <ul>
+        <li
+          v-for="(row, index) in importResults.data.rowsNotImported.slice().reverse()"
+          :key="index"
+        >
+          Row {{ row.rowNumber }} - {{ row.rowError }}
+        </li>
+      </ul>
+      <p>
+        <button
+          class="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+          @click="closeModal"
+        >
+          Close
+        </button>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+import FileUpload from '@jac-uk/jac-kit/draftComponents/Form/FileUpload';
+import { functions } from '@/firebase';
+
+export default {
+  name: 'UploadScores',
+  components: {
+    FileUpload,
+  },
+  data() {
+    return {
+      fileName: '',
+      importResults: null,
+    };
+  },
+  computed: {
+    buildFileFolder() {
+      return this.$attrs.filePath;
+    },
+  },
+  methods: {
+    closeModal() {
+      this.$emit('close');
+      this.importResults = null;
+    },
+    confirmModal() {
+      this.modalOpen = false;
+      this.$emit('confirmed');
+      document.body.style.overflow = '';
+    },
+    changeFileName(val) {
+      console.log(val);
+      this.fileName = val;
+      this.save();
+    },
+    async save() {
+      this.importResults = await functions.httpsCallable('processQualifyingTestScores')({ qualifyingTestId: this.$attrs.qualifyingTestId, fullFilePath: this.$attrs.filePath + this.fileName });
+    },
+    getNumericalFileName() {
+      const dateNow = new Date();
+      const dateToNumber = `${dateNow.getFullYear()}${dateNow.getMonth() + 1}${dateNow.getUTCDate()}${dateNow.getHours()}${dateNow.getMinutes()}${dateNow.getSeconds()}`;
+      return dateToNumber;
+    },
+
+  },
+};
+</script>

--- a/src/components/ModalViews/UploadScores.vue
+++ b/src/components/ModalViews/UploadScores.vue
@@ -3,7 +3,10 @@
     <div class="modal__title govuk-!-padding-2 govuk-heading-m">
       Upload Scenario QT Scores
     </div>
-    <div class="modal__content govuk-!-padding-4" v-if="!fileName">
+    <div
+      v-if="!fileName"
+      class="modal__content govuk-!-padding-4"
+    >
       <p class="modal__message govuk-body-l">
         <FileUpload
           id="qt-scores-file"
@@ -26,11 +29,16 @@
       </p>
     </div>
 
-    <div class="modal__content govuk-!-padding-4" v-if="this.fileName && !this.importResults">
+    <div
+      v-if="fileName && !importResults"
+      class="modal__content govuk-!-padding-4"
+    >
       Processing file...
-
     </div>
-    <div class="modal__content govuk-!-padding-4" v-if="this.importResults">
+    <div
+      v-if="importResults"
+      class="modal__content govuk-!-padding-4"
+    >
       <p>Successfully imported {{ importResults.data.successfullyImported }} records.</p>
       <p>The following row numbers were not imported: </p>
       <ul>
@@ -84,7 +92,6 @@ export default {
       document.body.style.overflow = '';
     },
     changeFileName(val) {
-      console.log(val);
       this.fileName = val;
       this.save();
     },

--- a/src/router.js
+++ b/src/router.js
@@ -82,7 +82,6 @@ import QualifyingTestReview from '@/views/Exercises/Tasks/QualifyingTests/Qualif
 import QualifyingTestResponses from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Responses';
 import QualifyingTestResponse from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Response';
 import QualifyingTestResponseView from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Response/View';
-import UploadScores from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/UploadScores';
 
 // Report views
 import ExerciseShowReports from '@/views/Exercises/Show/Reports';
@@ -566,15 +565,6 @@ const router = new Router({
                       },
                     },
                   ],
-                },
-                {
-                  path: 'upload-scores',
-                  component: UploadScores,
-                  name: 'upload-scores-view',
-                  meta: {
-                    requiresAuth: true,
-                    title: 'Qualifying Test | Upload Scores',
-                  },
                 },
               ],
             },

--- a/src/router.js
+++ b/src/router.js
@@ -82,6 +82,7 @@ import QualifyingTestReview from '@/views/Exercises/Tasks/QualifyingTests/Qualif
 import QualifyingTestResponses from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Responses';
 import QualifyingTestResponse from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Response';
 import QualifyingTestResponseView from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/Response/View';
+import UploadScores from '@/views/Exercises/Tasks/QualifyingTests/QualifyingTest/UploadScores';
 
 // Report views
 import ExerciseShowReports from '@/views/Exercises/Show/Reports';
@@ -565,6 +566,15 @@ const router = new Router({
                       },
                     },
                   ],
+                },
+                {
+                  path: 'upload-scores',
+                  component: UploadScores,
+                  name: 'upload-scores-view',
+                  meta: {
+                    requiresAuth: true,
+                    title: 'Qualifying Test | Upload Scores',
+                  },
                 },
               ],
             },

--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -464,7 +464,7 @@ export default {
       await functions.httpsCallable('activateQualifyingTest')({ qualifyingTestId: this.qualifyingTestId });
     },
     async btnGetScores() {
-      await functions.httpsCallable('scoreQualifyingTest')({qualifyingTestId: this.qualifyingTestId});
+      await functions.httpsCallable('scoreQualifyingTest')({ qualifyingTestId: this.qualifyingTestId });
     },
     btnShowUploadScores() {
       const route = {

--- a/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercises/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -286,7 +286,25 @@
       >
         Close & Score
       </ActionButton>
+
+      <Button
+        v-if="isActivated || isCompleted"
+        type="primary"
+        class="govuk-button govuk-button--primary govuk-!-margin-right-3"
+        @click="modalUploadOpen"
+      >
+        Upload Scores
+      </Button>
     </div>
+    <Modal
+      ref="modalRef"
+    >
+      <component
+        :is="`UploadScores`"
+        v-bind="uploadProps"
+        @close="modalUploadClose"
+      />
+    </Modal>
   </div>
 </template>
 
@@ -296,17 +314,22 @@ import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton';
 import { EXERCISE_STAGE, QUALIFYING_TEST } from '@jac-uk/jac-kit/helpers/constants';
 import { isDateGreaterThan } from '@jac-uk/jac-kit/helpers/date';
 import Select from '@jac-uk/jac-kit/draftComponents/Form/Select';
+import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
+import UploadScores from '@/components/ModalViews/UploadScores';
 
 export default {
   components: {
     ActionButton,
     Select,
+    Modal,
+    UploadScores,
   },
   data() {
     return {
       exerciseStage: '',
       candidateStatus: 'all',
       availableStatuses: null,
+      uploadProps: {},
     };
   },
   computed: {
@@ -382,7 +405,7 @@ export default {
         type,
       } = this.qualifyingTest;
 
-      const clipboardQT = { 
+      const clipboardQT = {
         additionalInstructions,
         feedbackSurvey,
         maxScore,
@@ -396,6 +419,9 @@ export default {
 
       const returnValue = JSON.stringify(clipboardQT);
       return returnValue;
+    },
+    uploadPath() {
+      return `/exercise/${this.exercise.id}/qualifying-tests/${this.qualifyingTestId}/`;
     },
   },
   watch: {
@@ -438,7 +464,30 @@ export default {
       await functions.httpsCallable('activateQualifyingTest')({ qualifyingTestId: this.qualifyingTestId });
     },
     async btnGetScores() {
-      await functions.httpsCallable('scoreQualifyingTest')({ qualifyingTestId: this.qualifyingTestId });
+      await functions.httpsCallable('scoreQualifyingTest')({qualifyingTestId: this.qualifyingTestId});
+    },
+    btnShowUploadScores() {
+      const route = {
+        name: 'upload-scores-view',
+        params: {
+          qualifyingTestId: this.$route.params.qualifyingTestId,
+        },
+      };
+      this.$router.push(route);
+    },
+    modalUploadOpen() {
+      this.uploadProps = {
+        name: 'QTScores',
+        filePath: this.uploadPath,
+        exerciseId: this.exercise.id,
+        qualifyingTestId: this.qualifyingTestId,
+        title: 'Upload Qualifying Test Scores',
+      };
+
+      this.$refs.modalRef.openModal();
+    },
+    modalUploadClose() {
+      this.$refs.modalRef.closeModal();
     },
     btnPause() {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## What's included?
The ability to upload Scenario QT scores via an XLSX spreadsheet

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Create a Scenario QT, apply and respond to the QT.

Use the template found here to add corresponding scores to each question - you must include:

1. The QTReponseId in the `ID` column
2. The scores for each question in the format `Score Q{{question-number}}`

You can try adding malformed scores, invalid ids, only a few questions from the QT or responses from a different QT / Exercise.

The results of the upload should be shown in the modal window detailing how many rows were imported and any rows that failed (with reasons).

Note: this currently only handles the first scenario of any scenario QT test (the template provided does not appear to differentiate between scenarios).

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Video can be found here:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
