### PR TITLE
#1693 Bugfix: handover report table is stuck in loading state

### DIFF
--- a/src/views/Exercise/Reports/Handover.vue
+++ b/src/views/Exercise/Reports/Handover.vue
@@ -74,6 +74,7 @@
       :data="report.rows"
       :columns="tableColumns"
       :page-size="1000"
+      local-data
       @change="getTableData"
     >
       <template #row="{row}">


### PR DESCRIPTION
## What's included?
Fix the table loading state on handover report.

Note: when Handover.vue is created, it will bind to firestore document and get the report data before Table component is rendered. And when Table component is mounted, it will set loading state to true. That's why the table already got data but the loading state is still showing. 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to Handover report of an exercise
2. Check the table is not stuck in loading state

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/181294424-f3b8a7ea-ec86-444c-93b8-81840f3b02fe.mov

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
