### PR TITLE
#1694 Add commas to numbers

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -81,6 +81,11 @@ const lookup = (value) => {
   return returnValue;
 };
 
+const formatNumber = (value) => {
+  return typeof value === 'number' ? value.toLocaleString('en-GB') : value;
+};
+
 export {
-  lookup
+  lookup,
+  formatNumber
 };

--- a/src/views/Candidates/CandidatesList.vue
+++ b/src/views/Candidates/CandidatesList.vue
@@ -29,7 +29,7 @@
           {{ new Date(row.created) | formatDate('long') }}
         </TableCell>
         <TableCell :title="tableColumns[2].title">
-          {{ countApplications(row) }}
+          {{ countApplications(row).toLocaleString('en-GB') }}
         </TableCell>
       </template>
     </Table>

--- a/src/views/Candidates/CandidatesList.vue
+++ b/src/views/Candidates/CandidatesList.vue
@@ -29,7 +29,7 @@
           {{ new Date(row.created) | formatDate('long') }}
         </TableCell>
         <TableCell :title="tableColumns[2].title">
-          {{ countApplications(row).toLocaleString('en-GB') }}
+          {{ countApplications(row) | formatNumber }}
         </TableCell>
       </template>
     </Table>

--- a/src/views/Exercise/Applications.vue
+++ b/src/views/Exercise/Applications.vue
@@ -32,15 +32,15 @@ export default {
       }
       const sideNavigation = [
         {
-          title: `Draft (${draft})`,
+          title: `Draft (${draft.toLocaleString('en-GB')})`,
           path: `${path}/draft`,
         },
         {
-          title: `Applied (${applied})`,
+          title: `Applied (${applied.toLocaleString('en-GB')})`,
           path: `${path}/applied`,
         },
         {
-          title: `Withdrawn (${withdrawn})`,
+          title: `Withdrawn (${withdrawn.toLocaleString('en-GB')})`,
           path: `${path}/withdrawn`,
         },
       ];

--- a/src/views/Exercise/Applications.vue
+++ b/src/views/Exercise/Applications.vue
@@ -13,6 +13,7 @@
 
 <script>
 import SideNavigation from '@/components/Navigation/SideNavigation';
