### PR TITLE
fix assessments edit

### DIFF
--- a/src/views/InformationReview/AssessmentsSummary.vue
+++ b/src/views/InformationReview/AssessmentsSummary.vue
@@ -297,13 +297,17 @@ export default {
   },
   methods: {
     hasAscAnswerDetails(index){
-      if (this.application.selectionCriteriaAnswers[index]) {
-        return this.application.selectionCriteriaAnswers[index].hasOwnProperty('answerDetails');
+      if (this.application.selectionCriteriaAnswers) {
+        if (this.application.selectionCriteriaAnswers[index]) {
+          return this.application.selectionCriteriaAnswers[index].hasOwnProperty('answerDetails');
+        }
       }
     },
     hasAscAnswers(index){
-      if (this.application.selectionCriteriaAnswers[index]) {
-        return this.application.selectionCriteriaAnswers[index].hasOwnProperty('answer');
+      if (this.application.selectionCriteriaAnswers) {
+        if (this.application.selectionCriteriaAnswers[index]) {
+          return this.application.selectionCriteriaAnswers[index].hasOwnProperty('answer');
+        }
       }
     },
     changeAssessmentInfo(obj) {


### PR DESCRIPTION
## What's included?
`AssessmentsSummary` component was erroring on certain application overviews preventing it from being edited.
This fix adds an additional check for the expected value.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Visit an application such as this one [https://admin-develop.judicialappointments.digital/exercise/QMrEnj3xZITwvJG0WK12/applications/applied/application/6Rx2gynLlaAd14BrE49R] on the current development environment.
- observe that the last blocks of application data are not editable.
- visit the same application on this branch
- observe data now editable (file uploads etc)


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
🟠 Medium risk - this does change code that is shared with other areas
🔴 High risk - this includes a lot of changes to shared code

## Additional context
![image](https://user-images.githubusercontent.com/44227249/151200984-75afcfa6-af2e-4e22-b9ce-4a6c9a57de3b.png)

![image](https://user-images.githubusercontent.com/44227249/151201068-d8f48a45-781b-4bee-a4b4-cd8918e87914.png)

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
