### PR TITLE
#1472 Fix: name blind sift link not showing up

### DIFF
--- a/src/views/Exercise/Tasks.vue
+++ b/src/views/Exercise/Tasks.vue
@@ -48,7 +48,7 @@ export default {
         },
       );
     }
-    if (exercise.siftStartDate) {
+    if (exercise.siftStartDate || exercise.nameBlindSiftStartDate) {
       sideNavigation.push(
         {
           title: 'Sift',

--- a/src/views/Exercise/Tasks.vue
+++ b/src/views/Exercise/Tasks.vue
@@ -48,7 +48,10 @@ export default {
         },
       );
     }
-    if (exercise.siftStartDate || exercise.nameBlindSiftStartDate) {
+    if (
+      (exercise.shortlistingMethods.indexOf('sift') && exercise.siftStartDate)
+      || (exercise.shortlistingMethods.indexOf('name-blind-paper-sift') && exercise.nameBlindSiftStartDate)
+    ) {
       sideNavigation.push(
         {
           title: 'Sift',

--- a/src/views/Exercise/Tasks.vue
+++ b/src/views/Exercise/Tasks.vue
@@ -50,8 +50,8 @@ export default {
     }
     if (exercise.shortlistingMethods && exercise.shortlistingMethods.length) {
       if (
-        (exercise.shortlistingMethods.indexOf('sift') && exercise.siftStartDate)
-        || (exercise.shortlistingMethods.indexOf('name-blind-paper-sift') && exercise.nameBlindSiftStartDate)
+        (exercise.shortlistingMethods.indexOf('sift') >= 0 && exercise.siftStartDate)
+        || (exercise.shortlistingMethods.indexOf('name-blind-paper-sift') >= 0 && exercise.nameBlindSiftStartDate)
       ) {
         sideNavigation.push(
           {

--- a/src/views/Exercise/Tasks.vue
+++ b/src/views/Exercise/Tasks.vue
@@ -48,16 +48,18 @@ export default {
         },
       );
     }
-    if (
-      (exercise.shortlistingMethods.indexOf('sift') && exercise.siftStartDate)
-      || (exercise.shortlistingMethods.indexOf('name-blind-paper-sift') && exercise.nameBlindSiftStartDate)
-    ) {
-      sideNavigation.push(
-        {
-          title: 'Sift',
-          path: `${path}/sift`,
-        },
-      );
+    if (exercise.shortlistingMethods && exercise.shortlistingMethods.length) {
+      if (
+        (exercise.shortlistingMethods.indexOf('sift') && exercise.siftStartDate)
+        || (exercise.shortlistingMethods.indexOf('name-blind-paper-sift') && exercise.nameBlindSiftStartDate)
+      ) {
+        sideNavigation.push(
+          {
+            title: 'Sift',
+            path: `${path}/sift`,
+          },
+        );
+      }
     }
     if (exercise.selectionDays) {
       sideNavigation.push(


### PR DESCRIPTION
## What's included?
Fixes a bug where the link to set up a Sift does not show for Name-blind sifts

## Who should test?
✅ Product owner
✅ Developers (code review only)

## How to test?

**Prepare your exercise**
Set up your exercise to have 'Name-blind Sift' selected as a shortlisting method and **not have** 'Sift' as a shortlisting method. Also ensure the Timeline is populated with corresponding dates.
Begin processing applications for the exercise (if not already started).

**Expected** ([see this fix](https://jac-admin-develop--pr1473-fix-1472-sift-link-m-qkj73tyf.web.app/))
Visit Tasks and notice there's a link to Sift

**Previous to this fix** ([see admin-develop](https://admin-develop.judicialappointments.digital))
Visit Tasks and the Sift link is missing

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work


## Video demo

https://user-images.githubusercontent.com/8524401/129719660-a860d90a-b4eb-46b6-af62-835eaa00e6ab.mov



---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
