### PR TITLE
membership display and edit

### DIFF
--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -200,6 +200,7 @@
           class="application-details"
         >
           <div v-if="application && exercise">
+            <!--
             <PersonalDetailsSummary
               :user-id="application.userId"
               :personal-details="application.personalDetails || {}"
@@ -225,12 +226,14 @@
               :is-panel-view="isPanelView"
               @updateApplication="changeApplication"
             />
+            -->
             <QualificationsAndMembershipsSummary
               :application="application"
               :exercise="exercise"
               :editable="(editMode && authorisedToPerformAction)"
               @updateApplication="changeApplication"
             />
+            <!---
             <ExperienceSummary
               :application="application"
               :exercise="exercise"
@@ -253,6 +256,7 @@
               :is-panel-view="isPanelView"
               @updateApplication="changeApplication"
             />
+            --->
           </div>
         </div>
 
@@ -297,14 +301,14 @@ import { saveAs } from 'file-saver';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 import SubmissionExtension from '@/components/ModalViews/SubmissionExtension';
 import Notes from '@/components/Notes/Notes';
-import PersonalDetailsSummary from '@/views/InformationReview/PersonalDetailsSummary';
-import CharacterInformationSummary from '@/views/InformationReview/CharacterInformationSummary';
-import EqualityAndDiversityInformationSummary from '@/views/InformationReview/EqualityAndDiversityInformationSummary';
-import PreferencesSummary from '@/views/InformationReview/PreferencesSummary';
+// import PersonalDetailsSummary from '@/views/InformationReview/PersonalDetailsSummary';
+// import CharacterInformationSummary from '@/views/InformationReview/CharacterInformationSummary';
+// import EqualityAndDiversityInformationSummary from '@/views/InformationReview/EqualityAndDiversityInformationSummary';
+// import PreferencesSummary from '@/views/InformationReview/PreferencesSummary';
 import QualificationsAndMembershipsSummary from '@/views/InformationReview/QualificationsAndMembershipsSummary';
-import ExperienceSummary from '@/views/InformationReview/ExperienceSummary';
-import AssessmentsSummary from '@/views/InformationReview/AssessmentsSummary';
-import AssessorsSummary from '@/views/InformationReview/AssessorsSummary';
+// import ExperienceSummary from '@/views/InformationReview/ExperienceSummary';
+// import AssessmentsSummary from '@/views/InformationReview/AssessmentsSummary';
+// import AssessorsSummary from '@/views/InformationReview/AssessorsSummary';
 import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer';
 import PageNotFound from '@/views/Errors/PageNotFound';
 import splitFullName from '@jac-uk/jac-kit/helpers/splitFullName';
