### PR TITLE
Other Downloads

### DIFF
--- a/src/views/Exercise/Details/Downloads/View.vue
+++ b/src/views/Exercise/Details/Downloads/View.vue
@@ -224,6 +224,28 @@
           </ul>
         </dd>
       </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Other Downloads
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <span v-if="!showOtherDownloads">
+            No files uploaded
+          </span>
+          <ul class="govuk-list">
+            <li
+              v-for="file in exercise.downloads.otherDownloads"
+              :key="file.file"
+            >
+              <DownloadLink
+                :file-name="file.file"
+                :title="file.title"
+                :exercise-id="exerciseId"
+              />
+            </li>
+          </ul>
+        </dd>
+      </div>
     </dl>
   </div>
 </template>
@@ -310,6 +332,18 @@ export default {
         this.exercise.downloads &&
         this.exercise.downloads.statutoryConsultationGuidanceLetter &&
         this.exercise.downloads.statutoryConsultationGuidanceLetter.length
+      ) {
+        return true;
+      } else {
+        return false;
+      }
+    },
+    showOtherDownloads() {
+      if (
+        this.exercise &&
+        this.exercise.downloads &&
+        this.exercise.downloads.otherDownloads &&
+        this.exercise.downloads.otherDownloads.length
       ) {
         return true;
       } else {

--- a/src/views/Exercise/Details/Downloads/View.vue
+++ b/src/views/Exercise/Details/Downloads/View.vue
@@ -232,7 +232,10 @@
           <span v-if="!showOtherDownloads">
             No files uploaded
           </span>
-          <ul class="govuk-list">
+          <ul
+            v-else
+            class="govuk-list"
+          >
             <li
               v-for="file in exercise.downloads.otherDownloads"
               :key="file.file"

--- a/src/views/Exercise/Details/Downloads/View.vue
+++ b/src/views/Exercise/Details/Downloads/View.vue
@@ -229,11 +229,8 @@
           Other Downloads
         </dt>
         <dd class="govuk-summary-list__value">
-          <span v-if="!showOtherDownloads">
-            No files uploaded
-          </span>
           <ul
-            v-else
+            v-if="hasOtherDownloads"
             class="govuk-list"
           >
             <li
@@ -247,6 +244,9 @@
               />
             </li>
           </ul>
+          <span v-else>
+            No files uploaded
+          </span>
         </dd>
       </div>
     </dl>
@@ -341,7 +341,7 @@ export default {
         return false;
       }
     },
-    showOtherDownloads() {
+    hasOtherDownloads() {
       if (
         this.exercise &&
         this.exercise.downloads &&


### PR DESCRIPTION
## What's included?
'Other Downloads' were missing from the additional content section of the vacancy details page. 
I have re-added them so that uploaded files can be accessed by candidates. 

This PR makes these downloads more visible on the admin platform

[Partnering apply side PR here](https://github.com/jac-uk/apply/pull/949)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Upload a document (or multiple) under 'other downloads' [admin side]
- Check the file appears, named correctly and downloadable on the apply side 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.
APPLY >>>
![Screenshot 2022-11-09 at 17 01 35](https://user-images.githubusercontent.com/44227249/200893898-7f25d9cc-9e57-41d9-ae04-2fdba4b217f1.png)

![image](https://user-images.githubusercontent.com/44227249/200895213-dcc989e1-ab97-4e1c-9c8f-392e4026989c.png)

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