+import { formatNumber } from '@/filters';
 
 export default {
   components: {
@@ -32,15 +33,15 @@ export default {
       }
       const sideNavigation = [
         {
-          title: `Draft (${draft.toLocaleString('en-GB')})`,
+          title: `Draft (${formatNumber(draft)})`,
           path: `${path}/draft`,
         },
         {
-          title: `Applied (${applied.toLocaleString('en-GB')})`,
+          title: `Applied (${formatNumber(applied)})`,
           path: `${path}/applied`,
         },
         {
-          title: `Withdrawn (${withdrawn.toLocaleString('en-GB')})`,
+          title: `Withdrawn (${formatNumber(withdrawn)})`,
           path: `${path}/withdrawn`,
         },
       ];

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -12,7 +12,7 @@
           Immediate start (S87)
           <span
             class="display-block govuk-heading-l govuk-!-margin-top-1"
-          >{{ exercise.immediateStart.toLocaleString('en-GB') }}</span>
+          >{{ exercise.immediateStart | formatNumber }}</span>
         </p>
       </div>
 
@@ -30,13 +30,13 @@
           <div class="govuk-grid-column-one-half">
             <p class="govuk-body">
               Draft
-              <span class="govuk-heading-l govuk-!-margin-top-1">{{ draftApplications.toLocaleString('en-GB') }}</span>
+              <span class="govuk-heading-l govuk-!-margin-top-1">{{ draftApplications | formatNumber }}</span>
             </p>
           </div>
           <div class="govuk-grid-column-one-half">
             <p class="govuk-body">
               Applied
-              <span class="govuk-heading-l govuk-!-margin-top-1">{{ appliedApplications.toLocaleString('en-GB') }}</span>
+              <span class="govuk-heading-l govuk-!-margin-top-1">{{ appliedApplications | formatNumber }}</span>
             </p>
           </div>
         </div>

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -12,7 +12,7 @@
           Immediate start (S87)
           <span
             class="display-block govuk-heading-l govuk-!-margin-top-1"
-          >{{ exercise.immediateStart }}</span>
+          >{{ exercise.immediateStart.toLocaleString('en-GB') }}</span>
         </p>
       </div>
 
@@ -30,13 +30,13 @@
           <div class="govuk-grid-column-one-half">
             <p class="govuk-body">
               Draft
-              <span class="govuk-heading-l govuk-!-margin-top-1">{{ draftApplications }}</span>
+              <span class="govuk-heading-l govuk-!-margin-top-1">{{ draftApplications.toLocaleString('en-GB') }}</span>
             </p>
           </div>
           <div class="govuk-grid-column-one-half">
             <p class="govuk-body">
               Applied
-              <span class="govuk-heading-l govuk-!-margin-top-1">{{ appliedApplications }}</span>
+              <span class="govuk-heading-l govuk-!-margin-top-1">{{ appliedApplications.toLocaleString('en-GB') }}</span>
             </p>
           </div>
         </div>

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -251,7 +251,7 @@
                 <td
                   class="govuk-table__cell govuk-table__cell--numeric"
                 >
-                  {{ row.toLocaleString('en-GB') }}
+                  {{ row | formatNumber }}
                 </td>
               </tr>
             </tbody>

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -251,7 +251,7 @@
                 <td
                   class="govuk-table__cell govuk-table__cell--numeric"
                 >
-                  {{ row }}
+                  {{ row.toLocaleString('en-GB') }}
                 </td>
               </tr>
             </tbody>

--- a/src/views/Exercise/Reports/Diversity.vue
+++ b/src/views/Exercise/Reports/Diversity.vue
@@ -65,7 +65,7 @@
               Total applications
             </span>
             <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-              {{ diversity.totalApplications.toLocaleString('en-GB') }}
+              {{ diversity.totalApplications | formatNumber }}
             </h2>
           </div>
         </div>

--- a/src/views/Exercise/Reports/Diversity.vue
+++ b/src/views/Exercise/Reports/Diversity.vue
@@ -65,7 +65,7 @@
               Total applications
             </span>
             <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-              {{ diversity.totalApplications }}
+              {{ diversity.totalApplications.toLocaleString('en-GB') }}
             </h2>
           </div>
         </div>

--- a/src/views/Exercise/Reports/Handover.vue
+++ b/src/views/Exercise/Reports/Handover.vue
@@ -54,7 +54,7 @@
             Approved for immediate appointment
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ totalApplicationRecords }}
+            {{ totalApplicationRecords.toLocaleString('en-GB') }}
           </h2>
         </div>
       </div>

--- a/src/views/Exercise/Reports/Handover.vue
+++ b/src/views/Exercise/Reports/Handover.vue
@@ -54,7 +54,7 @@
             Approved for immediate appointment
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ totalApplicationRecords.toLocaleString('en-GB') }}
+            {{ totalApplicationRecords | formatNumber }}
           </h2>
         </div>
       </div>

--- a/src/views/Exercise/Reports/Outreach.vue
+++ b/src/views/Exercise/Reports/Outreach.vue
@@ -65,7 +65,7 @@
               Total applications
             </span>
             <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-              {{ report.totalApplications }}
+              {{ report.totalApplications.toLocaleString('en-GB') }}
             </h2>
           </div>
         </div>

--- a/src/views/Exercise/Reports/Outreach.vue
+++ b/src/views/Exercise/Reports/Outreach.vue
@@ -65,7 +65,7 @@
               Total applications
             </span>
             <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-              {{ report.totalApplications.toLocaleString('en-GB') }}
+              {{ report.totalApplications | formatNumber }}
             </h2>
           </div>
         </div>

