### PR TITLE
#1525 Static Report

### DIFF
--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -481,7 +481,7 @@ export default {
         skillsAquisitionDetails: { label: 'Skills aquisition details', type: String },
         feePaidOrSalariedJudge: { label: 'Fee paid or salaried judge?', type: Boolean },
         feePaidOrSalariedSatForThirtyDays: { label: 'Fee paid or salaried sat for thirty days?', type: Boolean },
-        experience: { label: 'Post-qualificatin experience', type: String },
+        experience: { label: 'Post-qualification experience', type: String },
         experienceUnderSchedule2Three: { label: 'Experience under schedule 2 three?', type: Boolean },
         quasiJudicialSittingDaysDetails: { label: 'Quasi judicial sitting days details', type: String },
         quasiJudicialSatForThirtyDays: { label: 'Quasi judicial sat for thirty days?', type: Boolean },

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -368,12 +368,13 @@ export default {
           ],
         },
         {
-          name: 'Qualifications',
+          name: 'Qualifications and Experience',
           keys: [
             'qualifications',
             'skillsAquisitionDetails',
             'feePaidOrSalariedJudge',
             'feePaidOrSalariedSatForThirtyDays',
+            'experience',
             'experienceUnderSchedule2Three',
             'quasiJudicialSittingDaysDetails',
             'quasiJudicialSatForThirtyDays',
@@ -480,6 +481,7 @@ export default {
         skillsAquisitionDetails: { label: 'Skills aquisition details', type: String },
         feePaidOrSalariedJudge: { label: 'Fee paid or salaried judge?', type: Boolean },
         feePaidOrSalariedSatForThirtyDays: { label: 'Fee paid or salaried sat for thirty days?', type: Boolean },
+        experience: { label: 'Post-qualificatin experience', type: String },
         experienceUnderSchedule2Three: { label: 'Experience under schedule 2 three?', type: Boolean },
         quasiJudicialSittingDaysDetails: { label: 'Quasi judicial sitting days details', type: String },
         quasiJudicialSatForThirtyDays: { label: 'Quasi judicial sat for thirty days?', type: Boolean },


### PR DESCRIPTION
**Author checklist**

- [x] Include primary ticket number in title - e.g. "#123 New styling for widget" - and any additional tickets in description
- [x] Fill in the details below and delete as appropriate
- [x] Be proactive in getting your work approved 💪

---
## What's included?
Add qualified date and post-qualification experience date columns to custom report

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Enter an Exercise, go to Reports and then Custom Report. Click the dropdown for Select a column to display and click on Add `Qualifications` and `Post-qualification experience`. The two columns will then load on screen, just below the dropdown box. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:
![static_report_1](https://user-images.githubusercontent.com/79906532/151141017-1f8c7737-0e3d-445b-81cc-5cfe03ebb080.gif)

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
