### PR TITLE
Input custom ASC word limits

### DIFF
--- a/src/components/RepeatableFields/SelectionCriterion.vue
+++ b/src/components/RepeatableFields/SelectionCriterion.vue
@@ -1,5 +1,31 @@
 <template>
   <div>
+    <RadioGroup
+      :id="`selection-criterion-title_${index}`"
+      v-model="row.hasCustomWordLimit"
+      label="Would you like to add a custom word limit to this question?"
+      hint="if none is provided this will default to 250 words"
+      required
+    >
+      <RadioItem
+        :value="true"
+        label="Yes"
+      >
+        <TextField
+          id="word-limit"
+          v-model="row.wordLimit"
+          label="Word Limit"
+          class="govuk-!-width-one-quarter"
+          type="number"
+          required
+        />
+      </RadioItem>
+      <RadioItem
+        :value="false"
+        label="No"
+      />
+    </RadioGroup>
+
     <TextField
       :id="`selection-criterion-title_${index}`"
       v-model="row.title"
@@ -22,12 +48,16 @@
 <script>
 import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField';
 import RichTextInput from '@jac-uk/jac-kit/draftComponents/Form/RichTextInput';
+import RadioGroup from '@jac-uk/jac-kit/draftComponents/Form/RadioGroup';
+import RadioItem from '@jac-uk/jac-kit/draftComponents/Form/RadioItem';
 
 export default {
   name: 'SelectionCriterion',
   components: {
     TextField,
     RichTextInput,
+    RadioGroup,
+    RadioItem,
   },
   props: {
     row: {

--- a/src/components/RepeatableFields/SelectionCriterion.vue
+++ b/src/components/RepeatableFields/SelectionCriterion.vue
@@ -1,34 +1,9 @@
 <template>
   <div>
-    <RadioGroup
-      :id="`selection-criterion-title_${index}`"
-      v-model="row.hasCustomWordLimit"
-      label="Would you like to add a custom word limit to this question?"
-      hint="if none is provided this will default to 250 words"
-      required
-    >
-      <RadioItem
-        :value="true"
-        label="Yes"
-      >
-        <TextField
-          id="word-limit"
-          v-model="row.wordLimit"
-          label="Word Limit"
-          class="govuk-!-width-one-quarter"
-          type="number"
-          required
-        />
-      </RadioItem>
-      <RadioItem
-        :value="false"
-        label="No"
-      />
-    </RadioGroup>
-
     <TextField
       :id="`selection-criterion-title_${index}`"
       v-model="row.title"
+      style="display:inline-block;"
       label="Provide title to be displayed to the candidate."
       required
     />
@@ -40,6 +15,15 @@
       label="Provide text to be displayed to the candidate."
       required
     />
+    <TextField
+      id="word-limit"
+      v-model="row.wordLimit"
+      input-class="govuk-input--width-5"
+      label="Would you like to add a custom word limit to this question?"
+      hint="if none is provided this will default to 250 words"
+      type="number"
+    />
+    <hr>
 
     <slot name="removeButton" />
   </div>
@@ -48,16 +32,12 @@
 <script>
 import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField';
 import RichTextInput from '@jac-uk/jac-kit/draftComponents/Form/RichTextInput';
-import RadioGroup from '@jac-uk/jac-kit/draftComponents/Form/RadioGroup';
-import RadioItem from '@jac-uk/jac-kit/draftComponents/Form/RadioItem';
 
 export default {
   name: 'SelectionCriterion',
   components: {
     TextField,
     RichTextInput,
-    RadioGroup,
-    RadioItem,
   },
   props: {
     row: {

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -1945,6 +1945,10 @@
               >
                 <dt class="govuk-summary-list__key">
                   {{ exercise.selectionCriteria[index].title }}
+                  <span v-if="exercise.selectionCriteria[index].wordLimit">
+                    <br>
+                    {{ exercise.selectionCriteria[index].wordLimit + ' words ' }}
+                  </span>
                 </dt>
                 <dd class="govuk-summary-list__value">
                   <span v-if="item.answer">

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -878,7 +878,10 @@
                   :key="index"
                   class="govuk-summary-list"
                 >
-                  <div class="govuk-summary-list__row">
+                  <div
+                    v-if="exercise.additionalWorkingPreferences[index]"
+                    class="govuk-summary-list__row"
+                  >
                     <dt class="govuk-summary-list__key">
                       {{ exercise.additionalWorkingPreferences[index].question }}
                       <span class="govuk-body govuk-!-font-size-19">

--- a/src/views/Exercise/Details/Eligibility/View.vue
+++ b/src/views/Exercise/Details/Eligibility/View.vue
@@ -89,6 +89,12 @@
                 v-html="criterion.text"
               />
               <!-- eslint-enable -->
+              <p
+                v-if="criterion.wordLimit"
+                class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1"
+              >
+                {{ criterion.wordLimit }} word limit
+              </p>
               <hr>
             </li>
           </ul>


### PR DESCRIPTION
## What's included?
Options have been added to add a custom word limit to ASC, when a custom number is given this info is also shown in the the exercise eligibility information overview and on application overviews.

![image](https://user-images.githubusercontent.com/44227249/130100464-26e0ef49-5858-4ec5-af44-6f2198d876a3.png)

![image](https://user-images.githubusercontent.com/44227249/130100509-9dc4b3b6-e259-499b-bf25-92fe0eabd1f9.png)


## Who should test?
✅ Product owner
✅ Developers

## How to test?
### test in conjunction with [apply 816](https://github.com/jac-uk/apply/pull/816).

## admin
 - Set up/edit an exercise to have ASC.
 - Add a question with a custom word limit
 
 ## apply
 - Navigate to the applications
 - Add a question with a custom word limit
 - Observe the limit is presented and works
 
 •note•  the word count functionality has already been tested this is strictly about the custom number

## Risk - how likely is this to impact other areas?
🟢 Low risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_