--- a/src/views/Exercise/Reports/ReasonableAdjustments.vue
+++ b/src/views/Exercise/Reports/ReasonableAdjustments.vue
@@ -49,7 +49,7 @@
             Total applications
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ report.totalApplications }}
+            {{ report.totalApplications.toLocaleString('en-GB') }}
           </h2>
         </div>
       </div>
@@ -59,7 +59,7 @@
             Reasonable adjustments requests
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ report.rows.length }}
+            {{ report.rows.length.toLocaleString('en-GB') }}
           </h2>
         </div>
       </div>

--- a/src/views/Exercise/Reports/ReasonableAdjustments.vue
+++ b/src/views/Exercise/Reports/ReasonableAdjustments.vue
@@ -49,7 +49,7 @@
             Total applications
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ report.totalApplications.toLocaleString('en-GB') }}
+            {{ report.totalApplications | formatNumber }}
           </h2>
         </div>
       </div>
@@ -59,7 +59,7 @@
             Reasonable adjustments requests
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ report.rows.length.toLocaleString('en-GB') }}
+            {{ report.rows.length | formatNumber }}
           </h2>
         </div>
       </div>

--- a/src/views/Exercise/Stages.vue
+++ b/src/views/Exercise/Stages.vue
@@ -13,6 +13,8 @@
 
 <script>
 import SideNavigation from '@/components/Navigation/SideNavigation';
+import { formatNumber } from '@/filters';
+
 export default {
   components: {
     SideNavigation,
@@ -35,23 +37,23 @@ export default {
       }
       const sideNavigation = [
         {
-          title: `Review (${review.toLocaleString('en-GB')})`,
+          title: `Review (${formatNumber(review)})`,
           path: `${path}/review`,
         },
         {
-          title: `Shortlisted (${shortlisted.toLocaleString('en-GB')})`,
+          title: `Shortlisted (${formatNumber(shortlisted)})`,
           path: `${path}/shortlisted`,
         },
         {
-          title: `Selected (${selected.toLocaleString('en-GB')})`,
+          title: `Selected (${formatNumber(selected)})`,
           path: `${path}/selected`,
         },
         {
-          title: `Recommended (${recommended.toLocaleString('en-GB')})`,
+          title: `Recommended (${formatNumber(recommended)})`,
           path: `${path}/recommended`,
         },
         {
-          title: `Handover (${handover.toLocaleString('en-GB')})`,
+          title: `Handover (${formatNumber(handover)})`,
           path: `${path}/handover`,
         },
       ];

--- a/src/views/Exercise/Stages.vue
+++ b/src/views/Exercise/Stages.vue
@@ -35,23 +35,23 @@ export default {
       }
       const sideNavigation = [
         {
-          title: `Review (${review})`,
+          title: `Review (${review.toLocaleString('en-GB')})`,
           path: `${path}/review`,
         },
         {
-          title: `Shortlisted (${shortlisted})`,
+          title: `Shortlisted (${shortlisted.toLocaleString('en-GB')})`,
           path: `${path}/shortlisted`,
         },
         {
-          title: `Selected (${selected})`,
+          title: `Selected (${selected.toLocaleString('en-GB')})`,
           path: `${path}/selected`,
         },
         {
-          title: `Recommended (${recommended})`,
+          title: `Recommended (${recommended.toLocaleString('en-GB')})`,
           path: `${path}/recommended`,
         },
         {
-          title: `Handover (${handover})`,
+          title: `Handover (${handover.toLocaleString('en-GB')})`,
           path: `${path}/handover`,
         },
       ];

--- a/src/views/Exercise/Tasks/IndependentAssessments.vue
+++ b/src/views/Exercise/Tasks/IndependentAssessments.vue
@@ -13,7 +13,7 @@
             Sent
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ assessmentsSent }}
+            {{ assessmentsSent.toLocaleString('en-GB') }}
           </h2>
         </div>
       </div>
