### PR TITLE
1498 - record EMP basis 

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -41,7 +41,10 @@ const lookup = (value) => {
     selected: 'Selected',
     recommended: 'Recommended',
 
-    // 'xxx': 'xxx',`
+    // emp flags
+    'gender': 'Gender',
+    'ethnicity': 'Ethnicity',
+    // 'xxx': 'xxx',
   };
   returnValue = lookup[value];
   if (!returnValue) {

--- a/src/views/Exercise/Reports/Diversity.vue
+++ b/src/views/Exercise/Reports/Diversity.vue
@@ -424,7 +424,10 @@
               </th>
             </tr>
           </thead>
-          <tbody class="govuk-table__body">
+          <tbody 
+            v-if="diversity[activeTab].emp"
+            class="govuk-table__body"
+          >
             <tr class="govuk-table__row">
               <th
                 scope="col"

--- a/src/views/Exercise/Reports/Diversity.vue
+++ b/src/views/Exercise/Reports/Diversity.vue
@@ -403,6 +403,74 @@
             </tr>
           </tbody>
         </table>
+
+        <table class="govuk-table table-with-border">
+          <caption class="govuk-table__caption hidden">
+            Gender by exercise stage
+          </caption>
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th
+                scope="col"
+                class="govuk-table__header"
+              >
+                EMP status
+              </th>
+              <th
+                scope="col"
+                class="govuk-table__header govuk-table__header--numeric"
+              >
+                Applications
+              </th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <th
+                scope="col"
+                class="govuk-table__header"
+              >
+                EMP Not applied
+              </th>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                <Stat :stat="diversity[activeTab].emp.noAnswer" />
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th
+                scope="col"
+                class="govuk-table__header"
+              >
+                EMP applied
+              </th>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                <Stat :stat="diversity[activeTab].emp.applied" />
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th
+                scope="col"
+                class="govuk-table__header"
+              >
+                EMP applied on basis of ethnicity
+              </th>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                <Stat :stat="diversity[activeTab].emp.ethnicity" />
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th
+                scope="col"
+                class="govuk-table__header"
+              >
+                EMP applied on basis of gender
+              </th>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                <Stat :stat="diversity[activeTab].emp.gender" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/src/views/Exercise/Stages/HandoverList.vue
+++ b/src/views/Exercise/Stages/HandoverList.vue
@@ -25,6 +25,12 @@
           </div>
         </div>
       </div>
+      <p
+        v-if="!applicationRecords.length"
+        class="govuk-body govuk-!-margin-bottom-0"
+      >
+        No Handover Applications
+      </p>
       <Table
         data-key="id"
         :data="applicationRecords"
@@ -56,7 +62,7 @@
             {{ row.status | lookup }}
           </TableCell>
           <TableCell :title="tableColumns[0].title">
-            {{ row.flags.empApplied | toYesNo }}
+            {{ row.flags.empApplied | toYesNo | lookup }}
           </TableCell>
         </template>
       </Table>

--- a/src/views/Exercise/Stages/RecommendedEdit.vue
+++ b/src/views/Exercise/Stages/RecommendedEdit.vue
@@ -51,15 +51,19 @@
           id="emp-edit-input"
           v-model="empApplied"
           label=""
-          required
           hint=""
+          required
           :messages="{
             required: 'Please specify a value'
           }"
         >
           <RadioItem
-            :value="true"
-            label="Yes - EMP has been Applied"
+            value="gender"
+            label="Yes - EMP has been Applied on basis of gender"
+          />
+          <RadioItem
+            value="ethnicity"
+            label="Yes - EMP has been Applied on basis of ethnicity"
           />
           <RadioItem
             :value="false"

--- a/src/views/Exercise/Stages/RecommendedEdit.vue
+++ b/src/views/Exercise/Stages/RecommendedEdit.vue
@@ -50,20 +50,14 @@
         <RadioGroup
           id="emp-edit-input"
           v-model="empApplied"
-          label=""
-          hint=""
           required
           :messages="{
             required: 'Please specify a value'
           }"
         >
           <RadioItem
-            value="gender"
-            label="Yes - EMP has been Applied on basis of gender"
-          />
-          <RadioItem
-            value="ethnicity"
-            label="Yes - EMP has been Applied on basis of ethnicity"
+            :value="true"
+            label="Yes - EMP has been Applied"
           />
           <RadioItem
             :value="false"

--- a/src/views/Exercise/Stages/RecommendedList.vue
+++ b/src/views/Exercise/Stages/RecommendedList.vue
@@ -32,6 +32,12 @@
           </div>
         </div>
       </div>
