### PR TITLE
- Modal wont cancel, PQE blank fields bug, char info shows 'no info...' rather than no

### DIFF
--- a/src/components/Page/InformationReviewSectionRenderer.vue
+++ b/src/components/Page/InformationReviewSectionRenderer.vue
@@ -223,12 +223,6 @@
     </div>
 
     <span
-      v-else-if="isCharacterInformationSection"
-      class="govuk-body"
-    >
-      No
-    </span>
-    <span
       v-else
       class="govuk-body"
     >
@@ -289,9 +283,6 @@ export default {
   methods: {
     displayDate(date) {
       return this.displayMonthYearOnly ? formatDate(date, 'month') : formatDate(date);
-    },
-    isCharacterInformationSection() {
-      return this.$parent.$options.name == 'CharacterInformationSummaryV2';
     },
     changeField(obj) {
       this.$emit('changeField', obj);

--- a/src/components/Page/InformationReviewSectionRenderer.vue
+++ b/src/components/Page/InformationReviewSectionRenderer.vue
@@ -174,7 +174,7 @@
                   :edit="edit"
                   :index="index"
                   type="text"
-                  :extension="key"
+                  extension="otherTasks"
                   @changeField="changeField"
                 />
               </div>
@@ -216,12 +216,18 @@
         ref="removeModal"
       >
         <ModalInner
-          @closed="closeModal"
+          @close="closeModal"
           @confirmed="removeField"
         />
       </Modal>
     </div>
 
+    <span
+      v-else-if="isCharacterInformationSection"
+      class="govuk-body"
+    >
+      No
+    </span>
     <span
       v-else
       class="govuk-body"
@@ -283,6 +289,9 @@ export default {
   methods: {
     displayDate(date) {
       return this.displayMonthYearOnly ? formatDate(date, 'month') : formatDate(date);
+    },
+    isCharacterInformationSection() {
+      return this.$parent.$options.name == 'CharacterInformationSummaryV2';
     },
     changeField(obj) {
       this.$emit('changeField', obj);

--- a/src/components/Page/InformationReviewSectionRenderer.vue
+++ b/src/components/Page/InformationReviewSectionRenderer.vue
@@ -181,7 +181,7 @@
             </dd>
               
             <dd
-              v-else-if="data[index][key] instanceof Date"
+              v-else-if="data[index][key] ? data[index][key] instanceof Date : key.search('Date')"
               class="govuk-summary-list__value"
             >
               <InformationReviewRenderer

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -36,6 +36,46 @@
               </h1>
             </div>
             <div class="govuk-grid-column-one-half text-right print-none">
+              <span
+                v-if="activeTab == 'full'"
+              >
+                <span
+                  class="govuk-!-margin-left-4"
+                >
+                  <button
+                    v-if="isApplied"
+                    class="govuk-button btn-unlock"
+                    @click="unlock"
+                  >
+                    Unlock
+                  </button>
+                  <button
+                    v-else
+                    class="govuk-button btn-mark-as-applied"
+                    @click="submitApplication"
+                  >
+                    Mark as applied
+                  </button>
+                </span>
+                <span
+                  class="govuk-!-margin-left-4 govuk-!-margin-right-4"
+                >
+                  <button
+                    v-if="editMode"
+                    class="govuk-button govuk-button btn-unlock"
+                    @click="toggleEdit"
+                  >
+                    Done
+                  </button>
+                  <button
+                    v-else
+                    class="govuk-button govuk-button--secondary btn-mark-as-applied"
+                    @click="toggleEdit"
+                  >
+                    Edit
+                  </button>
+                </span>
+              </span>
               <div class="moj-button-menu">
                 <button
                   ref="dropDownRef"
@@ -73,44 +113,6 @@
                   </button>
                 </div>
               </div>
-
-              <span
-                v-if="activeTab == 'full'"
-                class=" govuk-!-margin-left-4"
-              >
-                <button
-                  v-if="isApplied"
-                  class="govuk-button btn-unlock"
-                  @click="unlock"
-                >
-                  Unlock
-                </button>
-                <button
-                  v-else
-                  class="govuk-button btn-mark-as-applied"
-                  @click="submitApplication"
-                >
-                  Mark as applied
-                </button>
-              </span>
-              <span
-                class=" govuk-!-margin-left-4"
-              >
-                <button
-                  v-if="editMode"
-                  class="govuk-button govuk-button btn-unlock"
-                  @click="toggleEdit"
-                >
-                  Done
-                </button>
-                <button
-                  v-else
-                  class="govuk-button govuk-button--secondary btn-mark-as-applied"
-                  @click="toggleEdit"
-                >
-                  Edit
-                </button>
-              </span>
             </div>
           </div>
 
@@ -309,6 +311,7 @@ import splitFullName from '@jac-uk/jac-kit/helpers/splitFullName';
 import { authorisedToPerformAction }  from '@/helpers/authUsers';
 import PageNotFound from '@/views/Errors/PageNotFound';
 import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer';
+import CharacterChecks from '@/views/Exercise/Tasks/CharacterChecks';
 
 import {
   isLegal,
@@ -335,6 +338,7 @@ export default {
     ExperienceSummary,
     AssessmentsSummary,
     AssessorsSummary,
+    CharacterChecks,
   },
   data() {
     return {

--- a/src/views/Exercise/Tasks/CharacterChecks.vue
+++ b/src/views/Exercise/Tasks/CharacterChecks.vue
@@ -294,6 +294,7 @@ import { formatDate } from '@jac-uk/jac-kit/filters/filters';
 import { functions } from '@/firebase';
 
 export default {
+  name: 'CharacterChecks',
   components: {
     Banner,
     ActionButton,

--- a/src/views/InformationReview/CharacterInformationSummaryV2.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV2.vue
@@ -6,7 +6,18 @@
         <dt class="govuk-summary-list__key widerColumn">
           Has been convicted for a criminal offence
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.criminalConvictions"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="criminalOffences"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.criminalConvictionDetails"
             :data-default="emptyObject(['details', 'date', 'title'])"
@@ -20,12 +31,25 @@
       </div>
     </dl>
 
-    <dl class="govuk-summary-list  govuk-!-margin-bottom-0">
+    <!-- CriminalCautionsSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key widerColumn">
           Has been cautioned for a criminal offence
         </dt>
-        <dd class="govuk-summary-list__value">
+
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.criminalCautions"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="criminalCautions"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.criminalCautionDetails"
             :edit="edit"
@@ -40,12 +64,23 @@
     </dl>
 
     <!-- FixedPenaltiesSummary -->
-    <dl class="govuk-summary-list smallerMargin">
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Has received a fixed penalty notice in the last 4 years
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.fixedPenalties"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="fixedPenalties"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.fixedPenaltyDetails"
             :display-month-year-only="false"
@@ -60,13 +95,24 @@
       </div>
     </dl>
 
-    <!-- FinancialMattersSummary -->
+    <!-- DrivingDisqualificationDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Has been disqualified from driving
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.drivingDisqualifications || !formData.drivingDisqualificationDetails"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="drivingDisqualifications"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.drivingDisqualificationDetails"
             :data-default="emptyObject(['details', 'date', 'title'])"
@@ -80,12 +126,24 @@
       </div>
     </dl>
 
+    <!-- RecentDrivingConvictionDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Was convicted of any motoring offences in the past 4 years
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.recentDrivingConvictions"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="recentDrivingConvictions"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.recentDrivingConvictionDetails"
             :data-default="emptyObject(['details', 'date', 'title'])"
@@ -99,12 +157,24 @@
       </div>
     </dl>
 
+    <!-- bankruptcyDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Has been declared bankrupt
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.bankruptcies"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="bankruptcies"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.bankruptcyDetails"
             :data-default="emptyObject(['details', 'date', 'title'])"
@@ -118,12 +188,24 @@
       </div>
     </dl>
 
+    <!-- ivas -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Has entered into an Individual Voluntary Agreement (IVA)
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.ivas"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="ivas"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.ivaDetails"
             :data-default="emptyObject(['details', 'date', 'title'])"
@@ -137,12 +219,24 @@
       </div>
     </dl>
 
+    <!-- LateTaxReturnSummary -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Has filed late tax returns
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.lateTaxReturns"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="lateTaxReturns"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.lateTaxReturnDetails"
             :data-default="emptyObject(['details', 'date', 'title'])"
@@ -156,12 +250,24 @@
       </div>
     </dl>
 
+    <!-- LateVatReturnSummary -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Has filed late VAT returns
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.lateVatReturns"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="lateVatReturns"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.lateVatReturnDetails"
             :data-default="emptyObject(['details', 'date', 'title'])"
@@ -175,12 +281,24 @@
       </div>
     </dl>
 
+    <!-- hmrcFineDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Has ever been fined by HMRC
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.hmrcFines"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="hmrcFines"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.hmrcFineDetails"
             :data-default="emptyObject(['details', 'date', 'title'])"
@@ -200,7 +318,18 @@
         <dt :class="requiredStyle">
           A subject of an allegation or claim of professional misconduct
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfProfessionalMisconduct"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfProfessionalMisconduct"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.subjectOfAllegationOrClaimOfProfessionalMisconductDetails"
             :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
@@ -214,12 +343,24 @@
       </div>
     </dl>
 
+    <!--SubjectOfAllegationOrClaimOfNegligenceSummary-->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           A subject of an allegation or claim of negligence
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfNegligence"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfNegligence"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.subjectOfAllegationOrClaimOfNegligenceDetails"
             :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
@@ -233,12 +374,24 @@
       </div>
     </dl>
 
+    <!-- SubjectOfAllegationOrClaimOfWrongfulDismissalDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           A subject of an allegation or claim of wrongful dismissal
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfWrongfulDismissal"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfWrongfulDismissal"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.subjectOfAllegationOrClaimOfWrongfulDismissalDetails"
             :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
@@ -251,13 +404,25 @@
         </dd>
       </div>
     </dl>
-
+    
+    <!-- subjectOfAllegationOrClaimOfDiscriminationProceedingDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           A subject of an allegation or claim of discrimination proceedings
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfDiscriminationProceeding"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfDiscriminationProceeding"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.subjectOfAllegationOrClaimOfDiscriminationProceedingDetails"
             :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
@@ -271,12 +436,24 @@
       </div>
     </dl>
 
+    <!-- subjectOfAllegationOrClaimOfHarassmentProceedingDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           A subject of an allegation or claim of harassment proceedings
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfHarassmentProceeding"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfHarassmentProceeding"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.subjectOfAllegationOrClaimOfHarassmentProceedingDetails"
             :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
@@ -290,12 +467,24 @@
       </div>
     </dl>
 
+    <!-- complaintOrDisciplinaryActionDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           A subject of complaints or disciplinary action
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.complaintOrDisciplinaryAction"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="complaintOrDisciplinaryAction"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.complaintOrDisciplinaryActionDetails"
             :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
@@ -309,12 +498,24 @@
       </div>
     </dl>
 
+    <!-- requestedToResignDetails -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
           Has been asked to resign from a position
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.requestedToResign"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="requestedToResign"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.requestedToResignDetails"
             :data-default="emptyObject(['details', 'date' ])"
@@ -334,7 +535,18 @@
         <dt :class="requiredStyle">
           Has any other character issues
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.furtherInformationDetails"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="furtherInformationDetails"
+            @changeField="changeInfo"
+          />
+          <hr>
           <InformationReviewSectionRenderer
             :data="formData.furtherInformationDetails"
             :data-default="emptyObject(['details', 'date'])"
@@ -348,6 +560,7 @@
       </div>
     </dl>
 
+    <!-- DeclarationsSummary -->
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
@@ -363,11 +576,13 @@
 
 <script>
 import InformationReviewSectionRenderer from '@/components/Page/InformationReviewSectionRenderer';
+import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer';
 import CharacterSummary from '@/views/InformationReview/CharacterSummary';
 
 export default {
   name: 'CharacterInformationSummaryV2',
   components: {
+    InformationReviewRenderer,
     InformationReviewSectionRenderer,
   },
   extends: CharacterSummary,

--- a/src/views/InformationReview/CharacterInformationSummaryV2.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV2.vue
@@ -14,9 +14,10 @@
             :edit="edit"
             :options="[true, false]"
             type="selection"
-            field="criminalOffences"
-            @changeField="changeInfo"
+            field="criminalConvictions"
+            @changeField="changeCharacterFlag"
           />
+
           <hr>
           <InformationReviewSectionRenderer
             :data="formData.criminalConvictionDetails"
@@ -47,7 +48,7 @@
             :options="[true, false]"
             type="selection"
             field="criminalCautions"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -78,7 +79,7 @@
             :options="[true, false]"
             type="selection"
             field="fixedPenalties"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -110,7 +111,7 @@
             :options="[true, false]"
             type="selection"
             field="drivingDisqualifications"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -141,7 +142,7 @@
             :options="[true, false]"
             type="selection"
             field="recentDrivingConvictions"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -172,7 +173,7 @@
             :options="[true, false]"
             type="selection"
             field="bankruptcies"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -203,7 +204,7 @@
             :options="[true, false]"
             type="selection"
             field="ivas"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -234,7 +235,7 @@
             :options="[true, false]"
             type="selection"
             field="lateTaxReturns"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -265,7 +266,7 @@
             :options="[true, false]"
             type="selection"
             field="lateVatReturns"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -296,7 +297,7 @@
             :options="[true, false]"
             type="selection"
             field="hmrcFines"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -327,7 +328,7 @@
             :options="[true, false]"
             type="selection"
             field="subjectOfAllegationOrClaimOfProfessionalMisconduct"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -358,7 +359,7 @@
             :options="[true, false]"
             type="selection"
             field="subjectOfAllegationOrClaimOfNegligence"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -389,7 +390,7 @@
             :options="[true, false]"
             type="selection"
             field="subjectOfAllegationOrClaimOfWrongfulDismissal"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -420,7 +421,7 @@
             :options="[true, false]"
             type="selection"
             field="subjectOfAllegationOrClaimOfDiscriminationProceeding"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -451,7 +452,7 @@
             :options="[true, false]"
             type="selection"
             field="subjectOfAllegationOrClaimOfHarassmentProceeding"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -482,7 +483,7 @@
             :options="[true, false]"
             type="selection"
             field="complaintOrDisciplinaryAction"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -513,7 +514,7 @@
             :options="[true, false]"
             type="selection"
             field="requestedToResign"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer
@@ -544,7 +545,7 @@
             :options="[true, false]"
             type="selection"
             field="furtherInformationDetails"
-            @changeField="changeInfo"
+            @changeField="changeCharacterFlag"
           />
           <hr>
           <InformationReviewSectionRenderer

--- a/src/views/InformationReview/ExperienceSummary.vue
+++ b/src/views/InformationReview/ExperienceSummary.vue
@@ -22,7 +22,7 @@
       </div>
     </div>
 
-    <!-- PQE -->
+    <!-- Post-qualification experience/PQE -->
     <div
       v-if="isLegal"
       class="govuk-!-margin-top-9"
@@ -371,8 +371,8 @@ export default {
     },
     changeInfo(obj) {
       let changedObj = this.application[obj.field] || {};
-      
-      if (obj.change && obj.extension && obj.hasOwnProperty('index')) { //nested field
+
+      if (obj.hasOwnProperty('change') && obj.hasOwnProperty('extension') && obj.hasOwnProperty('index')) { // extension ie. field[index].extension 
         if (!changedObj[obj.index]) {
           changedObj = {
             [obj.index]: {},

--- a/src/views/InformationReview/PreferencesSummary.vue
+++ b/src/views/InformationReview/PreferencesSummary.vue
@@ -352,7 +352,7 @@ export default {
     changePreferences(obj) {
       let changedObj = this.application[obj.field] || [];
 
-      if (obj.change && obj.hasOwnProperty('index')) {
+      if (obj.hasOwnProperty('change') && obj.hasOwnProperty('index')) {
         if (changedObj.length) {
           changedObj[obj.index].selection = obj.change;
         } else {


### PR DESCRIPTION
issues addressed
- Modal wont cancel 
- PQE blank fields bug 
- char info shows 'no info...' rather than no 
- Inputing custom othertask overwrites tasks 
- a few places relied on `obj.change` which was meant as a check for the existence of the value, currently doesnt accommodate false values 

<!---**Author checklist**

- [ ] Include primary ticket number in title - e.g. "#123 New styling for widget" - and any additional tickets in description
- [ ] Fill in the details below and delete as appropriate
- [ ] Be proactive in getting your work approved 💪

---
## What's included?
Describe the changes included in this pull request and highlight dependencies with other repos/tickets

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Describe the steps required to test & verify this change

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
🟠 Medium risk - this does change code that is shared with other areas
🔴 High risk - this includes a lot of changes to shared code

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

--->
<!--[https://jac-apply-admin-production--pr1537-260-tidy-up-cjakm8er.web.app](https://jac-apply-admin-production--pr1537-260-tidy-up-cjakm8er.web.app)-->

PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
