### PR TITLE
enable all admins to edit assessments

### DIFF
--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -250,7 +250,7 @@
               <AssessmentsSummary
                 :application="application"
                 :exercise="exercise"
-                :editable="(editMode && authorisedToPerformAction)"
+                :editable="editMode"
                 :is-panel-view="isPanelView"
                 @updateApplication="changeApplication"
               />

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -244,7 +244,7 @@
                 :application="application"
                 :application-id="applicationId"
                 :exercise="exercise"
-                :editable="(editMode && authorisedToPerformAction)"
+                :editable="editMode"
                 :is-panel-view="isPanelView"
               />
               <AssessmentsSummary

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -251,6 +251,7 @@
                 :application="application"
                 :exercise="exercise"
                 :editable="editMode"
+                :authorised-to-perform-action="authorisedToPerformAction"
                 :is-panel-view="isPanelView"
                 @updateApplication="changeApplication"
               />

--- a/src/views/InformationReview/AssessmentsSummary.vue
+++ b/src/views/InformationReview/AssessmentsSummary.vue
@@ -22,7 +22,7 @@
           <dd class="govuk-summary-list__value">
             <InformationReviewRenderer
               :data="hasAscAnswers(index) ? application.selectionCriteriaAnswers[index].answer : null"
-              :edit="editable"
+              :edit="editable && authorisedToPerformAction"
               :index="index"
               extension="answer"
               type="selection"
@@ -41,7 +41,7 @@
               <InformationReviewRenderer
                 v-if="application.selectionCriteriaAnswers[index] && application.selectionCriteriaAnswers[index].answer === true"
                 :data="hasAscAnswerDetails(index) ? application.selectionCriteriaAnswers[index].answerDetails : null"
-                :edit="editable"
+                :edit="editable && authorisedToPerformAction"
                 :index="index"
                 extension="answerDetails"
                 field="selectionCriteriaAnswers"
@@ -248,6 +248,11 @@ export default {
       default: () => {},
     },
     editable: {
+      type: [Boolean, Function, Promise],
+      required: true,
+      default: false,
+    },
+    authorisedToPerformAction: {
       type: [Boolean, Function, Promise],
       required: true,
       default: false,


### PR DESCRIPTION
## What's included?
Prior to #260 admins could edit both the assessors and self assessment sections, 260 limited this to superusers, this reenables all admins
 
## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to application view as non super user
- Click Edit at the top of the page
- Edit IA
- Edit Self Assessment

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---

https://user-images.githubusercontent.com/44227249/148557980-208703ae-cb1a-46f3-aafd-484cf0bb522a.mov
(NOTE VIDEO RECORDED AS SUPER USER)

(SCREEN SHOT FROM NON SUPER USER)
![image](https://user-images.githubusercontent.com/44227249/148558159-969aeccd-e56f-4457-a152-7f3f72cff120.png)

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
