### PR TITLE
#1685 Exercise list default screen

### DIFF
--- a/src/store/exercise/collection.js
+++ b/src/store/exercise/collection.js
@@ -6,9 +6,8 @@ import tableQuery from '@jac-uk/jac-kit/components/Table/tableQuery';
 export default {
   namespaced: true,
   actions: {
-    bind: firestoreAction(({ rootState, state, commit, bindFirestoreRef }, params) => {
+    bind: firestoreAction(({ rootState, state, bindFirestoreRef }, params) => {
       let firestoreRef;
-      if (state.isFavourites === null) { commit('updateFavourites', true); }
       if (state.isFavourites) {
         firestoreRef = firestore
         .collection('exercises')
@@ -45,7 +44,7 @@ export default {
   },
   state: {
     records: [],
-    isFavourites: null,
+    isFavourites: false,
     selectedItems: [],
   },
 };

--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -34,7 +34,7 @@
           v-if="isFavourites"
           class="govuk-heading-xl"
         >
-          Your exercises
+          Favourite exercises
         </h1>
         <h1
           v-else


### PR DESCRIPTION
## What's included?
- [x] Change Your exercises to Favourite exercises
- [x] When this screen loads default it to viewing all exercises and not favourites

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Open exercises page
2. Check it will load all exercises as default
3. Check `Your exercises` is changed to `Favourite exercises`

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/180750932-af65bf77-ee9a-4ebb-a57a-cf79c55c65ad.mov

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
