### PR TITLE
Repair display of driving disqualification answers

### DIFF
--- a/src/views/InformationReview/CharacterInformationSummaryV2.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV2.vue
@@ -112,7 +112,7 @@
           class="govuk-summary-list__value"
         >
           <InformationReviewRenderer
-            :data="formData.drivingDisqualifications || !formData.drivingDisqualificationDetails"
+            :data="formData.drivingDisqualifications"
             :edit="edit"
             :options="[true, false]"
             type="selection"


### PR DESCRIPTION
## What's included?
Dodgy data going into driving disqualifications.
This small change change mean the actual data, not a conditional as was erroneously being passed in is being displayed.
 
## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- View driving disqualifications on a application who has answers to the v2 character form, 
- The answer to DD should no longer always be yes.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
---
![image](https://user-images.githubusercontent.com/44227249/149498309-96acdb4d-e05f-4a31-b2f9-2c7577c57d5e.png)
# ^^ issue on main

![image](https://user-images.githubusercontent.com/44227249/149498837-b3226d37-eacc-40d3-9882-35531196b80b.png)
# ^^ same candidate, issue resolved
---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
