### PR TITLE
#1533 Hotfix QT xss

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-
       - uses: actions/setup-node@master
         with:
-          node-version: '10'
+          node-version: '12'
       - name: Installing project dependencies
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc && npm ci
       - name: Lint
@@ -89,7 +89,7 @@ jobs:
             ${{ runner.os }}-
       - uses: actions/setup-node@master
         with:
-          node-version: '10'
+          node-version: '12'
       - name: Installing project dependencies
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc && npm ci
       - name: Create env file

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
@@ -257,12 +257,11 @@
                     <!-- eslint-enable -->
                   </dl>
                 </div>
-                <!-- eslint-disable -->
                 <div
                   v-else
-                  v-html="testQuestion.details"
-                />
-                <!-- eslint-enable -->
+                >
+                  {{ testQuestion.details }}
+                </div>
                 <hr class="govuk-section-break govuk-section-break--visible">
                 <ol
                   v-if="isCriticalAnalysis && responses[index]"

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Review.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Review.vue
@@ -129,11 +129,7 @@
           {{ questionLabel }} {{ index + 1 }}
         </dt>
         <dd class="govuk-summary-list__value">
-          <!-- eslint-disable -->
-          <div
-            v-html="testQuestion.details"
-          />
-          <!-- eslint-enable -->
+          {{ testQuestion.details }}
 
           <hr class="govuk-section-break govuk-section-break--visible">
           <ol


### PR DESCRIPTION
## What's included?
Fixes cross-site scripting vulnerability raised by pen test team

## Who should test?
✅ Developers

## How to test?
Create a qualifying test with html in the following field:
 - Question Title

**Before the fix**, observe that the html is rendered on the QT Review screen and also on the QT Response View screen. This means that malicious html/javascript would also be rendered
<img width="711" alt="image" src="https://user-images.githubusercontent.com/8524401/146375000-9b8e4225-af8d-4138-8855-7c47710dce6b.png">

**After the fix**, observe that the html is shown as plain text on the QT Review screen and also on the QT Response View screen.  Any malicious html/javascript would **not** be rendered:
<img width="693" alt="image" src="https://user-images.githubusercontent.com/8524401/146375109-a3293fba-cf2e-4bb7-8b74-b7398bfcf4c1.png">


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:STAGING
_can be OFF, DEVELOP or STAGING_
