### PR TITLE
#1375 -Restrict access to approved email addresses

### DIFF
--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -22,10 +22,16 @@ const module = {
         if (state.authError) { commit('setAuthError', null); }
         let allOk = false;
         if (user.emailVerified) {
-          if (user.email.indexOf('@judicialappointments.digital') > 0) {
-            allOk = true;
-          }
           if (user.email.indexOf('@judicialappointments.gov.uk') > 0) {
+            allOk = true;
+          } else if ([
+            'warren.searle@judicialappointments.digital',
+            'halcyon@judicialappointments.digital',
+            'tom.russell@judicialappointments.digital',
+            'maria.brookes@judicialappointments.digital',
+            'kate.malone@judicialappointments.digital',
+            'joy.adeagbo@judicialappointments.digital',
+          ].indexOf(user.email) >= 0) {
             allOk = true;
           }
         }

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -21,19 +21,17 @@ const module = {
       } else {
         if (state.authError) { commit('setAuthError', null); }
         let allOk = false;
-        if (user.emailVerified) {
-          if (user.email.indexOf('@judicialappointments.gov.uk') > 0) {
-            allOk = true;
-          } else if ([
-            'warren.searle@judicialappointments.digital',
-            'halcyon@judicialappointments.digital',
-            'tom.russell@judicialappointments.digital',
-            'maria.brookes@judicialappointments.digital',
-            'kate.malone@judicialappointments.digital',
-            'joy.adeagbo@judicialappointments.digital',
-          ].indexOf(user.email) >= 0) {
-            allOk = true;
-          }
+        if (user.email.indexOf('@judicialappointments.gov.uk') > 0) {
+          allOk = true;
+        } else if ([
+          'warren.searle@judicialappointments.digital',
+          'halcyon@judicialappointments.digital',
+          'tom.russell@judicialappointments.digital',
+          'maria.brookes@judicialappointments.digital',
+          'kate.malone@judicialappointments.digital',
+          'joy.adeagbo@judicialappointments.digital',
+        ].indexOf(user.email) >= 0) {
+          allOk = true;
         }
         if (allOk) {
           let role = 'staff';

--- a/src/store/events.js
+++ b/src/store/events.js
@@ -1,7 +1,7 @@
 import { firestore } from '@/firebase';
 import { firestoreAction } from 'vuexfire';
 import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
-import tableQuery from '@jac-uk/jac-kit/helpers/tableQuery';
+import tableQuery from '@jac-uk/jac-kit/components/Table/tableQuery';
 
 export default {
   namespaced: true,

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -2,7 +2,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <p class="govuk-hint govuk-body govuk-!-margin-bottom-7">
-        Sign in to admin dashboard with your judicialappointments.digital Google account.
+        Sign in to admin dashboard with your judicialappointments.gov.uk account.
       </p>
       <p>
         <span

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -13,22 +13,23 @@
         </span>
         <button
           type="button"
-          class="govuk-button button-image"
+          class="govuk-button"
+          @click="loginWithMicrosoft"
+        >
+          Sign in with Microsoft
+        </button>
+
+        <button
+          type="button"
+          class="govuk-button button-image govuk-!-margin-left-5"
           @click="loginWithGoogle"
+          v-if="showGoogleLogin"
         >
           <img
             alt="Sign in with Google"
             src="@/assets/btn_google_signin_light_normal_web@2x.png"
             width="191"
           >
-        </button>
-
-        <button
-          type="button"
-          class="govuk-button"
-          @click="loginWithMicrosoft"
-        >
-          Sign in with Microsoft
         </button>
       </p>
     </div>
@@ -42,12 +43,20 @@ export default {
   data: function() {
     return {
       signInError: null,
+      showGoogleLogin: false,
     };
   },
   computed: {
     authError() {
       return this.$store.state.auth.authError || this.signInError;
     },
+  },
+  created() {
+    window.addEventListener('keyup', (e) => {
+      if (e.key === 'Escape') {
+        this.showGoogleLogin = true;
+      }
+    });
   },
   methods: {
     loginWithGoogle() {

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -22,6 +22,15 @@
             width="191"
           >
         </button>
+
+        <button
+          type="button"
+          class="govuk-button"
+          @click="loginWithMicrosoft"
+        >
+          Sign in with Microsoft
+        </button>
+
       </p>
     </div>
   </div>
@@ -44,6 +53,12 @@ export default {
   methods: {
     loginWithGoogle() {
       const provider = new auth.GoogleAuthProvider();
+      auth().signInWithPopup(provider).catch(err => {
+        this.signInError = err.message;
+      });
+    },
+    loginWithMicrosoft() {
+      const provider = new auth.OAuthProvider('microsoft.com');
       auth().signInWithPopup(provider).catch(err => {
         this.signInError = err.message;
       });

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -20,10 +20,10 @@
         </button>
 
         <button
+          v-if="showGoogleLogin"
           type="button"
           class="govuk-button button-image govuk-!-margin-left-5"
           @click="loginWithGoogle"
-          v-if="showGoogleLogin"
         >
           <img
             alt="Sign in with Google"

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -30,7 +30,6 @@
         >
           Sign in with Microsoft
         </button>
-
       </p>
     </div>
   </div>


### PR DESCRIPTION
## What's included?
Removed the ability for anyone with a .digital email address to log in to the admin. Now only users with a .gov.uk google account or in the pre-approved list can log in

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Try and log in with an email address outside of the list

## Risk - how likely is this to impact other areas?

🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Note: It has been discussed that .gov.uk email addresses are not google accounts - in the first instance, we can get around this by using .digital email addresses that are on a pre-agreed list held in the array shown. Long term, we can explore giving google accounts to .gov.uk email addresses or making the list dynamic and giving superusers the ability to add new email addresses from the admin.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
