### PR TITLE
#1649 Search functionality for exercises

### DIFF
--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -41,7 +41,10 @@
         >
           All exercises
         </h1>
-        <form @submit.prevent="checkForm">
+        <form
+          class="exercises-table"
+          @submit.prevent="checkForm"
+        >
           <Table
             ref="exercisesTable"
             data-key="id"
@@ -201,3 +204,9 @@ export default {
   },
 };
 </script>
+
+<style>
+.exercises-table input[type="search"] {
+  margin-left: 3px;
+}
+</style>

--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -63,6 +63,11 @@
             ]"
             multi-select
             :selection.sync="selectedItems"
+            :custom-search="{
+              placeholder: 'Search exercise names',
+              handler: exerciseSearch,
+              field: 'name',
+            }"
             @change="getTableData"
           >
             <template #actions>
@@ -187,6 +192,11 @@ export default {
     checkForm() {
       this.$store.dispatch('exerciseCollection/storeItems', { items: this.selectedItems });
       this.$router.push({ name: 'exercises-export' });
+    },
+    exerciseSearch(searchTerm) {
+      return new Promise(resolve => {
+        resolve([searchTerm, searchTerm.toLowerCase(), searchTerm.toUpperCase()]);
+      });
     },
   },
 };


### PR DESCRIPTION
**Author checklist**

- [x] Include primary ticket number in title - e.g. "#123 New styling for widget" - and any additional tickets in description
- [x] Fill in the details below and delete as appropriate
- [x] Be proactive in getting your work approved 💪

---
## What's included?
Add a search to enable a user to search for an exercise by name.

Note: Since Firestore doesn't support fuzzy search, the search value must be exactly same as the exercise name. 

Related issue: [ #65 Bugfix. Search clear button doesn't update value](https://github.com/jac-uk/jac-kit/pull/65)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Preview URL: https://jac-admin-develop--pr1650-feature-1649-search-i301sem8.web.app

1. Go to exercises.
2. Check search functionality.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/174787921-0caaca6a-596c-42c2-a8bf-7dc20e5ae7be.mov

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