+      <p
+        v-if="!applicationRecords.length"
+        class="govuk-body govuk-!-margin-bottom-0"
+      >
+        No Recommended Applications
+      </p>
       <Table
         data-key="id"
         :data="applicationRecords"
@@ -63,13 +69,10 @@
             {{ row.status | lookup }}
           </TableCell>
           <TableCell :title="tableColumns[4].title">
-            {{ row.flags.empApplied | toYesNo }}
+            {{ row.flags.empApplied | toYesNo | lookup }}
           </TableCell>
         </template>
       </Table>
-      <p v-if="!applicationRecords.length">
-        No applications found.
-      </p>
     </form>
   </div>
 </template>

--- a/src/views/Exercise/Stages/ReviewList.vue
+++ b/src/views/Exercise/Stages/ReviewList.vue
@@ -24,6 +24,12 @@
           </div>
         </div>
       </div>
+      <p
+        v-if="!applicationRecords.length"
+        class="govuk-body"
+      >
+        No Applications
+      </p>
       <Table
         data-key="id"
         :data="applicationRecords"

--- a/src/views/Exercise/Stages/SelectedEdit.vue
+++ b/src/views/Exercise/Stages/SelectedEdit.vue
@@ -53,12 +53,14 @@
           :messages="{
             required: 'Please specify a value'
           }"
-          label=""
-          hint=""
         >
           <RadioItem
-            :value="true"
-            label="Yes - EMP has been Applied"
+            value="gender"
+            label="Yes - EMP has been Applied on basis of gender"
+          />
+          <RadioItem
+            value="ethnicity"
+            label="Yes - EMP has been Applied on basis of ethnicity"
           />
           <RadioItem
             :value="false"

--- a/src/views/Exercise/Stages/SelectedList.vue
+++ b/src/views/Exercise/Stages/SelectedList.vue
@@ -32,6 +32,12 @@
           </div>
         </div>
       </div>
+      <p
+        v-if="!applicationRecords.length"
+        class="govuk-body govuk-!-margin-bottom-0"
+      >
+        No Selected Applications
+      </p>
       <Table
         data-key="id"
         :data="applicationRecords"
@@ -63,7 +69,7 @@
             {{ row.status | lookup }}
           </TableCell>
           <TableCell :title="tableColumns[4].title">
-            {{ row.flags.empApplied | toYesNo }}
+            {{ row.flags.empApplied | toYesNo | lookup }}
           </TableCell>
         </template>
       </Table>

--- a/src/views/Exercise/Stages/ShortlistedEdit.vue
+++ b/src/views/Exercise/Stages/ShortlistedEdit.vue
@@ -38,8 +38,12 @@
           }"
         >
           <RadioItem
-            :value="true"
-            label="Yes - EMP has been Applied"
+            value="gender"
+            label="Yes - EMP has been Applied on basis of gender"
+          />
+          <RadioItem
+            value="ethnicity"
+            label="Yes - EMP has been Applied on basis of ethnicity"
           />
           <RadioItem
             :value="false"

--- a/src/views/Exercise/Stages/ShortlistedList.vue
+++ b/src/views/Exercise/Stages/ShortlistedList.vue
@@ -32,6 +32,12 @@
           </div>
         </div>
       </div>
+      <p
+        v-if="!applicationRecords.length"
+        class="govuk-body govuk-!-margin-bottom-0"
+      >
+        No Shortlisted Applications
+      </p>
       <Table
         data-key="id"
         :data="applicationRecords"
@@ -63,7 +69,7 @@
             {{ row.status | lookup }}
           </TableCell>
           <TableCell :title="tableColumns[4].title">
-            {{ row.flags.empApplied | toYesNo }}
+            {{ row.flags.empApplied | toYesNo | lookup }}
           </TableCell>
         </template>
       </Table>


### PR DESCRIPTION
## What's included?
This code enables EMP flag on the basis of 'ethnicity' or 'gender' to be added at the shortlisted and recommended stages. 
An accompanying digital platform ticket adds these stats to the diversity report.
These results are then displayed on platform on the diversity report page.

![image](https://user-images.githubusercontent.com/44227249/143247954-b36d323c-d97b-4dd5-a581-451ed2b7080f.png)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Navigate to an exercise where applications are closed and candidates are being processed. 
- Progress a candidate or candidates, through the stages, adding EMP and observing available options.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context

https://user-images.githubusercontent.com/44227249/142028307-d2425aa1-3cc0-4484-af2f-d0d6b6af423d.mov

PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