@@ -329,14 +333,14 @@ export default {
     PageNotFound,
     InformationReviewRenderer,
     CharacterChecks,
-    PersonalDetailsSummary,
-    CharacterInformationSummary,
-    EqualityAndDiversityInformationSummary,
-    PreferencesSummary,
+    // PersonalDetailsSummary,
+    // CharacterInformationSummary,
+    // EqualityAndDiversityInformationSummary,
+    // PreferencesSummary,
     QualificationsAndMembershipsSummary,
-    ExperienceSummary,
-    AssessmentsSummary,
-    AssessorsSummary,
+    // ExperienceSummary,
+    // AssessmentsSummary,
+    // AssessorsSummary,
   },
   data() {
     return {

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -200,7 +200,6 @@
           class="application-details"
         >
           <div v-if="application && exercise">
-            <!--
             <PersonalDetailsSummary
               :user-id="application.userId"
               :personal-details="application.personalDetails || {}"
@@ -226,14 +225,12 @@
               :is-panel-view="isPanelView"
               @updateApplication="changeApplication"
             />
-            -->
             <QualificationsAndMembershipsSummary
               :application="application"
               :exercise="exercise"
               :editable="(editMode && authorisedToPerformAction)"
               @updateApplication="changeApplication"
             />
-            <!---
             <ExperienceSummary
               :application="application"
               :exercise="exercise"
@@ -256,7 +253,6 @@
               :is-panel-view="isPanelView"
               @updateApplication="changeApplication"
             />
-            --->
           </div>
         </div>
 
@@ -301,14 +297,14 @@ import { saveAs } from 'file-saver';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 import SubmissionExtension from '@/components/ModalViews/SubmissionExtension';
 import Notes from '@/components/Notes/Notes';
-// import PersonalDetailsSummary from '@/views/InformationReview/PersonalDetailsSummary';
-// import CharacterInformationSummary from '@/views/InformationReview/CharacterInformationSummary';
-// import EqualityAndDiversityInformationSummary from '@/views/InformationReview/EqualityAndDiversityInformationSummary';
-// import PreferencesSummary from '@/views/InformationReview/PreferencesSummary';
+import PersonalDetailsSummary from '@/views/InformationReview/PersonalDetailsSummary';
+import CharacterInformationSummary from '@/views/InformationReview/CharacterInformationSummary';
+import EqualityAndDiversityInformationSummary from '@/views/InformationReview/EqualityAndDiversityInformationSummary';
+import PreferencesSummary from '@/views/InformationReview/PreferencesSummary';
 import QualificationsAndMembershipsSummary from '@/views/InformationReview/QualificationsAndMembershipsSummary';
-// import ExperienceSummary from '@/views/InformationReview/ExperienceSummary';
-// import AssessmentsSummary from '@/views/InformationReview/AssessmentsSummary';
-// import AssessorsSummary from '@/views/InformationReview/AssessorsSummary';
+import ExperienceSummary from '@/views/InformationReview/ExperienceSummary';
+import AssessmentsSummary from '@/views/InformationReview/AssessmentsSummary';
+import AssessorsSummary from '@/views/InformationReview/AssessorsSummary';
 import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer';
 import PageNotFound from '@/views/Errors/PageNotFound';
 import splitFullName from '@jac-uk/jac-kit/helpers/splitFullName';
@@ -333,14 +329,14 @@ export default {
     PageNotFound,
     InformationReviewRenderer,
     CharacterChecks,
-    // PersonalDetailsSummary,
-    // CharacterInformationSummary,
-    // EqualityAndDiversityInformationSummary,
-    // PreferencesSummary,
+    PersonalDetailsSummary,
+    CharacterInformationSummary,
+    EqualityAndDiversityInformationSummary,
+    PreferencesSummary,
     QualificationsAndMembershipsSummary,
-    // ExperienceSummary,
-    // AssessmentsSummary,
-    // AssessorsSummary,
+    ExperienceSummary,
+    AssessmentsSummary,
+    AssessorsSummary,
   },
   data() {
     return {

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -90,11 +90,11 @@
                 role="menu"
               >
                 <button
-                    class="govuk-button govuk-button--secondary drop-down-button"
-                    @click="downloadPage"
-                  >
-                    Download Page
-                  </button>
+                  class="govuk-button govuk-button--secondary drop-down-button"
+                  @click="downloadPage"
+                >
+                  Download Page
+                </button>
                 <button
                   id="docDownloadButton"
                   class="govuk-button govuk-button--secondary drop-down-button"
@@ -297,8 +297,8 @@ import { saveAs } from 'file-saver';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 import SubmissionExtension from '@/components/ModalViews/SubmissionExtension';
 import Notes from '@/components/Notes/Notes';
-import CharacterInformationSummary from '@/views/InformationReview/CharacterInformationSummary';
 import PersonalDetailsSummary from '@/views/InformationReview/PersonalDetailsSummary';
+import CharacterInformationSummary from '@/views/InformationReview/CharacterInformationSummary';
 import EqualityAndDiversityInformationSummary from '@/views/InformationReview/EqualityAndDiversityInformationSummary';
 import PreferencesSummary from '@/views/InformationReview/PreferencesSummary';
 import QualificationsAndMembershipsSummary from '@/views/InformationReview/QualificationsAndMembershipsSummary';
@@ -410,9 +410,6 @@ export default {
     applicationId() {
       return this.$route.params.applicationId;
     },
-    exerciseId() {
-      return this.$store.state.exerciseDocument.record ? this.$store.state.exerciseDocument.record.id : null;
-    },
     applicationReferenceNumber() {
       return this.$store.state.application.record ? this.$store.state.application.record.referenceNumber : null;
     },
@@ -421,20 +418,6 @@ export default {
     },
     generateFilename() {
       return this.applicationReferenceNumber ? this.applicationReferenceNumber : 'judicial-appointments-application';
-    },
-    ethnicGroupDetails() {
-      switch (this.application.equalityAndDiversitySurvey.ethnicGroup) {
-      case 'other-asian':
-        return this.application.equalityAndDiversitySurvey.otherEthnicGroupAsianDetails;
-      case 'other-white':
-        return this.application.equalityAndDiversitySurvey.otherEthnicGroupWhiteDetails;
-      case 'other-black':
-        return this.application.equalityAndDiversitySurvey.otherEthnicGroupBlackDetails;
-      case 'other-mixed':
-        return this.application.equalityAndDiversitySurvey.otherEthnicGroupMixedDetails;
-      default:
-        return this.application.equalityAndDiversitySurvey.otherEthnicGroupDetails;
-      }
     },
     isApplied() {
       if (this.application) {
@@ -446,24 +429,6 @@ export default {
         }
       }
       return false;
-    },
-    otherMemberships() {
-      // @NOTE this is a bit ugly as we can't just lookup label
-      const selected = {};
-
-      if (this.application.professionalMemberships) {
-        this.application.professionalMemberships.forEach(membership => {
-          if (this.application.memberships[membership]) {
-            const otherMembership = this.exercise.otherMemberships.find(m => m.value === membership);
-            selected[membership] = {
-              ...this.application.memberships[membership],
-              label: otherMembership.label,
-            };
-          }
-        });
-      }
-
-      return selected;
     },
     title() {
       let title = this.application.personalDetails.title;
@@ -602,22 +567,6 @@ export default {
     submitApplication() {
       this.$store.dispatch('application/submit');
     },
-    showMembershipOption(ref) {
-      if (this.application && this.application.professionalMemberships) {
-        return this.application.professionalMemberships.indexOf(ref) >= 0;
-      }
-      return false;
-    },
-    preferNotToSay(field) {
-      const val = 'prefer-not-to-say';
-      if (field === val) {
-        return true;
-      }
-      if (Array.isArray(field) && field.includes(val)) {
-        return true;
-      }
-      return false;
-    },
     makeFullName(objChanged) {
       if (objChanged.firstName && this.application.personalDetails.lastName) {
         objChanged.fullName = `${objChanged.firstName} ${this.application.personalDetails.lastName}`;
@@ -642,56 +591,11 @@ export default {
         exerciseRef: this.exercise.referenceNumber,
       });
     },
-    doFileUpload(val, field) {
-      if (val) {
-        this.$store.dispatch('application/update', { data: { [field]: val }, id: this.applicationId });
-
-        logEvent('info', 'Application updated (document uploaded)', {
-          applicationId: this.applicationId,
-          candidateName: this.application.personalDetails.fullName,
-          exerciseRef: this.exercise.referenceNumber,
-        });
-      }
-    },
-    editAssessor(AssessorNr) {
-      // this.assessorDetails = {};
-      if (AssessorNr === 1) {
-        this.assessorDetails = {
-          AssessorNr: AssessorNr,
-          applicationId: this.applicationId,
-          email: this.application.firstAssessorEmail,
-          fullName: this.application.firstAssessorFullName,
-          phone: this.application.firstAssessorPhone,
-          title: this.application.firstAssessorTitle,
-        };
-      }
-      if (AssessorNr === 2) {
-        this.assessorDetails = {
-          AssessorNr: AssessorNr,
-          applicationId: this.applicationId,
-          email: this.application.secondAssessorEmail,
-          fullName: this.application.secondAssessorFullName,
-          phone: this.application.secondAssessorPhone,
-          title: this.application.secondAssessorTitle,
-        };
-      }
-      this.openModal('assessorModal');
-    },
-    editLeadershipJudgeDetails() {
-      this.openModal('modalLeadershipJudgeDetails');
-    },
     openModal(modalRef){
       this.$refs[modalRef].openModal();
     },
     closeModal(modalRef) {
       this.$refs[modalRef].closeModal();
-    },
-    savedModal(modalRef) {
-      logEvent('info',  `Application updated (${modalRef})`, {
-        applicationId: this.applicationId,
-        candidateName: this.application.personalDetails.fullName,
-        exerciseRef: this.exercise.referenceNumber,
-      });
     },
     changeApplication(obj) {
       this.$store.dispatch('application/update', { data: obj, id: this.applicationId });

--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -56,12 +56,6 @@
         </TableCell>
       </template>
     </Table>
-    <p
-      v-if="!applications.length"
-      class="govuk-body"
-    >
-      No applications found.
-    </p>
   </div>
 </template>
 

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -254,7 +254,7 @@
       >
         Memberships
       </h2>
-      <div v-if="Object.keys(application.memberships).length || application.professionalMemberships || editable">
+      <div v-if="hasMemberships || editable">
         <!-- professionalMemberships -->
         <dl
           v-if="application.professionalMemberships || editable"
@@ -741,6 +741,7 @@
       >
         No answers provided
       </div>
+      <hr>
     </div>
   </div>
 </template>
@@ -788,7 +789,11 @@ export default {
   },
   computed: {
     applicationHasQualifications() {
-      return this.application.qualifications && Object.values(this.application.qualifications).length > 0;
+      if (this.application.qualifications) {
+        return Object.values(this.application.qualifications).length > 0;
+      } else {
+        return false;
+      }
     },
     exercise() {
       return this.$store.state.exerciseDocument.record;
@@ -798,6 +803,15 @@ export default {
     },
     hasRelevantMemberships() {
       return hasRelevantMemberships(this.exercise);
+    },
+    hasMemberships() {
+      if (this.application.memberships) {
+        return Object.keys(this.application.memberships).length;
+      } else if (this.application.professionalMemberships) {
+        return this.application.professionalMemberships;
+      } else {
+        return false;
+      }
     },
     isNonLegal() {
       return isNonLegal(this.exercise);

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -7,52 +7,94 @@
       >
         Qualifications
       </h2>
-      <div>
-        <div>
-          <dl
-            v-for="(item, index) in application.qualifications"
-            :key="item.name"
+      <div v-if="applicationHasQualifications">
+        <dl
+          v-for="(qualification, index) in application.qualifications"
+          :key="qualification.name"
+        >
+          <button
+            v-if="editable"
+            class="govuk-button govuk-button--warning govuk-button--secondary govuk-!-margin-bottom-0 float-right"
+            @click="openModal(index)"
           >
-            <button
-              v-if="editable"
-              class="govuk-button govuk-button--warning govuk-button--secondary govuk-!-margin-bottom-0 float-right"
-              @click="openModal(index)"
-            >
-              Remove
-            </button>
-            <div
-              class="govuk-summary-list govuk-!-margin-bottom-5"
-            >
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key widerColumn">
-                  Qualification
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <InformationReviewRenderer
-                    :data="application.qualifications[index].type"
-                    field="qualifications"
-                    extension="type"
-                    :index="index"
-                    :edit="editable"
-                    :options="['advocate-scotland', 'barrister', 'CILEx', 'solicitor']"
-                    type="selection"
-                    @changeField="changeQualificationOrMembership"
-                  />
-                </dd>
-              </div>
+            Remove
+          </button>
+          <div
+            class="govuk-summary-list govuk-!-margin-bottom-0"
+          >
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key widerColumn">
+                Qualification
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <InformationReviewRenderer
+                  :data="application.qualifications[index].type"
+                  field="qualifications"
+                  extension="type"
+                  :index="index"
+                  :edit="editable"
+                  :options="['advocate-scotland', 'barrister', 'CILEx', 'solicitor']"
+                  type="selection"
+                  @changeField="changeQualificationOrMembership"
+                />
+              </dd>
+            </div>
 
-              <div class="govuk-summary-list__row">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key widerColumn">
+                Location
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <InformationReviewRenderer
+                  :data="application.qualifications[index].location"
+                  field="qualifications"
+                  extension="location"
+                  :index="index"
+                  :edit="editable"
+                  :options="['england-wales', 'northern-ireland', 'scotland']"
+                  type="selection"
+                  @changeField="changeQualificationOrMembership"
+                />
+              </dd>
+            </div>
+            <div
+              v-if="qualification.hasOwnProperty('date') || editable"
+              class="govuk-summary-list__row"
+            >
+              <dt
+                class="govuk-summary-list__key widerColumn"
+              >
+                {{ qualification.type === 'barrister' ? 'Date completed pupillage' : 'Date qualified' }} 
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <InformationReviewRenderer
+                  :data="application.qualifications[index].date"
+                  field="qualifications"
+                  extension="date"
+                  :index="index"
+                  :edit="editable"
+                  type="date"
+                  @changeField="changeQualificationOrMembership"
+                />
+              </dd>
+            </div> 
+
+            <template>
+              <div
+                v-if="qualification.type === 'barrister' && ((qualification.qualificationNotComplete && qualification.details) || editable)"
+                class="govuk-summary-list__row"
+              >
                 <dt class="govuk-summary-list__key widerColumn">
-                  Location
+                  Has not completed pupillage
                 </dt>
                 <dd class="govuk-summary-list__value">
                   <InformationReviewRenderer
-                    :data="application.qualifications[index].location"
+                    :data="application.qualifications[index].qualificationNotComplete"
                     field="qualifications"
-                    extension="location"
+                    extension="qualificationNotComplete"
                     :index="index"
                     :edit="editable"
-                    :options="['england-wales', 'northern-ireland', 'scotland']"
+                    :options="[true, false]"
                     type="selection"
                     @changeField="changeQualificationOrMembership"
                   />
@@ -60,71 +102,26 @@
               </div>
 
               <div
-                v-if="item.date || editable"
+                v-if="qualification.type === 'barrister' && (qualification.qualificationNotComplete === true)"
                 class="govuk-summary-list__row"
               >
-                <dt
-                  class="govuk-summary-list__key widerColumn"
-                >
-                  {{ item.type === 'barrister' ? 'Date completed pupillage' : 'Date qualified' }} 
+                <dt class="govuk-summary-list__key widerColumn">
+                  Did not complete pupillage notes
                 </dt>
                 <dd class="govuk-summary-list__value">
                   <InformationReviewRenderer
-                    :data="application.qualifications[index].date"
+                    :data="application.qualifications[index].details"
                     field="qualifications"
-                    extension="date"
+                    extension="details"
                     :index="index"
                     :edit="editable"
-                    type="date"
                     @changeField="changeQualificationOrMembership"
                   />
                 </dd>
-              </div> 
-
-              <template>
-                <div
-                  v-if="item.type === 'barrister' && ((item.qualificationNotComplete && item.details) || editable)"
-                  class="govuk-summary-list__row"
-                >
-                  <dt class="govuk-summary-list__key widerColumn">
-                    Has not completed pupillage
-                  </dt>
-                  <dd class="govuk-summary-list__value">
-                    <InformationReviewRenderer
-                      :data="application.qualifications[index].qualificationNotComplete"
-                      field="qualifications"
-                      extension="qualificationNotComplete"
-                      :index="index"
-                      :edit="editable"
-                      :options="[true, false]"
-                      type="selection"
-                      @changeField="changeQualificationOrMembership"
-                    />
-                  </dd>
-                </div>
-
-                <div
-                  v-if="item.type === 'barrister' && (item.qualificationNotComplete === true)"
-                  class="govuk-summary-list__row"
-                >
-                  <dt class="govuk-summary-list__key widerColumn">
-                    Did not complete pupillage notes
-                  </dt>
-                  <dd class="govuk-summary-list__value">
-                    <InformationReviewRenderer
-                      :data="application.qualifications[index].details"
-                      field="qualifications"
-                      extension="details"
-                      :index="index"
-                      :edit="editable"
-                      @changeField="changeQualificationOrMembership"
-                    />
-                  </dd>
-                </div>
-              </template>
-            </div>
-          </dl>
-        </div>
+              </div>
+            </template>
+          </div>
+        </dl>
       </div>
       <div
         class="govuk-body"
@@ -133,6 +130,7 @@
           v-if="!applicationHasQualifications"
         >
           No answers provided
+          <hr>
         </div>
         <button
           v-if="editable"
@@ -152,7 +150,6 @@
         />
       </Modal>
     </div>
-
     <!-- applied schedules -->
     <div>
       <dl
@@ -248,31 +245,31 @@
         </dd>
       </dl>
     </div>
-
-    <!-- memberships -->
-    <div
+    <!-- memberships + professional Memberships -->
+    <div 
       v-if="hasRelevantMemberships"
-      class="govuk-!-margin-top-9"
     >
-      <h2 class="govuk-heading-l">
+      <h2
+        class="govuk-heading-l govuk-!-margin-top-6"
+      >
         Memberships
       </h2>
-      <div>
+      <div v-if="Object.keys(application.memberships).length || application.professionalMemberships || editable">
+        <!-- professionalMemberships -->
         <dl
-          v-if="application.memberships"
-          class="govuk-summary-list govuk-!-margin-bottom-8"
+          v-if="application.professionalMemberships || editable"
         >
           <div
-            v-for="(membership, key) in exercise.memberships"
-            :key="key"
-            class="govuk-summary-list__row"
+            class="govuk-summary-list govuk-!-margin-bottom-0"
           >
-            <div v-if="fieldContains(application.memberships, membership) || editable">
+            <div 
+              v-if="showMembershipOption('chartered-association-of-building-engineers')"
+              class="govuk-summary-list__row"
+            >
               <dt class="govuk-summary-list__key widerColumn">
-                {{ membership }}
+                Chartered Association of Building Engineers
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ application.memberships }}
                 <h5
                   v-if="editable"
                   class="govuk-hint govuk-!-margin-1"
@@ -280,26 +277,442 @@
                   Date
                 </h5>
                 <InformationReviewRenderer
-                  :data="hasMemberships ? application.memberships[membership].date : null"
-                  field="memberships"
-                  extension="date"
-                  :index="membership.value"
+                  :data="application.charteredAssociationBuildingEngineersDate"
                   :edit="editable"
                   type="date"
+                  field="charteredAssociationBuildingEngineersDate"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Number
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.charteredAssociationBuildingEngineersNumber"
+                  :edit="editable"
+                  type="text"
+                  field="charteredAssociationBuildingEngineersNumber"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Information
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.charteredAssociationBuildingEngineersInformation"
+                  :edit="editable"
+                  type="text"
+                  field="charteredAssociationBuildingEngineersInformation"
+                  @changeField="changeProfessionalMembership"
+                />
+              </dd>
+            </div>
+
+            <div
+              v-if="showMembershipOption('chartered-institute-of-building')"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Chartered Institue of Building
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Date
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.charteredInstituteBuildingDate"
+                  :edit="editable"
+                  type="date"
+                  field="charteredInstituteBuildingDate"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Number
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.charteredInstituteBuildingNumber"
+                  :edit="editable"
+                  type="text"
+                  field="charteredInstituteBuildingNumber"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Information
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.charteredInstituteBuildingInformation"
+                  :edit="editable"
+                  type="text"
+                  field="charteredInstituteBuildingInformation"
+                  @changeField="changeProfessionalMembership"
+                />
+              </dd>
+            </div>
+
+            <div
+              v-if="showMembershipOption('chartered-institute-of-environmental-health')"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Chartered Institute of Environmental Health
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Date
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.charteredInstituteEnvironmentalHealthDate"
+                  :edit="editable"
+                  type="date"
+                  field="charteredInstituteEnvironmentalHealthDate"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Number
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.charteredInstituteEnvironmentalHealthNumber"
+                  :edit="editable"
+                  type="text"
+                  field="charteredInstituteEnvironmentalHealthNumber"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Information
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.charteredInstituteEnvironmentalHealthInformation"
+                  :edit="editable"
+                  type="text"
+                  field="charteredInstituteEnvironmentalHealthInformation"
+                  @changeField="changeProfessionalMembership"
+                />
+              </dd>
+            </div>
+
+            <div
+              v-if="showMembershipOption('general-medical-council')"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                General Medical Council
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Date
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.generalMedicalCouncilDate"
+                  :edit="editable"
+                  type="date"
+                  field="generalMedicalCouncilDate"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Number
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.generalMedicalCouncilNumber"
+                  :edit="editable"
+                  type="text"
+                  field="generalMedicalCouncilNumber"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Information
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.generalMedicalCouncilInformation"
+                  :edit="editable"
+                  type="text"
+                  field="generalMedicalCouncilInformation"
+                  @changeField="changeProfessionalMembership"
+                />
+                <ul
+                  v-if="application.generalMedicalCouncilConditional"
+                  class="govuk-list"
+                >
+                  <p class="govuk-hint">
+                    Conditions
+                  </p>
+                  <li
+                    v-if="(application.generalMedicalCouncilConditionalStartDate
+                      && application.generalMedicalCouncilConditionalEndDate) && !editable"
+                  >
+                    {{ application.generalMedicalCouncilConditionalStartDate | formatDate }}
+                    to {{ application.generalMedicalCouncilConditionalEndDate | formatDate }}
+                  </li>
+                  <li
+                    v-if="(application.generalMedicalCouncilConditionalStartDate
+                      && !application.generalMedicalCouncilConditionalEndDate) && !editable"
+                  >
+                    {{ application.generalMedicalCouncilConditionalStartDate | formatDate }} — current
+                  </li>
+                  <li
+                    v-if="editable"
+                  >
+                    <h5
+                      class="govuk-hint govuk-!-margin-1"
+                    >
+                      Start Date
+                    </h5>
+                    <InformationReviewRenderer
+                      :data="application.generalMedicalCouncilConditionalStartDate"
+                      :edit="editable"
+                      type="date"
+                      field="generalMedicalCouncilConditionalStartDate"
+                      @changeField="changeProfessionalMembership"
+                    />
+                    <h5
+                      class="govuk-hint govuk-!-margin-1"
+                    >
+                      End Date
+                    </h5>
+                    <InformationReviewRenderer
+                      :data="application.generalMedicalCouncilConditionalEndDate"
+                      :edit="editable"
+                      type="date"
+                      field="generalMedicalCouncilConditionalEndDate"
+                      @changeField="changeProfessionalMembership"
+                    />
+                  </li>
+                  <li>
+                    <h5
+                      v-if="editable"
+                      class="govuk-hint govuk-!-margin-1"
+                    >
+                      Details
+                    </h5>
+                    <InformationReviewRenderer
+                      :data="application.generalMedicalCouncilConditionalDetails"
+                      :edit="editable"
+                      type="text"
+                      field="generalMedicalCouncilConditionalDetails"
+                      @changeField="changeProfessionalMembership"
+                    />
+                  </li>
+                </ul>
+              </dd>
+            </div>
+
+            <div
+              v-if="showMembershipOption('royal-college-of-psychiatrists')"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Royal College of Psychiatrists
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Date
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalCollegeOfPsychiatristsDate"
+                  :edit="editable"
+                  type="date"
+                  field="royalCollegeOfPsychiatristsDate"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Number
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalCollegeOfPsychiatristsNumber"
+                  :edit="editable"
+                  type="text"
+                  field="royalCollegeOfPsychiatristsNumber"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Information
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalCollegeOfPsychiatristsInformation"
+                  :edit="editable"
+                  type="text"
+                  field="royalCollegeOfPsychiatristsInformation"
+                  @changeField="changeProfessionalMembership"
+                />
+              </dd>
+            </div>
+
+            <div
+              v-if="showMembershipOption('royal-institution-of-chartered-surveyors')"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Royal Institution of Chartered Surveyors
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Date
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalInstitutionCharteredSurveyorsDate"
+                  :edit="editable"
+                  type="date"
+                  field="royalInstitutionCharteredSurveyorsDate"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Number
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalInstitutionCharteredSurveyorsNumber"
+                  :edit="editable"
+                  type="text"
+                  field="royalInstitutionCharteredSurveyorsNumber"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Information
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalInstitutionCharteredSurveyorsInformation"
+                  :edit="editable"
+                  type="text"
+                  field="royalInstitutionCharteredSurveyorsInformation"
+                  @changeField="changeProfessionalMembership"
+                />
+              </dd>
+            </div>
+
+            <div
+              v-if="showMembershipOption('royal-institute-of-british-architects')"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Royal Institute of British Architects
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Date
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalInstituteBritishArchitectsDate"
+                  :edit="editable"
+                  type="date"
+                  field="royalInstituteBritishArchitectsDate"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Number
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalInstituteBritishArchitectsNumber"
+                  :edit="editable"
+                  type="text"
+                  field="royalInstituteBritishArchitectsNumber"
+                  @changeField="changeProfessionalMembership"
+                />
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Information
+                </h5>
+                <InformationReviewRenderer
+                  :data="application.royalInstituteBritishArchitectsInformation"
+                  :edit="editable"
+                  type="text"
+                  field="royalInstituteBritishArchitectsInformation"
+                  @changeField="changeProfessionalMembership"
+                />
+              </dd>
+            </div>
+
+            <div
+              v-for="(membership, key) in otherMemberships"
+              :key="key"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key widerColumn">
+                {{ membership.label }}
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <h5
+                  v-if="editable"
+                  class="govuk-hint govuk-!-margin-1"
+                >
+                  Date
+                </h5>
+                <InformationReviewRenderer
+                  :data="membership.date"
+                  :edit="editable"
+                  :index="membership.label"
+                  extension="date"
+                  type="date"
+                  field="memberships"
                   @changeField="changeQualificationOrMembership"
                 />
                 <h5
                   v-if="editable"
                   class="govuk-hint govuk-!-margin-1"
                 >
-                  Membership Number
+                  Number
                 </h5>
                 <InformationReviewRenderer
-                  :data="hasMemberships ? application.memberships[membership.value].number : null"
-                  field="memberships"
-                  extension="number"
-                  :index="membership.value"
+                  :data="membership.number"
                   :edit="editable"
+                  :index="membership.label"
+                  extension="number"
+                  type="text"
+                  field="memberships"
                   @changeField="changeQualificationOrMembership"
                 />
                 <h5
@@ -309,23 +722,24 @@
                   Information
                 </h5>
                 <InformationReviewRenderer
-                  :data="hasMemberships ? application.memberships[membership.value].information : null"
-                  field="memberships"
-                  extension="information"
-                  :index="membership.value"
+                  :data="membership.information"
                   :edit="editable"
+                  :index="membership.label"
+                  extension="information"
+                  type="text"
+                  field="memberships"
                   @changeField="changeQualificationOrMembership"
                 />
-              </dd>
+              </dd> 
             </div>
           </div>
         </dl>
-        <dl
-          v-else
-          class="govuk-body"
-        >
-          No answers provided
-        </dl>
+      </div>
+      <div
+        v-else
+        class="govuk-body"
+      >
+        No answers provided
       </div>
     </div>
   </div>
@@ -369,7 +783,6 @@ export default {
         qualificationNotComplete: null,
         details: null,
       },
-      hasMemberships: !!this.application.memberships,
       currentIndex: null,
     };
   },
@@ -390,10 +803,22 @@ export default {
       return isNonLegal(this.exercise);
     },
     otherMemberships() {
-      if (Array.isArray(this.exercise.otherMemberships)) {
-        return this.exercise.otherMemberships.filter(membership => this.exercise.memberships.includes(membership.value));
+      // @NOTE this is a bit ugly as we can't just lookup label
+      const selected = {};
+
+      if (this.application.professionalMemberships) {
+        this.application.professionalMemberships.forEach(membership => {
+          if (this.application.memberships[membership]) {
+            const otherMembership = this.exercise.otherMemberships.find(m => m.value === membership);
+            selected[membership] = {
+              ...this.application.memberships[membership],
+              label: otherMembership.label,
+            };
+          }
+        });
       }
-      return null;
+
+      return selected;
     },
     scheduleApplies(){
       return (this.exercise.appliedSchedule == 'schedule-2-3' && this.application.applyingUnderSchedule2Three) ||
@@ -413,7 +838,10 @@ export default {
       return false;
     },
     showMembershipOption(ref) {
-      return this.exercise.memberships.indexOf(ref) >= 0;
+      if (this.application && this.application.professionalMemberships) {
+        return this.application.professionalMemberships.indexOf(ref) >= 0;
+      }
+      return false;
     },
     addQualification() {
       let changedObj = this.application.qualifications || [];
@@ -461,10 +889,12 @@ export default {
         [obj.field]: {
           ...this.application[obj.field], ...changedObj },
       };
+      
+      this.$emit('updateApplication', updatedApplication);
 
-      // console.log(updatedApplication);
-      this.$emit('updateApplication', updatedApplication );
-
+    },
+    changeProfessionalMembership(obj) {
+      this.$emit('updateApplication', obj);
     },
     closeModal() {
       this.currentIndex = null;

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -257,7 +257,7 @@
       <div v-if="hasMemberships || editable">
         <!-- professionalMemberships -->
         <dl
-          v-if="application.professionalMemberships || editable"
+          v-if="exercise.memberships.length || application.professionalMemberships || editable"
         >
           <div
             class="govuk-summary-list govuk-!-margin-bottom-0"
@@ -411,7 +411,6 @@
                 />
               </dd>
             </div>
-
             <div
               v-if="showMembershipOption('general-medical-council')"
               class="govuk-summary-list__row"
@@ -740,8 +739,8 @@
         class="govuk-body"
       >
         No answers provided
+        <hr>
       </div>
-      <hr>
     </div>
   </div>
 </template>
@@ -805,7 +804,9 @@ export default {
       return hasRelevantMemberships(this.exercise);
     },
     hasMemberships() {
-      if (this.application.memberships) {
+      if (this.exercise.memberships) {
+        return this.exercise.memberships.length;
+      } else if (this.application.memberships) {
         return Object.keys(this.application.memberships).length;
       } else if (this.application.professionalMemberships) {
         return this.application.professionalMemberships;
@@ -854,6 +855,8 @@ export default {
     showMembershipOption(ref) {
       if (this.application && this.application.professionalMemberships) {
         return this.application.professionalMemberships.indexOf(ref) >= 0;
+      } else if (this.exercise.memberships) {
+        return this.exercise.memberships.indexOf(ref) >= 0;
       }
       return false;
     },

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -411,6 +411,7 @@
                 />
               </dd>
             </div>
+
             <div
               v-if="showMembershipOption('general-medical-council')"
               class="govuk-summary-list__row"
@@ -675,13 +676,16 @@
               </dd>
             </div>
 
+            {{  }}
+
             <div
-              v-for="(membership, key) in otherMemberships"
+              v-for="(membership, key) in exercise.otherMemberships"
               :key="key"
               class="govuk-summary-list__row"
             >
               <dt class="govuk-summary-list__key widerColumn">
                 {{ membership.label }}
+                <!-- {{ application.memberships[membership.label] }}  -->
               </dt>
               <dd class="govuk-summary-list__value">
                 <h5
@@ -691,7 +695,7 @@
                   Date
                 </h5>
                 <InformationReviewRenderer
-                  :data="membership.date"
+                  :data="application.memberships[membership.label].date || null"
                   :edit="editable"
                   :index="membership.label"
                   extension="date"
@@ -706,7 +710,7 @@
                   Number
                 </h5>
                 <InformationReviewRenderer
-                  :data="membership.number"
+                  :data="application.memberships[membership.label].number"
                   :edit="editable"
                   :index="membership.label"
                   extension="number"
@@ -721,7 +725,7 @@
                   Information
                 </h5>
                 <InformationReviewRenderer
-                  :data="membership.information"
+                  :data="application.memberships[membership.label].information"
                   :edit="editable"
                   :index="membership.label"
                   extension="information"


### PR DESCRIPTION
## What's included?
[An issue was raised regarding General Medical Council membership not showing correctly](https://judicial-appointments.slack.com/archives/C033NNNU5TP/p1651751762050909).
After a review of the `QualificationsAndMembership.vue` code, it appears i had missed the display and edit of certain memberships, GMC being one. 
This PR should fix to include these memberships and allow their editing by admins as per application edits.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Find an application which declares membership to GMC or other membership.
- Observe correct display and edit of given information.

## Risk - how likely is this to impact other areas?
🟠 Medium risk 

## Additional context
See above link to slack.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
