### PR TITLE
#165 Change of wording for IAs

### DIFF
--- a/src/helpersTMP/Timeline/exerciseTimeline.js
+++ b/src/helpersTMP/Timeline/exerciseTimeline.js
@@ -197,7 +197,7 @@ const exerciseTimeline = (data) => {
         {
           entry: 'Return date for independent assessments',
           date: data.independentAssessmentsReturnDate,
-          dateString: getDateString(data.independentAssessmentsReturnDate),
+          dateString: getDateString(data.independentAssessmentsReturnDate, 'hour'),
         }
       );
     }

--- a/src/helpersTMP/date.js
+++ b/src/helpersTMP/date.js
@@ -35,9 +35,14 @@ const formatDate = (date, type) => {
   }
 
   const month = date.toLocaleString('en-GB', { month: 'long' });
+  const hour = date.toLocaleString('en-GB', { hour: 'numeric', hour12: true }).toLowerCase();
 
   if (type && type === 'month') {
     return `${month} ${date.getFullYear()}`;
+  }
+
+  if (type && type === 'hour') {
+    return `${hour} on ${date.getDate()} ${month} ${date.getFullYear()}`;
   }
 
   return `${date.getDate()} ${month} ${date.getFullYear()}`;


### PR DESCRIPTION
## What's included?
Update the wording of "Return date for independent assessments" in the timeline. E.g. `1 pm on 1 October 2022`.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the timeline of an exercise and check the date format of "Return date for independent assessments".

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Screenshot:

<img width="790" alt="admin #165 Change of wording for IAs" src="https://user-images.githubusercontent.com/79906532/197200383-21079d2a-4d6d-4eb3-b19e-b6bb855caa2b.png">

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
