### PR TITLE
digital-platform#794 Use local emulator suite

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,7 @@
 NODE_ENV=test
 VUE_APP_FIREBASE_API_KEY='firebase_api_key'
 VUE_APP_FIREBASE_AUTH_DOMAIN='firebase_auth_domain'
-VUE_APP_FIREBASE_DATABASE_URL='firebase_database_url'
+VUE_APP_FIREBASE_DATABASE_URL='https://firebase_database_url.firebaseio.com'
 VUE_APP_FIREBASE_PROJECT_ID='firebase_project_id'
 VUE_APP_FIREBASE_STORAGE_BUCKET='firebase_storage_bucket'
 VUE_APP_FIREBASE_MESSAGING_SENDER_ID='firebase_messaging_sender_id'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^16.0.0",
         "@ckeditor/ckeditor5-vue": "^1.0.3",
-        "@jac-uk/jac-kit": "^0.1.6",
+        "@jac-uk/jac-kit": "^0.1.8",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.13.0",
         "@sentry/vue": "^7.13.0",
@@ -2464,9 +2464,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "0.1.6",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.6/446a5d865882a0a3a56951bdf385fe9ed08e5b0e",
-      "integrity": "sha512-HSi7ChNXSC03ysX9EJV7yIu74/+a70QJzGgvPN862GfsaodXTIgw2RGKJpivcZFatILqkt2BMX0xwVyMSM7deg=="
+      "version": "0.1.8",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.8/bdb5315edd194ffccf7c0afc22edce95217c261c",
+      "integrity": "sha512-hr+0+W3pjcDRJ/7ID4yuNgATSmi1JKkYvYGltjp3ibhtuw1ichabu/4OWwALVOz6JtUdk5vET+65jlVzMDZeqQ=="
     },
     "node_modules/@jest/console": {
       "version": "27.5.1",
@@ -22160,9 +22160,9 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "0.1.6",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.6/446a5d865882a0a3a56951bdf385fe9ed08e5b0e",
-      "integrity": "sha512-HSi7ChNXSC03ysX9EJV7yIu74/+a70QJzGgvPN862GfsaodXTIgw2RGKJpivcZFatILqkt2BMX0xwVyMSM7deg=="
+      "version": "0.1.8",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.8/bdb5315edd194ffccf7c0afc22edce95217c261c",
+      "integrity": "sha512-hr+0+W3pjcDRJ/7ID4yuNgATSmi1JKkYvYGltjp3ibhtuw1ichabu/4OWwALVOz6JtUdk5vET+65jlVzMDZeqQ=="
     },
     "@jest/console": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^16.0.0",
     "@ckeditor/ckeditor5-vue": "^1.0.3",
-    "@jac-uk/jac-kit": "^0.1.6",
+    "@jac-uk/jac-kit": "^0.1.8",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.13.0",
     "@sentry/vue": "^7.13.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -191,7 +191,6 @@
 
 <script>
 import { auth } from '@/firebase';
-import firebase from '@firebase/app';
 import { authorisedToPerformAction }  from '@/helpers/authUsers';
 import permissionMixin from '@/permissionMixin';
 
