### PR TITLE
#1356 Display client details of QT participant

### DIFF
--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
@@ -351,7 +351,62 @@
             </table>
           </div>
         </div>
-        <!-- // END CONNECTION TAB -->
+        <div v-if="activeTab === 'client'">
+          <h2 class="govuk-heading-m">
+            Client
+          </h2>
+          <dl
+            v-if="response.client"
+            class="govuk-summary-list"
+          >
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Platform
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ response.client.platform }}
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Browser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ response.client.userAgent }}
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Timezone
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ response.client.timezone }}
+              </dd>
+            </div>
+            <div
+              v-if="initialServerOffset"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Initial time offset
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ initialServerOffset / 1000 }} seconds
+              </dd>
+            </div>
+            <div
+              v-if="latestServerOffset"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Latest time offset
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ latestServerOffset / 1000 }} seconds
+              </dd>
+            </div>
+          </dl>
+        </div>
         <div v-if="activeTab === 'history'">
           <h2 class="govuk-heading-m">
             History
@@ -415,8 +470,7 @@
             </table>
           </div>
         </div>
-        <!-- // END HISTORY TAB -->
-      </div><!-- hasStarted -->
+      </div>
     </div>
   </div>
 </template>
@@ -452,20 +506,32 @@ export default {
   },
   computed: {
     tabs(){
-      return [
-        {
+      const tabsList = [];
+      if (this.response) {
+        tabsList.push({
           ref: 'questions',
           title: 'Questions',
-        },
-        {
-          ref: 'logs',
-          title: 'Connection',
-        },
-        {
-          ref: 'history',
-          title: 'History',
-        },
-      ];
+        });
+        if (this.response.client) {
+          tabsList.push({
+            ref: 'client',
+            title: 'Client',
+          });
+        }
+        if (this.logs) {
+          tabsList.push({
+            ref: 'logs',
+            title: 'Connection',
+          });
+        }
+        if (this.response.history) {
+          tabsList.push({
+            ref: 'history',
+            title: 'History',
+          });
+        }
+      }
+      return tabsList;
     },
     responseId() {
       const id = this.$route.params.responseId;
@@ -587,6 +653,20 @@ export default {
     },
     routeNamePrefix() {
       return this.isTieBreaker ? 'equal-merit-tie-breaker' : 'qualifying-test';
+    },
+    initialServerOffset() {
+      if (this.response && this.response.client && this.response.statusLog) {
+        const offset = this.response.statusLog.started - this.response.client.timestamp;
+        return offset;
+      }
+      return false;
+    },
+    latestServerOffset() {
+      if (this.response && this.response.lastUpdated && this.response.lastUpdatedClientTime) {
+        const offset = this.response.lastUpdated - this.response.lastUpdatedClientTime;
+        return offset;
+      }
+      return false;
     },
   },
   watch: {


### PR DESCRIPTION
## What's included?
During a QT we collect information about the user's platform, browser and local time. Here we are displaying that information in Admin.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
On a qualifying test response page notice there is a new tab called 'Client'.
The 'Client' tab **should not** be available before the test has been started (as we haven't been able to collect data from the user).
The 'Client' tab **should** be available during and after a test has been started.
When available the 'Client' tab should display key information about the user's local environment such as:
- Platform
- Browser
- Timezone
- Initial time offset. This is the difference in seconds between the user's local time and our server's time
- Latest time offset. A significant change here from the initial value indicates that the user changed their local clock (or device) during the test.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Here's an example of the Client tab
<img width="641" alt="image" src="https://user-images.githubusercontent.com/8524401/130205655-322864af-35f0-4b5f-ad20-203f738774b8.png">

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
