### PR TITLE
digital-platform#657 Identify auto-submitted QTs

### DIFF
--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
@@ -24,7 +24,7 @@
             Status
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ response.status | lookup }} {{ response.isOutOfTime ? 'DNF' : '' }}
+            {{ response.status | lookup }} {{ response.isOutOfTime ? '(auto-submitted)' : '' }}
             <button
               v-if="authorisedToPerformAction"
               :disabled="hasActivated"

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Responses.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Responses.vue
@@ -36,7 +36,7 @@
           {{ row.candidate.fullName | showAlternative(row.candidate.email) | showAlternative(row.candidate.id) }}
         </TableCell>
         <TableCell :title="tableColumns[1].title">
-          {{ row.status | lookup }} {{ row.isOutOfTime ? 'DNF' : '' }}
+          {{ row.status | lookup }} {{ row.isOutOfTime ? '(auto-submitted)' : '' }}
         </TableCell>
         <TableCell :title="tableColumns[2].title">
           {{ formatTimeLimit(row.duration.testDurationAdjusted) }}

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -79,7 +79,7 @@
             :to="{ name: routeNamePrefix + '-responses', params: { qualifyingTestId: this.$route.params.qualifyingTestId, status: qtStatus('COMPLETED') }}"
           >
             Completed
-          </RouterLink> / Out of Time
+          </RouterLink> / Auto-submitted
           <span
             class="display-block govuk-heading-l govuk-!-margin-top-1"
           >{{ qualifyingTest.counts.completed }} / {{ qualifyingTest.counts.outOfTime }}</span>


### PR DESCRIPTION
## What's included?
Simple change to replace the wording "Out of time" and "DNF" with "(auto-submitted)" for QTs.
See /jac-uk/digital-platform/issues/657 for details

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Log in to admin.
Locate a QT which has completed and has responses.
Notice that 'Out of time' has been replaced by 'Auto-submitted' on the following pages:
 - QT dashboard
 - QT responses list
 - QT response
See screen grabs below.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

**QT dashboard. Before**
<img width="235" alt="image" src="https://user-images.githubusercontent.com/8524401/149958477-220d5c02-add9-4139-9208-ef723e2c107c.png">

**QT dashboard. After**
<img width="278" alt="image" src="https://user-images.githubusercontent.com/8524401/149958730-2b855889-ee37-41c2-978c-b6f0458299ef.png">

**QT responses list. Before**
<img width="388" alt="image" src="https://user-images.githubusercontent.com/8524401/149958585-0375b2ba-8a2a-4cde-93f6-98581ecee850.png">

**QT responses list. After**
<img width="451" alt="image" src="https://user-images.githubusercontent.com/8524401/149958800-5d618028-7b44-4548-9120-04a17b1a77b4.png">

**QT response. Before**
<img width="464" alt="image" src="https://user-images.githubusercontent.com/8524401/149958637-2c021a74-c29e-4272-b734-6f4b8d5cfba6.png">

**QT response. After**
<img width="549" alt="image" src="https://user-images.githubusercontent.com/8524401/149958863-72252f2b-d7fb-4927-8661-3844fc4d77f5.png">

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
