### PR TITLE
#1555 Add candidate reference number to custom report

### DIFF
--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -331,6 +331,7 @@ export default {
         {
           name: 'Application Info',
           keys: [
+            'referenceNumber',
             'personalDetails.dateOfBirth',
             'personalDetails.title',
             'personalDetails.citizenship',
@@ -425,6 +426,7 @@ export default {
         },
       ],
       keys: {
+        referenceNumber: { label: 'Candidate reference number', type: String },
         applyingForWelshPost: { label: 'Applying for Welsh Post?', type: Boolean },
         canReadAndWriteWelsh: { label: 'Can read and write Welsh?', type: Boolean },
         canSpeakWelsh: { label: 'Can speak Welsh?', type: Boolean },


### PR DESCRIPTION
**Author checklist**

- [x] Include primary ticket number in title - e.g. "#123 New styling for widget" - and any additional tickets in description
- [x] Fill in the details below and delete as appropriate
- [x] Be proactive in getting your work approved 💪

---
## What's included?
Add candidate reference number to custom report

## Who should test?
✅ Product owner
✅ Developers


## How to test?
Enter an Exercise, go to Reports and then Custom Report. Click the drop down for Select a column to display and click on Add candidate reference number. The Candidate reference will then load on screen, just below the drop down box. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work


## Additional context
Demo:
![custom_report_candidate_reference_number](https://user-images.githubusercontent.com/79906532/150753739-344960fd-3f07-453f-9100-5a38e08c18a2.gif)


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
