### PR TITLE
#1770 Admin Amending Email Addresses for Candidates

### DIFF
--- a/src/views/Candidates/Actions.vue
+++ b/src/views/Candidates/Actions.vue
@@ -63,12 +63,11 @@
 </template>
 
 <script>
-import firebase from '@firebase/app';
 import { functions } from '@/firebase';
-import { authorisedToPerformAction }  from '@/helpers/authUsers';
 import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField';
 import Banner from '@jac-uk/jac-kit/draftComponents/Banner';
 import Form from '@jac-uk/jac-kit/draftComponents/Form/Form';
+import permissionMixin from '@/permissionMixin';
 
 export default {
   name: 'Actions',
@@ -77,6 +76,7 @@ export default {
     Banner,
   },
   extends: Form,
+  mixins: [permissionMixin],
   props: {
     candidateId: {
       type: String,
@@ -85,7 +85,6 @@ export default {
   },
   data() {
     return {
-      authorisedToPerformAction: false,
       currentEmailAddress: 'unknown',
       newEmailAddress: null,
       message: '',
@@ -99,11 +98,7 @@ export default {
     },
   },
   async created() {
-    const email = firebase.auth().currentUser.email;
-    this.authorisedToPerformAction = await authorisedToPerformAction(email);
-    if (this.authorisedToPerformAction) {
-      this.getCurrentEmailAddress(this.candidateId);
-    }
+    this.getCurrentEmailAddress(this.candidateId);
   },
   methods: {
     async getCurrentEmailAddress() {
@@ -124,7 +119,7 @@ export default {
     async save() {
       this.validate();
       if (this.isValid()) {
-        if (this.authorisedToPerformAction) {
+        if (this.hasPermissions([this.PERMISSIONS.candidates.permissions.canUpdateCandidates.value])) {
           this.submitted = true;
           try {
             const response = await functions.httpsCallable('updateEmailAddress')({

--- a/src/views/Candidates/CandidatesView.vue
+++ b/src/views/Candidates/CandidatesView.vue
@@ -65,7 +65,7 @@
       <Applications :candidate-id="candidateId" />
     </div>
     <div
-      v-if="activeTab === 'actions' && authorisedUser"
+      v-if="activeTab === 'actions'"
     >
       <Actions :candidate-id="getUserId" />
     </div>
@@ -73,7 +73,6 @@
 </template>
 
 <script>
-import firebase from '@firebase/app';
 import TabsList from '@jac-uk/jac-kit/draftComponents/TabsList';
 import Notes from '@/components/Notes/Notes';
 import Applications from '@jac-uk/jac-kit/draftComponents/Candidates/Applications';
@@ -81,7 +80,6 @@ import PersonalDetailsSummary from '@/views/InformationReview/PersonalDetailsSum
 import CharacterInformationSummary from '@/views/InformationReview/CharacterInformationSummary';
 import EqualityAndDiversity from '@jac-uk/jac-kit/draftComponents/Candidates/EqualityAndDiversity';
 import Actions from '@/views/Candidates/Actions';
-import { authorisedToPerformAction }  from '@/helpers/authUsers';
 import permissionMixin from '@/permissionMixin';
 
 export default {
@@ -98,7 +96,6 @@ export default {
   mixins: [permissionMixin],
   data() {
     return {
-      authorisedToPerformAction: false,
       editMode: false,
       activeTab: 'details',
       candidateId: '',
@@ -129,9 +126,6 @@ export default {
         });
       return tabs;
     },
-    authorisedUser(){
-      return this.authorisedToPerformAction;
-    },
     candidateRecord() {
       return this.$store.state.candidates.record;
     },
@@ -161,8 +155,6 @@ export default {
     this.candidateId = this.getUserId;
     this.$store.dispatch('candidates/bindDoc', this.candidateId);
     this.$store.dispatch('candidates/bindDocs', this.candidateId);
-    const email = firebase.auth().currentUser.email;
-    this.authorisedToPerformAction = await authorisedToPerformAction(email);
   },
   destroyed() {
     this.$store.dispatch('candidates/unbindDoc');


### PR DESCRIPTION
## What's included?
Allow a user to access `Candidates - Actions` and change an email address.

The right to do this should then be added to these User Roles:
- Operations Team Member
- Operations Senior Manager
- Digital Super User

Note: this changes will remove hard coded permission control in "Candidates - Actions" page.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to a candidate page.
2. Check if the current user which the user role is one of above roles can amend the candidate's email address.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
User role: Operations Senior Manager

<img width="1240" alt="#1770 Admin Amending Email Addresses for Candidates_2" src="https://user-images.githubusercontent.com/79906532/198244361-112d9958-efed-4770-bcb7-f7d0fc84c1ab.png">

User role: Other JAC Staff

<img width="1241" alt="#1770 Admin Amending Email Addresses for Candidates_1" src="https://user-images.githubusercontent.com/79906532/198244397-cac0c65d-0e05-4bf8-8fbd-462e0c759d2e.png">

## Related permissions
- Permissions have been added / updated. Details: `canUpdateCandidates`

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