@@ -220,15 +219,19 @@ export default {
   watch: {
     async isSignedIn() {
       if (this.isSignedIn) {
-        const email = firebase.auth().currentUser.email;
+        const email = auth.currentUser.email;
         this.authorisedToPerformAction = await authorisedToPerformAction(email);
       }
     },
   },
   async created() {
+    console.log('created', this.isSignedIn);
     if (this.isSignedIn) {
+      console.log('is signed in');
       await this.$store.dispatch('services/bind');
-      const email = firebase.auth().currentUser.email;
+      console.log('bound');
+      const email = auth.currentUser.email;
+      console.log('email', email);
       this.authorisedToPerformAction = await authorisedToPerformAction(email);
     }
   },
@@ -239,7 +242,7 @@ export default {
   },
   methods: {
     signOut() {
-      auth().signOut();
+      auth.signOut();
       this.$router.go('/sign-in');
     },
     async onMouseOver() {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -37,5 +37,5 @@ if (process.env.VUE_APP_RECAPTCHA_TOKEN) {
   firebase.appCheck().activate(process.env.VUE_APP_RECAPTCHA_TOKEN);
 }
 
-export { firestore, auth, functions, Timestamp };
+export { firestore, auth, functions, storage, Timestamp };
 export default firebase;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -2,6 +2,7 @@ import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
 import 'firebase/functions';
+import 'firebase/storage';
 // import 'firebase/database';
 import 'firebase/app-check';
 
@@ -19,6 +20,7 @@ const config = {
 const functions = firebase.initializeApp(config).functions('europe-west2');
 const firestore = firebase.firestore();
 const auth = firebase.auth();
+const storage = firebase.storage();
 // const database = firebase.database();
 const Timestamp = firebase.firestore.Timestamp;
 
@@ -27,6 +29,7 @@ if (location.hostname === 'localhost' && process.env.VUE_APP_FIREBASE_USE_EMULAT
   firestore.useEmulator('localhost', 8080);
   functions.useEmulator('localhost', 5001);
   auth.useEmulator('http://localhost:9099');
+  storage.useEmulator('localhost', 9199);
   // database.useEmulator('localhost', 9000);
 }
 // App check

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -3,7 +3,7 @@ import 'firebase/auth';
 import 'firebase/firestore';
 import 'firebase/functions';
 import 'firebase/storage';
-// import 'firebase/database';
+import 'firebase/database';
 import 'firebase/app-check';
 
 // Configure and initialise Firebase
@@ -21,7 +21,7 @@ const functions = firebase.initializeApp(config).functions('europe-west2');
 const firestore = firebase.firestore();
 const auth = firebase.auth();
 const storage = firebase.storage();
-// const database = firebase.database();
+const database = firebase.database();
 const Timestamp = firebase.firestore.Timestamp;
 
 // Local emulator
@@ -30,12 +30,12 @@ if (location.hostname === 'localhost' && process.env.VUE_APP_FIREBASE_USE_EMULAT
   functions.useEmulator('localhost', 5001);
   auth.useEmulator('http://localhost:9099');
   storage.useEmulator('localhost', 9199);
-  // database.useEmulator('localhost', 9000);
+  database.useEmulator('localhost', 9000);
 }
 // App check
 if (process.env.VUE_APP_RECAPTCHA_TOKEN) {
   firebase.appCheck().activate(process.env.VUE_APP_RECAPTCHA_TOKEN);
 }
 
-export { firestore, auth, functions, storage, Timestamp };
+export { firestore, auth, functions, storage, database, Timestamp };
 export default firebase;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,8 +1,9 @@
 import firebase from 'firebase/app';
-import 'firebase/app-check';
-import 'firebase/functions';
-import 'firebase/firestore';
 import 'firebase/auth';
+import 'firebase/firestore';
+import 'firebase/functions';
+import 'firebase/database';
+import 'firebase/app-check';
 
 // Configure and initialise Firebase
 // Config variables are pulled from the environment at build time
@@ -16,22 +17,22 @@ const config = {
   appId: process.env.VUE_APP_FIREBASE_APP_ID,
 };
 const functions = firebase.initializeApp(config).functions('europe-west2');
-
-if (process.env.VUE_APP_USE_FUNCTIONS_EMULATOR === 'true') {
-  functions.useEmulator('localhost', '5000');
-}
-
-// Initialise Firestore
 const firestore = firebase.firestore();
+const auth = firebase.auth();
+const database = firebase.database();
+const Timestamp = firebase.firestore.Timestamp;
 
+// Local emulator
+if (location.hostname === 'localhost' && process.env.VUE_APP_FIREBASE_USE_EMULATORS == 'true') {
+  firestore.useEmulator('localhost', 8080);
+  functions.useEmulator('localhost', 5001);
+  auth.useEmulator('http://localhost:9099');
+  database.useEmulator('localhost', 9000);
+}
 // App check
-let appCheck;
 if (process.env.VUE_APP_RECAPTCHA_TOKEN) {
-  appCheck = firebase.appCheck().activate(process.env.VUE_APP_RECAPTCHA_TOKEN);
+  firebase.appCheck().activate(process.env.VUE_APP_RECAPTCHA_TOKEN);
 }
 
-// Other firebase exports
-const auth = firebase.auth;
-
-export { firestore, auth, functions, appCheck };
+export { firestore, auth, functions, database, Timestamp };
 export default firebase;

--- a/src/helpers/authUsers.js
+++ b/src/helpers/authUsers.js
@@ -1,4 +1,5 @@
 const authorisedUsers = [
+  'digitalteam@judicialappointments.digital',
   'warren.searle@judicialappointments.digital',
   'tom.russell@judicialappointments.digital',
   'andrew.isaac@judicialappointments.digital',

--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,7 @@ Object.keys(localFilters)
   });
 
 let vueInstance = false;
-auth().onAuthStateChanged(async (user) => {
+auth.onAuthStateChanged(async (user) => {
   // check if user is a new user.
   // TODO: check if there is a better way of doing this
   // TODO: the logic for this actually sits on SignIn.vue but the redirect on line 44 still occurs without the next 3 lines

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -31,6 +31,7 @@ const module = {
         if (user.email.indexOf('@judicialappointments.gov.uk') > 0) {
           allOk = true;
         } else if ([
+          'digitalteam@judicialappointments.digital',
           'warren.searle@judicialappointments.digital',
           'halcyon@judicialappointments.digital',
           'tom.russell@judicialappointments.digital',
@@ -51,7 +52,7 @@ const module = {
             user = { ...user, emailVerified: true };
             shouldEnsureEmailVerified = true;
           }
-          
+
           commit('setCurrentUser', {
             uid: user.uid,
             email: user.email,
@@ -62,7 +63,7 @@ const module = {
             await functions.httpsCallable('ensureEmailValidated')({});
           }
         } else {
-          auth().signOut();
+          auth.signOut();
           commit('setAuthError', 'This site is restricted to employees of the Judicial Appointments Commission');
         }
       }

--- a/src/store/qualifyingTest/qualifyingTestResponses.js
+++ b/src/store/qualifyingTest/qualifyingTestResponses.js
@@ -1,5 +1,5 @@
 import firebase from '@firebase/app';
-import { firestore } from '@/firebase';
+import { auth, firestore } from '@/firebase';
 import { firestoreAction } from 'vuexfire';
 import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
 import tableQuery from '@jac-uk/jac-kit/components/Table/tableQuery';
@@ -118,7 +118,7 @@ export default {
     },
     resetTest: async (context) => {
       const timestamp = firebase.firestore.FieldValue.serverTimestamp();
-      const email = firebase.auth().currentUser.email;
+      const email = auth.currentUser.email;
       const canReset = await authorisedToPerformAction(email);
       if (canReset) {
         const rec = context.state.record;
@@ -133,7 +133,7 @@ export default {
       }
     },
     markAsCompleted: async (context) => {
-      const email = firebase.auth().currentUser.email;
+      const email = auth.currentUser.email;
       const canMarkAsCompleted = await authorisedToPerformAction(email);
       if (canMarkAsCompleted) {
         const rec = context.state.record;

--- a/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
+++ b/src/views/Exercise/Tasks/QualifyingTests/QualifyingTest/Response/View.vue
@@ -482,7 +482,7 @@
 </template>
 
 <script>
-import firebase from '@firebase/app';
+import { auth } from '@/firebase';
 import { QUALIFYING_TEST } from '@jac-uk/jac-kit/helpers/constants';
 import EditableField from '@jac-uk/jac-kit/draftComponents/EditableField';
 import Select from '@jac-uk/jac-kit/draftComponents/Form/Select';
@@ -694,7 +694,7 @@ export default {
   },
   async created() {
     this.$store.dispatch('qualifyingTestResponses/bindRecord', { id: this.responseId });
-    const email = firebase.auth().currentUser.email;
+    const email = auth.currentUser.email;
     this.authorisedToPerformAction = await authorisedToPerformAction(email);
   },
   methods: {

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -37,6 +37,7 @@
 </template>
 
 <script>
+import firebase from 'firebase/app';
 import { auth, functions } from '@/firebase';
 
 export default {
@@ -64,11 +65,11 @@ export default {
       this.signInError = 'Your account requires approval before access is granted. Please request this from a manager.';
     },
     signOut() {
-      auth().signOut();
+      auth.signOut();
     },
     checkIfNewUser(user) {
       if (user.additionalUserInfo.isNewUser) {
-        this.disableNewUser(auth().currentUser.uid).then(() => {
+        this.disableNewUser(auth.currentUser.uid).then(() => {
           this.signOut();
         }).catch(() => {
           this.signOut();
@@ -76,16 +77,16 @@ export default {
       }
     },
     loginWithGoogle() {
-      const provider = new auth.GoogleAuthProvider();
-      auth().signInWithPopup(provider).then((user) => {
+      const provider = new firebase.auth.GoogleAuthProvider();
+      auth.signInWithPopup(provider).then((user) => {
         this.checkIfNewUser(user);
       }).catch(err => {
         this.signInError = err.message;
       });
     },
     loginWithMicrosoft() {
-      const provider = new auth.OAuthProvider('microsoft.com');
-      auth().signInWithPopup(provider).then((user) => {
+      const provider = new firebase.auth.OAuthProvider('microsoft.com');
+      auth.signInWithPopup(provider).then((user) => {
         this.checkIfNewUser(user);
       }).catch(err => {
         this.signInError = err.message;

--- a/tests/unit/store/qualifyingTest/qualifyingTestResponses.spec.js
+++ b/tests/unit/store/qualifyingTest/qualifyingTestResponses.spec.js
@@ -1,4 +1,3 @@
-import firebase from '@firebase/app';
 import { auth } from '@/firebase';
 import * as authUsers from '@/helpers/authUsers';
 import qualifyingTestResponses from '@/store/qualifyingTest/qualifyingTestResponses';

--- a/tests/unit/store/qualifyingTest/qualifyingTestResponses.spec.js
+++ b/tests/unit/store/qualifyingTest/qualifyingTestResponses.spec.js
@@ -1,4 +1,5 @@
 import firebase from '@firebase/app';
+import { auth } from '@/firebase';
 import * as authUsers from '@/helpers/authUsers';
 import qualifyingTestResponses from '@/store/qualifyingTest/qualifyingTestResponses';
 import { mockScenarioResponses, mockScenarioQualifyingTest, mockScenarioQualifyingTestResponse } from '../../storeMocks';
@@ -8,7 +9,20 @@ const mockContext = {
 };
 
 jest.spyOn(authUsers,'authorisedToPerformAction').mockImplementation((email) => {
-  return email === 'test@test.com';
+  return email === 'authorised@test.com';
+});
+
+jest.mock('@/firebase', () => {
+  return {
+    auth: {
+      currentUser: {
+        email: 'authorised@test.com',
+      },
+    },
+    firestore: {
+      collection: jest.fn(),
+    },
+  };
 });
 
 describe('store/qualifyingTestResponses', () => {
@@ -55,11 +69,7 @@ describe('store/qualifyingTestResponses', () => {
         });
 
         it('user is not authorised to reset candidate test', async () => {
-          jest.spyOn(firebase,'auth').mockImplementation(() => ({
-            currentUser: {
-              email: 'user@test.com',
-            },
-          }));
+          auth.currentUser.email = 'not.authorised@test.com';
           mockContext.state = {
             record: {
               id: '1',
@@ -75,11 +85,7 @@ describe('store/qualifyingTestResponses', () => {
         });
 
         it('user is authorised to reset and field isOutOfTime doesn`t exist', async () => {
-          jest.spyOn(firebase,'auth').mockImplementation(() => ({
-            currentUser: {
-              email: 'test@test.com',
-            },
-          }));
+          auth.currentUser.email = 'authorised@test.com';
           mockContext.state = {
             record: {
               id: '1',
@@ -100,11 +106,7 @@ describe('store/qualifyingTestResponses', () => {
         });
 
         it('isOutOfTime field is updated if exists and equals to true', async () => {
-          jest.spyOn(firebase,'auth').mockImplementation(() => ({
-            currentUser: {
-              email: 'test@test.com',
-            },
-          }));
+          auth.currentUser.email = 'authorised@test.com';
           mockContext.state = {
             record: {
               id: '1',
@@ -126,11 +128,7 @@ describe('store/qualifyingTestResponses', () => {
         });
 
         it('isOutOfTime field is not updated if exists and equals to false', async () => {
-          jest.spyOn(firebase,'auth').mockImplementation(() => ({
-            currentUser: {
-              email: 'test@test.com',
-            },
-          }));
+          auth.currentUser.email = 'authorised@test.com';
           mockContext.state = {
             record: {
               id: '1',
@@ -159,11 +157,7 @@ describe('store/qualifyingTestResponses', () => {
         });
 
         it('user is not authorised to mark candidate test as completed', async () => {
-          jest.spyOn(firebase,'auth').mockImplementation(() => ({
-            currentUser: {
-              email: 'user@test.com',
-            },
-          }));
+          auth.currentUser.email = 'not.authorised@test.com';
           mockContext.state = {
             record: {
               id: '1',
@@ -175,11 +169,7 @@ describe('store/qualifyingTestResponses', () => {
         });
 
         it('user is authorised to mark candidate test as completed', async () => {
-          jest.spyOn(firebase,'auth').mockImplementation(() => ({
-            currentUser: {
-              email: 'test@test.com',
-            },
-          }));
+          auth.currentUser.email = 'authorised@test.com';
           mockContext.state = {
             record: {
               id: '1',


### PR DESCRIPTION
## What's included?
Changes our code base to enable the use of local emulator suite.
This will enable faster local development and will be useful for user testing

See related work on [digital-platform#795](https://github.com/jac-uk/digital-platform/pull/795)

Note: here we have also included the following fixes:
 - Bugfix: use correct firebase instances
 - Bugfix: fix unit tests and simplify mocks

## Who should test?
✅ Developers

## How to test?
Amend your `env.develop.local` file to include the following line:
```
VUE_APP_FIREBASE_USE_EMULATORS=true
```
When running `npm run serve` a value of `true` for the above line will mean the Admin UI connects to the local emulator suite. A value of `false` will mean the Admin UI connects to the `develop` environment.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Include screen grabs, video demo, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
