### PR TITLE
Hot fix for recommended to handover

### DIFF
--- a/src/views/Exercise/Stages/RecommendedEdit.vue
+++ b/src/views/Exercise/Stages/RecommendedEdit.vue
@@ -6,6 +6,18 @@
       <Banner
         :message="warningMessage"
       />
+      <button
+        class="govuk-button govuk-!-margin-right-1"
+        @click="confirm"
+      >
+        Proceed with change
+      </button>
+      <button
+        class="govuk-button govuk-button--secondary"
+        @click="cancel"
+      >
+        Cancel and amend
+      </button>
     </div>
     <ErrorSummary
       :errors="errors"
@@ -128,7 +140,7 @@ export default {
       this.showWarning = false;
     },
     async save() {
-      if (this.itemsWithIssues() && this.newSelectedStatus === APPLICATION_STATUS.APPROVED_FOR_IMMEDIATE_APPOINTMENT){
+      if (this.itemsWithIssues() && this.newSelectedStatus === APPLICATION_STATUS.APPROVED_FOR_IMMEDIATE_APPOINTMENT && !this.confirmedSave){
         this.showWarning = true;
       } else {
         let stageValue = EXERCISE_STAGE.RECOMMENDED;


### PR DESCRIPTION
---
## What's included?
Currently, admins cannot move a candidate from Recommended stage to Handover stage if they have either eligibility issues or character issues.

This PR provides an option to override the warning presented when this is attempted

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
View an exercise with applications in the Recommended stage. Select one (or more) which has issues, then click `Set Status` and select `Approved for immediate appointment`.

You should see the warning and an option to proceed with change. This overrides the warning and moves the candidate to Handover.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
