### PR TITLE
Prevent error on exercises w/o additional working preferences

### DIFF
--- a/src/views/InformationReview/PreferencesSummary.vue
+++ b/src/views/InformationReview/PreferencesSummary.vue
@@ -223,7 +223,7 @@
     </div>
 
     <div
-      v-if="exercise.additionalWorkingPreferences.length"
+      v-if="exercise.additionalWorkingPreferences && exercise.additionalWorkingPreferences.length"
     >
       <h2
         class="govuk-heading-l govuk-!-margin-top-6"


### PR DESCRIPTION
## What's included?
Some exercises are erroring due to having no additional working preferences, not a critical error, but good for housekeeping

## Who should test?
✅ Developers

## How to test?
???
This should remove the sentry error

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
- See attached ticket and sentry issue

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
