### PR TITLE
#1764 Application Submission Reminder

### DIFF
--- a/src/permissions.js
+++ b/src/permissions.js
@@ -67,6 +67,10 @@ const PERMISSIONS = {
         label: 'Can delete candidate character information',
         value: 'e9',
       },
+      canSendApplicationReminders: {
+        label: 'Can send application reminders',
+        value: 'e10',
+      },
     },
   },
   candidates: {

--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -8,13 +8,24 @@
       </div>
 
       <div
-        v-if="status === 'applied'"
+        v-if="status === 'draft' || status === 'applied'"
         class="moj-page-header-actions__actions float-right"
       >
         <div class="moj-button-menu">
           <div class="moj-button-menu__wrapper">
             <button
-              v-if="hasPermissions([
+              v-if="status === 'draft' && hasPermissions([
+                PERMISSIONS.exercises.permissions.canReadExercises.value,
+                PERMISSIONS.applications.permissions.canReadApplications.value
+              ])"
+              class="govuk-button govuk-button moj-button-menu__item moj-page-header-actions__action"
+              data-module="govuk-button"
+              @click="sendApplicationReminders()"
+            >
+              Send reminders
+            </button>
+            <button
+              v-if="status === 'applied' && hasPermissions([
                 PERMISSIONS.exercises.permissions.canReadExercises.value,
                 PERMISSIONS.applications.permissions.canReadApplications.value
               ])"
@@ -127,6 +138,9 @@ export default {
         reportData.push(Object.values(row).map(cell => cell));
       });
       return reportData;
+    },
+    async sendApplicationReminders() {
+      await functions.httpsCallable('sendApplicationReminders')({ exerciseId: this.exercise.id });
     },
     async exportContacts() {
       const title = 'Contacts';

--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -15,10 +15,7 @@
           <div class="moj-button-menu__wrapper">
             <button
               v-if="status === 'draft' && hasPermissions([
-                PERMISSIONS.exercises.permissions.canReadExercises.value,
-                PERMISSIONS.applications.permissions.canReadApplications.value,
-                PERMISSIONS.applications.permissions.canUpdateApplications.value,
-                PERMISSIONS.notifications.permissions.canCreateNotifications.value,
+                PERMISSIONS.exercises.permissions.canSendApplicationReminders.value,
               ])"
               class="govuk-button govuk-button moj-button-menu__item moj-page-header-actions__action"
               data-module="govuk-button"


### PR DESCRIPTION
## What's included?
Send a reminder email to all applications in Draft.

The application reminder template:
<img width="614" alt="#1764 Application Submission Reminder Template" src="https://user-images.githubusercontent.com/79906532/200887116-c8ef8a98-6867-4f16-ad45-6e8b41a5ee7b.png">

Note: this PR is related to [[digital-platform] Send application submission reminders](https://github.com/jac-uk/digital-platform/pull/789).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to the draft application list of an exercise.
2. Click "Send reminders" to send reminder email.
3. Go the Notification page and check if the "Application Submission Reminder" is in the queue.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/201130910-d14a7fc2-ae3b-4e91-84e3-af740a8e8b55.mov

## Related permissions
- `canSendApplicationReminders `

---
PREVIEW:DEVELOP
