### PR TITLE
#1614 Process applications button missing from exercise overview

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,13 +12,9 @@ import * as Integrations from '@sentry/integrations';
 import './styles/main.scss';
 
 if (process.env.NODE_ENV !== 'development') {
-  // Split the URL
-  const host = window.location.host;
-  const parts = host.split('.');
-
   Sentry.init({
     dsn: 'https://ab99abfef6294bc5b564e635d7b7cb4b@sentry.io/1792541',
-    environment: parts[0] == 'admin' ? 'production' : 'staging',
+    environment: store.getters.appEnvironment.toLowerCase(),
     release: process.env.PACKAGE_VERSION, // made available in vue.config.js
     integrations: [new Integrations.Vue({ Vue, attachProps: true })],
   });

--- a/src/store.js
+++ b/src/store.js
@@ -92,6 +92,9 @@ const store = new Vuex.Store({
       }
       return '';
     },
+    isProduction: (state, getters) => {
+      return getters.appEnvironment === 'PRODUCTION';
+    },
   },
 });
 

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -158,22 +158,6 @@
         Copy to Clipboard
       </ActionButton>
       <br>
-      <button
-        v-if="isReadyForTesting"
-        class="govuk-button"
-        type="primary"
-        @click="changeNoOfTestApplications()"
-      >
-        Create test applications
-      </button>
-      <ActionButton
-        v-if="isTesting"
-        ref="createTestApplicationsBtn"
-        type="primary"
-        @click="createTestApplications()"
-      >
-        Create test applications
-      </ActionButton>
       <ActionButton
         v-if="isReadyForProcessing"
         @click="startProcessing()"
@@ -186,6 +170,22 @@
       >
         Process late applications
       </ActionButton>
+      <div v-if="!isProduction">
+        <button
+          v-if="isReadyForTesting"
+          class="govuk-button"
+          @click="changeNoOfTestApplications()"
+        >
+          Create test applications
+        </button>
+        <ActionButton
+          v-if="isTesting"
+          ref="createTestApplicationsBtn"
+          @click="createTestApplications()"
+        >
+          Create test applications
+        </ActionButton>
+      </div>
     </div>
     <Modal
       ref="modalChangeExerciseState"
@@ -227,6 +227,9 @@ export default {
     ChangeNoOfTestApplications,
   },
   computed: {
+    isProduction() {
+      return this.$store.getters['isProduction'];
+    },
     exercise() {
       return this.$store.getters['exerciseDocument/data']();
     },
@@ -274,10 +277,10 @@ export default {
       return this.isPublished && this.isApproved && !this.isTesting && !this.isTested;
     },
     isProcessing() {
-      return isProcessing(this.exercise) && this.isTested;
+      return isProcessing(this.exercise);
     },
     isReadyForProcessing() {
-      return this.isApproved && !this.isProcessing && this.isTested;
+      return this.isApproved && !this.isProcessing;
       // @TODO perhaps also check that exercise has closed
     },
 


### PR DESCRIPTION
## What's included?

- Closes #1614 so Process Application buttons now display correctly
- Hidden the Create Test Applications button on the Production environment
- Consolidated environment logic

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
On the Exercise Overview page for an exercise which has received applications observe the following:
- 'Process applications' button is present and working
- 'Create test applications' button is present on develop and staging environments but not present on production


## Risk - how likely is this to impact other areas?
🟢 Low risk - this is a self-contained piece of work 

## Additional context
![image](https://user-images.githubusercontent.com/44227249/168316034-6a20bdd2-6811-42d3-b93d-91530bcaca37.png)

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