@@ -21,7 +21,7 @@
         <div class="panel govuk-!-margin-bottom-9">
           <span class="govuk-caption-m">Completed</span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ assessmentsCompleted }}
+            {{ assessmentsCompleted.toLocaleString('en-GB') }}
           </h2>
         </div>
       </div>
@@ -273,20 +273,20 @@
               v-if="applicationRecordCounts.review"
               value="review"
             >
-              Review ({{ applicationRecordCounts.review }})
+              Review ({{ applicationRecordCounts.review.toLocaleString('en-GB') }})
             </option>
             <option
               v-if="applicationRecordCounts.shortlisted"
               value="shortlisted"
             >
-              Shortlisted ({{ applicationRecordCounts.shortlisted }})
+              Shortlisted ({{ applicationRecordCounts.shortlisted.toLocaleString('en-GB') }})
             </option>
 
             <option
               v-if="applicationRecordCounts.selected"
               value="selected"
             >
-              Selected ({{ applicationRecordCounts.selected }})
+              Selected ({{ applicationRecordCounts.selected.toLocaleString('en-GB') }})
             </option>
           </select>
 

--- a/src/views/Exercise/Tasks/IndependentAssessments.vue
+++ b/src/views/Exercise/Tasks/IndependentAssessments.vue
@@ -13,7 +13,7 @@
             Sent
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ assessmentsSent.toLocaleString('en-GB') }}
+            {{ assessmentsSent | formatNumber }}
           </h2>
         </div>
       </div>
@@ -21,7 +21,7 @@
         <div class="panel govuk-!-margin-bottom-9">
           <span class="govuk-caption-m">Completed</span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ assessmentsCompleted.toLocaleString('en-GB') }}
+            {{ assessmentsCompleted | formatNumber }}
           </h2>
         </div>
       </div>
@@ -273,20 +273,20 @@
               v-if="applicationRecordCounts.review"
               value="review"
             >
-              Review ({{ applicationRecordCounts.review.toLocaleString('en-GB') }})
+              Review ({{ applicationRecordCounts.review | formatNumber }})
             </option>
             <option
               v-if="applicationRecordCounts.shortlisted"
               value="shortlisted"
             >
-              Shortlisted ({{ applicationRecordCounts.shortlisted.toLocaleString('en-GB') }})
+              Shortlisted ({{ applicationRecordCounts.shortlisted | formatNumber }})
             </option>
 
             <option
               v-if="applicationRecordCounts.selected"
               value="selected"
             >
-              Selected ({{ applicationRecordCounts.selected.toLocaleString('en-GB') }})
+              Selected ({{ applicationRecordCounts.selected | formatNumber }})
             </option>
           </select>
 

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -72,7 +72,7 @@
           </RouterLink>
           <span
             class="display-block govuk-heading-l govuk-!-margin-top-1"
-          >{{ qualifyingTest.counts.initialised }} / {{ qualifyingTest.counts.activated }}</span>
+          >{{ qualifyingTest.counts.initialised.toLocaleString('en-GB') }} / {{ qualifyingTest.counts.activated.toLocaleString('en-GB') }}</span>
         </p>
         <p class="govuk-body">
           <RouterLink
@@ -82,7 +82,7 @@
           </RouterLink> / Auto-submitted
           <span
             class="display-block govuk-heading-l govuk-!-margin-top-1"
-          >{{ qualifyingTest.counts.completed }} / {{ qualifyingTest.counts.outOfTime }}</span>
+          >{{ qualifyingTest.counts.completed.toLocaleString('en-GB') }} / {{ qualifyingTest.counts.outOfTime.toLocaleString('en-GB') }}</span>
         </p>
       </div>
     </div>
@@ -103,7 +103,7 @@
           >
             Started
           </RouterLink>
-          <span class="govuk-heading-l govuk-!-margin-top-1">{{ qualifyingTest.counts.started }}</span>
+          <span class="govuk-heading-l govuk-!-margin-top-1">{{ qualifyingTest.counts.started.toLocaleString('en-GB') }}</span>
         </p>
         <p class="govuk-body">
           <RouterLink
