### PR TITLE
Hotfix: #1705 Panel name link not working

### DIFF
--- a/src/components/PanelPacks/PanelPacks.vue
+++ b/src/components/PanelPacks/PanelPacks.vue
@@ -25,7 +25,6 @@
           <TableCell :title="tableColumns[0].title">
             <RouterLink
               :to="{ name: `exercise-tasks-${row.type}-view`, params: { panelId: row.id } }"
-              target="_blank"
             >
               {{ row.name }}
             </RouterLink>


### PR DESCRIPTION
## What's included?
When click the panel name link it just loops back around to the same screen. The current solution is to remove the `target="_blank"` on the anchor link.

Note: when `PanelsView` component is created, it will check the selected panel state and redirect to the previous page if it's empty. That's why the link will loop back when we open it in a new tab.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to Task `Sift` or `Selection day` page and check if panel name link works.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/182655577-293138ed-39db-47f1-82e2-c24a9c6e0243.mov

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
