### PR TITLE
#1324 Made changes to display correct number of days in Full Information view

### DIFF
--- a/src/views/Exercises/Applications/Application.vue
+++ b/src/views/Exercises/Applications/Application.vue
@@ -309,11 +309,11 @@
                     />
                   </dd>
                 </div>
-                <div 
+                <div
                   v-if="application.personalDetails.reasonableAdjustments === true"
                   class="govuk-summary-list__row "
                 >
-                  <dt 
+                  <dt
                     class="govuk-summary-list__key"
                   >
                     Reasonable Adjustments Details
@@ -1463,7 +1463,7 @@
                 class="govuk-summary-list__row"
               >
                 <dt class="govuk-summary-list__key">
-                  Sat for at least {{ application.pjeDays || 30 }} days
+                  Sat for at least {{ exercise.pjeDays || 30 }} days
                 </dt>
                 <dd class="govuk-summary-list__value">
                   <p class="govuk-body">
@@ -1495,7 +1495,7 @@
                 class="govuk-summary-list__row"
               >
                 <dt class="govuk-summary-list__key">
-                  Sat for at least {{ application.pjeDays || 30 }} days in one or all of these appointments
+                  Sat for at least {{ exercise.pjeDays || 30 }} days in one or all of these appointments
                 </dt>
                 <dd class="govuk-summary-list__value">
                   <p class="govuk-body">


### PR DESCRIPTION
## What's included?
The number of sitting days displayed in Full Information tab in Applications on Admin now matches the number of days requested in Eligibility Information section of the exercise.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

1. Create an exercise on Admin, input the desired number of days under Eligibility Information section for the question "Does previous judicial experience (PJE) apply?" and note this number.
2. Apply for a vacancy on Apply.
3. Check the candidate application on Admin->Applications->Applied->(Candidate)->Full information tab->under the Judicial Experience section, note the label "Sat for at least (NUMBER) days". Number displayed here should match the number entered for "Does previous judicial experience (PJE) apply?" in step 1.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
![SC1](https://user-images.githubusercontent.com/40855898/123119531-85ed1c00-d43b-11eb-8d24-f30ce02b1467.png)
![SC2](https://user-images.githubusercontent.com/40855898/123119537-87b6df80-d43b-11eb-882c-b7c59c9fd04d.png)
[Video of the functionality was uploaded in the testing folder](https://drive.google.com/file/d/1QJCDcphQD9JdZY1ChuV7-KoOWC6e5LmC/view?usp=sharing).

---
PREVIEW:DEVELOP
