### PR TITLE
#1686 Candidate details

### DIFF
--- a/src/components/PanelPacks/PanelPacks.vue
+++ b/src/components/PanelPacks/PanelPacks.vue
@@ -25,6 +25,7 @@
           <TableCell :title="tableColumns[0].title">
             <RouterLink
               :to="{ name: `exercise-tasks-${row.type}-view`, params: { panelId: row.id } }"
+              target="_blank"
             >
               {{ row.name }}
             </RouterLink>
@@ -63,6 +64,7 @@
           <TableCell :title="tableColumnsCandidates[0].title">
             <RouterLink
               :to="{ name: 'exercise-application', params: { applicationId: row.id } }"
+              target="_blank"
             >
               {{ row.application.referenceNumber }}
             </RouterLink>

--- a/src/components/PanelPacks/PanelPacks.vue
+++ b/src/components/PanelPacks/PanelPacks.vue
@@ -70,6 +70,7 @@
           <TableCell :title="tableColumnsCandidates[1].title">
             <RouterLink
               :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+              target="_blank"
             >
               {{ row.candidate.fullName }}
             </RouterLink>

--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -48,6 +48,7 @@
           <RouterLink
             class="govuk-link"
             :to="{name: 'exercise-applications-application', params: { applicationId: row.id, status: status }}"
+            target="_blank"
           >
             {{ row.referenceNumber | showAlternative(row.id) }}
           </RouterLink>

--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -53,7 +53,12 @@
           </RouterLink>
         </TableCell>
         <TableCell :title="tableColumns[1].title">
-          {{ row.personalDetails && row.personalDetails.fullName }}
+          <RouterLink
+            :to="{ name: 'candidates-view', params: { id: row.userId } }"
+            target="_blank"
+          >
+            {{ row.personalDetails && row.personalDetails.fullName }}
+          </RouterLink>
         </TableCell>
         <TableCell :title="tableColumns[2].title">
           {{ row.status | lookup }}

--- a/src/views/Exercise/Stages/HandoverList.vue
+++ b/src/views/Exercise/Stages/HandoverList.vue
@@ -54,6 +54,7 @@
           <TableCell :title="tableColumns[1].title">
             <RouterLink
               :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+              target="_blank"
             >
               {{ row.candidate.fullName }}
             </RouterLink>

--- a/src/views/Exercise/Stages/RecommendedList.vue
+++ b/src/views/Exercise/Stages/RecommendedList.vue
@@ -61,6 +61,7 @@
           <TableCell :title="tableColumns[1].title">
             <RouterLink
               :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+              target="_blank"
             >
               {{ row.candidate.fullName }}
             </RouterLink>

--- a/src/views/Exercise/Stages/ReviewList.vue
+++ b/src/views/Exercise/Stages/ReviewList.vue
@@ -66,6 +66,7 @@
           <TableCell :title="tableColumns[1].title">
             <RouterLink
               :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+              target="_blank"
             >
               {{ row.candidate.fullName }}
             </RouterLink>

--- a/src/views/Exercise/Stages/SelectedList.vue
+++ b/src/views/Exercise/Stages/SelectedList.vue
@@ -61,6 +61,7 @@
           <TableCell :title="tableColumns[1].title">
             <RouterLink
               :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+              target="_blank"
             >
               {{ row.candidate.fullName }}
             </RouterLink>

--- a/src/views/Exercise/Stages/ShortlistedList.vue
+++ b/src/views/Exercise/Stages/ShortlistedList.vue
@@ -61,6 +61,7 @@
           <TableCell :title="tableColumns[1].title">
             <RouterLink
               :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+              target="_blank"
             >
               {{ row.candidate.fullName }}
             </RouterLink>

--- a/src/views/Exercise/Tasks/CharacterChecks.vue
+++ b/src/views/Exercise/Tasks/CharacterChecks.vue
@@ -140,7 +140,12 @@
               </RouterLink>
             </TableCell>
             <TableCell :title="tableColumns[1].title">
-              {{ row.candidate.fullName }}
+              <RouterLink
+                :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+                target="_blank"
+              >
+                {{ row.candidate.fullName }}
+              </RouterLink>
             </TableCell>
             <TableCell :title="tableColumns[2].title">
               {{ row.stage }}
@@ -215,7 +220,12 @@
               </RouterLink>
             </TableCell>
             <TableCell :title="tableColumnsCharacterChecksRequested[1].title">
-              {{ row.candidate.fullName }}
+              <RouterLink
+                :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+                target="_blank"
+              >
+                {{ row.candidate.fullName }}
+              </RouterLink>
             </TableCell>
             <TableCell :title="tableColumnsCharacterChecksRequested[2].title">
               {{ row.stage }}
@@ -269,7 +279,12 @@
               </RouterLink>
             </TableCell>
             <TableCell :title="tableColumns[1].title">
-              {{ row.candidate.fullName }}
+              <RouterLink
+                :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+                target="_blank"
+              >
+                {{ row.candidate.fullName }}
+              </RouterLink>
             </TableCell>
             <TableCell :title="tableColumns[2].title">
               {{ row.stage }}

--- a/src/views/Exercise/Tasks/IndependentAssessments.vue
+++ b/src/views/Exercise/Tasks/IndependentAssessments.vue
@@ -135,6 +135,7 @@
             <TableCell :title="tableColumns[1].title">
               <RouterLink
                 :to="{ name: 'candidates-view', params: { id: row.candidate.id } }"
+                target="_blank"
               >
                 {{ row.candidate.fullName }}
               </RouterLink>


### PR DESCRIPTION
## What's included?
The Candidate Details screen is linked to from some places in the system but not others. Some Candidate names are a link to the profile and we would like to make all link to the profile and open in a separate tab.

Note: this issue is related to [Application link open in new tab #71](https://github.com/jac-uk/jac-kit/pull/71).

- [x] Tasks - Independent Assessments - the candidate name is a link and opens the candidate details screen but this needs to open in a new tab.
- [x] Tasks - Character checks - Make the Name link to the candidate details and open in a new tab
- [x] Tasks - Selection day - Candidates tab make the candidates details open in a new tab
- [x] Stages - Make the candidates details open in a new tab
- [x] Applications - Make the Name link to the candidate details and open in a new tab

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Click on a candidate name link on `Character checks`, `Selection day`, `Stages`, `Applications` and see if it opens candidate details in a new tab

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/180766632-9066f5bb-6ffb-49aa-af92-2a4ecbe570f3.mov

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
