### PR TITLE
#1762 Admin Amending Application Data

### DIFF
--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -33,12 +33,9 @@
             </h1>
           </div>
 
-          <div
-            v-if="hasPermissions([PERMISSIONS.applications.permissions.canUpdateApplications.value])"
-            class="govuk-grid-column-one-half text-right print-none"
-          >
+          <div class="govuk-grid-column-one-half text-right print-none">
             <span
-              v-if="activeTab == 'full'"
+              v-if="activeTab == 'full' && hasPermissions([PERMISSIONS.applications.permissions.canUpdateApplications.value])"
             >
               <span
                 class="govuk-!-margin-left-4"
@@ -199,11 +196,11 @@
             <PersonalDetailsSummary
               :user-id="application.userId"
               :personal-details="application.personalDetails || {}"
-              :editable="editMode"
+              :editable="editable"
               @update="changePersonalDetails"
             />
             <CharacterInformationSummary
-              :editable="(editMode && authorisedToPerformAction)"
+              :editable="editable"
               :character-information="correctCharacterInformation"
               :version="applicationVersion"
               @updateApplication="changeApplication"
@@ -211,26 +208,26 @@
             <EqualityAndDiversityInformationSummary
               :application="application"
               :equality-and-diversity-survey="application.equalityAndDiversitySurvey || {}"
-              :editable="(editMode && authorisedToPerformAction)"
+              :editable="editable"
               @updateApplication="changeApplication"
             />
             <PreferencesSummary
               :application="application"
               :exercise="exercise"
-              :editable="(editMode && authorisedToPerformAction)"
+              :editable="editable"
               :is-panel-view="isPanelView"
               @updateApplication="changeApplication"
             />
             <QualificationsAndMembershipsSummary
               :application="application"
               :exercise="exercise"
-              :editable="(editMode && authorisedToPerformAction)"
+              :editable="editable"
               @updateApplication="changeApplication"
             />
             <ExperienceSummary
               :application="application"
               :exercise="exercise"
-              :editable="(editMode && authorisedToPerformAction)"
+              :editable="editable"
               :is-panel-view="isPanelView"
               @updateApplication="changeApplication"
             />
@@ -238,14 +235,14 @@
               :application="application"
               :application-id="applicationId"
               :exercise="exercise"
-              :editable="editMode"
+              :editable="editable"
               :is-panel-view="isPanelView"
             />
             <AssessmentsSummary
               :application="application"
               :exercise="exercise"
-              :editable="editMode"
-              :authorised-to-perform-action="authorisedToPerformAction"
+              :editable="editable"
+              :authorised-to-perform-action="editable"
               :is-panel-view="isPanelView"
               @updateApplication="changeApplication"
             />
@@ -304,7 +301,6 @@ import InformationReviewRenderer from '@/components/Page/InformationReviewRender
 import PageNotFound from '@/views/Errors/PageNotFound';
 import splitFullName from '@jac-uk/jac-kit/helpers/splitFullName';
 import { logEvent } from '@/helpers/logEvent';
-import { authorisedToPerformAction }  from '@/helpers/authUsers';
 import CharacterChecks from '@/views/Exercise/Tasks/CharacterChecks';
 import {
   isLegal,
@@ -338,7 +334,6 @@ export default {
   mixins: [permissionMixin],
   data() {
     return {
-      authorisedToPerformAction: false,
       editMode: false,
       activeTab: 'full',
       dropDownExpanded: false,
@@ -381,7 +376,7 @@ export default {
       return tabs;
     },
     editable() {
-      return this.editMode && this.authorisedToPerformAction;
+      return this.editMode && this.hasPermissions([this.PERMISSIONS.applications.permissions.canUpdateApplications.value]);
     },
     exercise() {
       return this.$store.state.exerciseDocument.record;
@@ -482,7 +477,6 @@ export default {
   },
   methods: {
     async pageLoad() {
-      this.authorisedToPerformAction = await authorisedToPerformAction(this.$store.state.auth.currentUser.email);
       if (this.$route.params.tab) {
         this.activeTab = this.$route.params.tab;
       }


### PR DESCRIPTION
## What's included?
Allow admins to amend applications by removing hard-coded email permission control. The following user roles will be able to perform the amending action:
- Operations Team Member
- Operations Senior Manager
- Digital Super User

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to an application of an exercise.
2. Check if the current user which the user role is one of above roles can amend the application.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
User role: Operations Senior Manager

https://user-images.githubusercontent.com/79906532/198006819-28b4f954-420d-4ac3-8e5e-585098c33e5f.mov

User role: Other JAC Staff

https://user-images.githubusercontent.com/79906532/198006848-25ddab23-b0b7-41b1-be02-8fc399e6df94.mov

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
