### PR TITLE
digital-platform#666 Change to PAJE answers

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -40,7 +40,7 @@ const lookup = (value) => {
     shortlisted: 'Shortlisted',
     selected: 'Selected',
     recommended: 'Recommended',
-    
+
     // Editable Application helpers
     date: 'Date',
     details: 'Details',
@@ -54,11 +54,16 @@ const lookup = (value) => {
     // emp flags
     'gender': 'Gender',
     'ethnicity': 'Ethnicity',
+
+    // PAJE answers
+    'online-and-judge-led': 'Yes - online resources and judge-led discussion group course',
+    'online-only': 'Yes - online resources only',
+
     // 'xxx': 'xxx',
   };
 
   returnValue = lookup[value];
-  
+
   if (!returnValue) {
     if (Object.keys(filters).indexOf('lookup') >= 0) { // use jac-kit lookup, if it exists
       returnValue = filters.lookup(value);

--- a/src/views/InformationReview/EqualityAndDiversityInformationSummary.vue
+++ b/src/views/InformationReview/EqualityAndDiversityInformationSummary.vue
@@ -50,8 +50,8 @@
           />
         </dd>
       </div>
-    
-      <div 
+
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.professionalBackground, 'other-professional-background')"
         class="govuk-summary-list__row"
       >
@@ -69,7 +69,7 @@
           />
         </dd>
       </div>
-      
+
       <div
         v-if="isLegal"
         class="govuk-summary-list__row"
@@ -97,7 +97,7 @@
         </dd>
       </div>
 
-      <div 
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.currentLegalRole, 'other-fee-paid-judicial-office-holder')"
         class="govuk-summary-list__row"
       >
@@ -115,8 +115,8 @@
           />
         </dd>
       </div>
-        
-      <div 
+
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.currentLegalRole, 'other-salaried-judicial-office-holder')"
         class="govuk-summary-list__row"
       >
@@ -134,8 +134,8 @@
           />
         </dd>
       </div>
-        
-      <div 
+
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.currentLegalRole, 'other-current-legal-role')"
         class="govuk-summary-list__row"
       >
@@ -178,7 +178,7 @@
         </dd>
       </div>
 
-      <div 
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.feePaidJudicialRole, 'other-fee-paid-judicial-office')"
         class="govuk-summary-list__row"
       >
@@ -292,8 +292,8 @@
           />
         </dd>
       </div>
-    
-      <div 
+
+      <div
         v-if="hasEthnicGroupDetails"
         class="govuk-summary-list__row"
       >
@@ -332,7 +332,7 @@
         </dd>
       </div>
 
-      <div 
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.gender, 'other-gender')"
         class="govuk-summary-list__row"
       >
@@ -371,7 +371,7 @@
         </dd>
       </div>
 
-      <div 
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.changedGender, false)"
         class="govuk-summary-list__row"
       >
@@ -410,7 +410,7 @@
         </dd>
       </div>
 
-      <div 
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.sexualOrientation, 'other-sexual-orientation')"
         class="govuk-summary-list__row"
       >
@@ -449,7 +449,7 @@
         </dd>
       </div>
 
-      <div 
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.disability, true)"
         class="govuk-summary-list__row"
       >
@@ -488,7 +488,7 @@
         </dd>
       </div>
 
-      <div 
+      <div
         v-if="fieldContains(equalityAndDiversitySurvey.religionFaith, 'other-religion')"
         class="govuk-summary-list__row"
       >
@@ -504,7 +504,7 @@
           />
         </dd>
       </div>
-    
+
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key widerColumn">
           Attended outreach events
@@ -526,8 +526,8 @@
           />
         </dd>
       </div>
-    
-      <div 
+
+      <div
         v-if="isLegal"
         class="govuk-summary-list__row"
       >
@@ -552,7 +552,7 @@
         </dd>
       </div>
 
-      <div 
+      <div
         v-if="isLegal"
         class="govuk-summary-list__row"
       >
@@ -568,13 +568,13 @@
           <InformationReviewRenderer
             v-else
             type="selection"
-            :options="[true, false, 'prefer-not-to-say']"
+            :options="['online-and-judge-led', 'online-only', false, 'prefer-not-to-say']"
             field="hasTakenPAJE"
             :edit="editable"
             :data="equalityAndDiversitySurvey.hasTakenPAJE"
             @changeField="changeEqualityAndDiversityInformation"
           />
-        </dd> 
+        </dd>
       </div>
     </dl>
     <span


### PR DESCRIPTION
## What's included?
Update to support the change to PAJE answers, as outlined in https://github.com/jac-uk/digital-platform/issues/666

There's a corresponding change in Apply here: https://github.com/jac-uk/apply/pull/849

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Admin changes can be previewed here: https://jac-admin-develop--pr1554-feature-666-paje-iw2wa8lq.web.app/
Apply changes can be previewed here: https://jac-apply-develop--pr849-feature-666-paje-dbsqxipr.web.app/

In the Equality and Diversity Survey the question 'Have you taken part in the Pre-Application Judicial Education Programme (PAJE)?' should now offer the following answers:
- Yes - online resources and judge-led discussion group course
- Yes - online resources only
- No
- Prefer not to say

We need to check that this change is reflected in both Apply and Admin

In Apply:
- Create an application for a **legal** exercise
- Complete the Equality and Diversity survey taking note of the answer provided to the PAJE question

In Admin:
- Go to Draft Applications (for the relevant exercise) and click on the application you just created
- In application view locate 'Equality and diversity information' and the answer displayed for 'Participated in Pre-Application Judicial Education Programme'
- Observe that the answer displayed matches the answer provided by the candidate

Try changing the selected answer in Apply and observe that the correct answer is displayed in Admin.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context

**Apply. Equality & diversity. PAJE question**
<img width="586" alt="image" src="https://user-images.githubusercontent.com/8524401/149983740-de01865d-c378-4a35-8b9c-f7f6c32794a3.png">

**Admin. Application view. Equality & diversity. PAJE answer**
<img width="879" alt="image" src="https://user-images.githubusercontent.com/8524401/149983904-4f77c04e-6d66-4e4e-9f8f-a071c2c4f90e.png">

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
