### PR TITLE
#1545 - Revise Character issues version logic

### DIFF
--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -390,7 +390,7 @@ export default {
       return isNonLegal(this.exercise);
     },
     correctCharacterInformation() {
-      if (this.isVersion2) {
+      if (this.applicationVersion === 2) {
         return this.application.characterInformationV2 || {};
       } else {
         return this.application.characterInformation || {};
@@ -403,16 +403,7 @@ export default {
       return hasIndependentAssessments(this.exercise);
     },
     applicationVersion() {
-      if (this.exercise._applicationVersion) {
-        return this.exercise._applicationVersion;
-      } else if (this.application.characterInformationV2) {
-        return 2;
-      } else {
-        return 1;
-      }
-    },
-    isVersion2() {
-      return this.applicationVersion === 2;
+      return this.exercise._applicationVersion || 1;
     },
     applications() {
       return this.$store.state.applications.records;

--- a/src/views/InformationReview/CharacterInformationSummaryV1.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV1.vue
@@ -18,16 +18,20 @@
           field="criminalOffences"
           @changeField="changeCharacterFlag"
         />
-        <hr>
-        <InformationReviewSectionRenderer
-          :data="formData.criminalOffenceDetails"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          :edit="edit"
-          field="criminalOffenceDetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.criminalOffences === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :data="formData.criminalOffenceDetails"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            :edit="edit"
+            field="criminalOffenceDetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div>
       </dd>
     </div>
     
@@ -46,16 +50,20 @@
           field="nonMotoringFixedPenaltyNotices"
           @changeField="changeCharacterFlag"
         />
-        <hr>
-        <InformationReviewSectionRenderer
-          :data="formData.nonMotoringFixedPenaltyNoticesDetails"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          :edit="edit"
-          field="nonMotoringFixedPenaltyNoticesDetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.nonMotoringFixedPenaltyNotices === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :data="formData.nonMotoringFixedPenaltyNoticesDetails"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            :edit="edit"
+            field="nonMotoringFixedPenaltyNoticesDetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div>
       </dd>
     </div>
 
@@ -74,16 +82,20 @@
           field="drivingDisqualificationDrinkDrugs"
           @changeField="changeCharacterFlag"
         />
-        <hr>
-        <InformationReviewSectionRenderer
-          :data="formData.drivingDisqualificationDrinkDrugsDetails"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          :edit="edit"
-          field="drivingDisqualificationDrinkDrugsDetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.drivingDisqualificationDrinkDrugs === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :data="formData.drivingDisqualificationDrinkDrugsDetails"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            :edit="edit"
+            field="drivingDisqualificationDrinkDrugsDetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div>
       </dd>
     </div>
 
@@ -102,16 +114,20 @@
           field="endorsementsOrMotoringFixedPenalties"
           @changeField="changeCharacterFlag"
         />
-        <hr>
-        <InformationReviewSectionRenderer
-          :edit="edit"
-          :data="formData.endorsementsOrMotoringFixedPenaltiesDetails"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          field="endorsementsOrMotoringFixedPenaltiesDetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.endorsementsOrMotoringFixedPenalties === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :edit="edit"
+            :data="formData.endorsementsOrMotoringFixedPenaltiesDetails"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            field="endorsementsOrMotoringFixedPenaltiesDetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div>
       </dd>
     </div>
 
@@ -130,16 +146,20 @@
           field="declaredBankruptOrIVA"
           @changeField="changeCharacterFlag"
         />
-        <hr>
-        <InformationReviewSectionRenderer
-          :edit="edit"
-          :data="formData.declaredBankruptOrIVADetails"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          field="declaredBankruptOrIVADetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.declaredBankruptOrIVA === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :edit="edit"
+            :data="formData.declaredBankruptOrIVADetails"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            field="declaredBankruptOrIVADetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div>
       </dd>
     </div>
 
@@ -158,17 +178,20 @@
           type="selection"
           @changeField="changeCharacterFlag"
         />
-
-        <hr>
-        <InformationReviewSectionRenderer
-          :edit="edit"
-          :data="formData.lateTaxReturnOrFinedDetails"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          field="lateTaxReturnOrFinedDetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.lateTaxReturnOrFined === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :edit="edit"
+            :data="formData.lateTaxReturnOrFinedDetails"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            field="lateTaxReturnOrFinedDetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div>
       </dd>
     </div>
 
@@ -187,16 +210,20 @@
           field="involvedInProfessionalMisconduct"
           @changeField="changeCharacterFlag"
         />
-        <hr>
-        <InformationReviewSectionRenderer
-          :data="formData.involvedInProfessionalMisconductDetails"
-          :edit="edit"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          field="involvedInProfessionalMisconductDetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.involvedInProfessionalMisconduct === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :data="formData.involvedInProfessionalMisconductDetails"
+            :edit="edit"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            field="involvedInProfessionalMisconductDetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div> 
       </dd>
     </div>
     
@@ -215,16 +242,20 @@
           field="diciplinaryActionOrAskedToResign"
           @changeField="changeCharacterFlag"
         />
-        <hr>
-        <InformationReviewSectionRenderer
-          :data="formData.diciplinaryActionOrAskedToResignDetails"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          :edit="edit"
-          field="diciplinaryActionOrAskedToResignDetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.diciplinaryActionOrAskedToResign === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :data="formData.diciplinaryActionOrAskedToResignDetails"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            :edit="edit"
+            field="diciplinaryActionOrAskedToResignDetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div>
       </dd>
     </div>
 
@@ -243,16 +274,20 @@
           field="otherCharacterIssues"
           @changeField="changeCharacterFlag"
         />
-        <hr>
-        <InformationReviewSectionRenderer
-          :data="formData.otherCharacterIssuesDetails"
-          :edit="edit"
-          :data-default="emptyObject(['details', 'date', 'title'])"
-          field="otherCharacterIssuesDetails"
-          @changeField="changeInfo"
-          @removeField="removeInfo"
-          @addField="addInfo"
-        />
+        <div
+          v-if="formData.otherCharacterIssues === true || edit"
+        >
+          <hr>
+          <InformationReviewSectionRenderer
+            :data="formData.otherCharacterIssuesDetails"
+            :edit="edit"
+            :data-default="emptyObject(['details', 'date', 'title'])"
+            field="otherCharacterIssuesDetails"
+            @changeField="changeInfo"
+            @removeField="removeInfo"
+            @addField="addInfo"
+          />
+        </div>
       </dd>
     </div>
   </dl>


### PR DESCRIPTION
## What's included?
Revision of `isVersion2` computed, which had an oversight causing the wrong version to show.
Detail field in v1 character from on application view now only shows if true, or in edit mode.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Observe Character form is displaying correct Qs and As
- Ensure 'details' only show when an character issue has been marked as true

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