@@ -111,7 +111,7 @@
           >
             In Progress
           </RouterLink>
-          <span class="govuk-heading-l govuk-!-margin-top-1">{{ qualifyingTest.counts.inProgress }}</span>
+          <span class="govuk-heading-l govuk-!-margin-top-1">{{ qualifyingTest.counts.inProgress.toLocaleString('en-GB') }}</span>
         </p>
       </div>
     </div>
@@ -187,19 +187,19 @@
                 v-if="applicationRecordCounts.review"
                 value="review"
               >
-                Review ({{ applicationRecordCounts.review }})
+                Review ({{ applicationRecordCounts.review.toLocaleString('en-GB') }})
               </option>
               <option
                 v-if="applicationRecordCounts.shortlisted"
                 value="shortlisted"
               >
-                Shortlisted ({{ applicationRecordCounts.shortlisted }})
+                Shortlisted ({{ applicationRecordCounts.shortlisted.toLocaleString('en-GB') }})
               </option>
               <option
                 v-if="applicationRecordCounts.selected"
                 value="selected"
               >
-                Selected ({{ applicationRecordCounts.selected }})
+                Selected ({{ applicationRecordCounts.selected.toLocaleString('en-GB') }})
               </option>
             </Select>
             <Select
@@ -214,19 +214,19 @@
                 v-if="applicationRecordCounts.reviewEMP"
                 value="review"
               >
-                Review ({{ applicationRecordCounts.reviewEMP }})
+                Review ({{ applicationRecordCounts.reviewEMP.toLocaleString('en-GB') }})
               </option>
               <option
                 v-if="applicationRecordCounts.shortlistedEMP"
                 value="shortlisted"
               >
-                Shortlisted ({{ applicationRecordCounts.shortlistedEMP }})
+                Shortlisted ({{ applicationRecordCounts.shortlistedEMP.toLocaleString('en-GB') }})
               </option>
               <option
                 v-if="applicationRecordCounts.selectedEMP"
                 value="selected"
               >
-                Selected ({{ applicationRecordCounts.selectedEMP }})
+                Selected ({{ applicationRecordCounts.selectedEMP.toLocaleString('en-GB') }})
               </option>
             </Select>
           </div>

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/View.vue
@@ -72,7 +72,7 @@
           </RouterLink>
           <span
             class="display-block govuk-heading-l govuk-!-margin-top-1"
-          >{{ qualifyingTest.counts.initialised.toLocaleString('en-GB') }} / {{ qualifyingTest.counts.activated.toLocaleString('en-GB') }}</span>
+          >{{ qualifyingTest.counts.initialised | formatNumber }} / {{ qualifyingTest.counts.activated | formatNumber }}</span>
         </p>
         <p class="govuk-body">
           <RouterLink
@@ -82,7 +82,7 @@
           </RouterLink> / Auto-submitted
           <span
             class="display-block govuk-heading-l govuk-!-margin-top-1"
-          >{{ qualifyingTest.counts.completed.toLocaleString('en-GB') }} / {{ qualifyingTest.counts.outOfTime.toLocaleString('en-GB') }}</span>
+          >{{ qualifyingTest.counts.completed | formatNumber }} / {{ qualifyingTest.counts.outOfTime | formatNumber }}</span>
         </p>
       </div>
     </div>
@@ -103,7 +103,7 @@
           >
             Started
           </RouterLink>
-          <span class="govuk-heading-l govuk-!-margin-top-1">{{ qualifyingTest.counts.started.toLocaleString('en-GB') }}</span>
+          <span class="govuk-heading-l govuk-!-margin-top-1">{{ qualifyingTest.counts.started | formatNumber }}</span>
         </p>
         <p class="govuk-body">
           <RouterLink
@@ -111,7 +111,7 @@
           >
             In Progress
           </RouterLink>
