### PR TITLE
Edit application fixes

### DIFF
--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -301,18 +301,18 @@ import { saveAs } from 'file-saver';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 import SubmissionExtension from '@/components/ModalViews/SubmissionExtension';
 import Notes from '@/components/Notes/Notes';
-import PersonalDetailsSummary from '@/views/InformationReview/PersonalDetailsSummary';
 import CharacterInformationSummary from '@/views/InformationReview/CharacterInformationSummary';
+import PersonalDetailsSummary from '@/views/InformationReview/PersonalDetailsSummary';
 import EqualityAndDiversityInformationSummary from '@/views/InformationReview/EqualityAndDiversityInformationSummary';
 import PreferencesSummary from '@/views/InformationReview/PreferencesSummary';
 import QualificationsAndMembershipsSummary from '@/views/InformationReview/QualificationsAndMembershipsSummary';
 import ExperienceSummary from '@/views/InformationReview/ExperienceSummary';
 import AssessmentsSummary from '@/views/InformationReview/AssessmentsSummary';
 import AssessorsSummary from '@/views/InformationReview/AssessorsSummary';
+import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer';
+import PageNotFound from '@/views/Errors/PageNotFound';
 import splitFullName from '@jac-uk/jac-kit/helpers/splitFullName';
 import { authorisedToPerformAction }  from '@/helpers/authUsers';
-import PageNotFound from '@/views/Errors/PageNotFound';
-import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer';
 import CharacterChecks from '@/views/Exercise/Tasks/CharacterChecks';
 
 import {

--- a/src/views/InformationReview/CharacterInformationSummary.vue
+++ b/src/views/InformationReview/CharacterInformationSummary.vue
@@ -8,7 +8,7 @@
         Version {{ version }}
       </h3>
       <div
-        v-if="!hasValues(characterInformation)"
+        v-if="!hasValues(characterInformation) && !editable"
         class="govuk-body"
       >
         No information provided

--- a/src/views/InformationReview/CharacterInformationSummaryV1.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV1.vue
@@ -291,12 +291,6 @@
       </dd>
     </div>
   </dl>
-  <span
-    v-else
-    class="govuk-body"
-  >
-    No information provided
-  </span>
 </template>
 
 <script>

--- a/src/views/InformationReview/CharacterInformationSummaryV2.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV2.vue
@@ -578,7 +578,7 @@
             :edit="edit"
             :options="[true, false]"
             type="selection"
-            field="furtherInformationDetails"
+            field="furtherInformation"
             @changeField="changeCharacterFlag"
           />
           <div v-if="formData.furtherInformation">


### PR DESCRIPTION
## What's included?
a few tweaks and fixes to keep #260 working

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Applications which had not completed the char-survey couldn't be edited by admins, `v-if` was only checking the data, not the edit mode toggle

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP

_can be OFF, DEVELOP or STAGING_