-          <span class="govuk-heading-l govuk-!-margin-top-1">{{ qualifyingTest.counts.inProgress.toLocaleString('en-GB') }}</span>
+          <span class="govuk-heading-l govuk-!-margin-top-1">{{ qualifyingTest.counts.inProgress | formatNumber }}</span>
         </p>
       </div>
     </div>
@@ -187,19 +187,19 @@
                 v-if="applicationRecordCounts.review"
                 value="review"
               >
-                Review ({{ applicationRecordCounts.review.toLocaleString('en-GB') }})
+                Review ({{ applicationRecordCounts.review | formatNumber }})
               </option>
               <option
                 v-if="applicationRecordCounts.shortlisted"
                 value="shortlisted"
               >
-                Shortlisted ({{ applicationRecordCounts.shortlisted.toLocaleString('en-GB') }})
+                Shortlisted ({{ applicationRecordCounts.shortlisted | formatNumber }})
               </option>
               <option
                 v-if="applicationRecordCounts.selected"
                 value="selected"
               >
-                Selected ({{ applicationRecordCounts.selected.toLocaleString('en-GB') }})
+                Selected ({{ applicationRecordCounts.selected | formatNumber }})
               </option>
             </Select>
             <Select
@@ -214,19 +214,19 @@
                 v-if="applicationRecordCounts.reviewEMP"
                 value="review"
               >
-                Review ({{ applicationRecordCounts.reviewEMP.toLocaleString('en-GB') }})
+                Review ({{ applicationRecordCounts.reviewEMP | formatNumber }})
               </option>
               <option
                 v-if="applicationRecordCounts.shortlistedEMP"
                 value="shortlisted"
               >
-                Shortlisted ({{ applicationRecordCounts.shortlistedEMP.toLocaleString('en-GB') }})
+                Shortlisted ({{ applicationRecordCounts.shortlistedEMP | formatNumber }})
               </option>
               <option
                 v-if="applicationRecordCounts.selectedEMP"
                 value="selected"
               >
-                Selected ({{ applicationRecordCounts.selectedEMP.toLocaleString('en-GB') }})
+                Selected ({{ applicationRecordCounts.selectedEMP | formatNumber }})
               </option>
             </Select>
           </div>

--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -115,7 +115,7 @@
                 class="govuk-table__cell--numeric"
                 :title="tableColumns[4].title"
               >
-                {{ row.applicationsCount }}
+                {{ row.applicationsCount.toLocaleString('en-GB') }}
               </TableCell>
             </template>
           </Table>

--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -115,7 +115,7 @@
                 class="govuk-table__cell--numeric"
                 :title="tableColumns[4].title"
               >
-                {{ row.applicationsCount.toLocaleString('en-GB') }}
+                {{ row.applicationsCount | formatNumber }}
               </TableCell>
             </template>
           </Table>

--- a/tests/unit/filters.spec.js
+++ b/tests/unit/filters.spec.js
@@ -1,0 +1,13 @@
+import { formatNumber } from '@/filters';
+
+describe('filters', () => {
+  it('formatNumber', () => {
+    expect(formatNumber(100)).toEqual('100');
+    expect(formatNumber(1000)).toEqual('1,000');
+    expect(formatNumber(100000)).toEqual('100,000');
+    expect(formatNumber(1000000)).toEqual('1,000,000');
+    expect(formatNumber('1000')).toEqual('1000');
+    expect(formatNumber(null)).toEqual(null);
+    expect(formatNumber(undefined)).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
## What's included?
Add commas to numbers so they are easier to read, e.g., `1000 -> 1,000`.

This will be anywhere we display numbers on the platform:
- [x] Applicant count on the Exercises table
- [x] Applicant count on the Candidates table
- [x] Overview page
- [x] Applications menu
- [x] Stages menu
- [x] Reports

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the admin platform and check number display

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/181252919-f982bec6-97c2-47dd-b256-17bdf9f6f5b6.mov

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
