### PR TITLE
preview 'listing' and 'detail'

### DIFF
--- a/src/components/Previews/DetailPreview.vue
+++ b/src/components/Previews/DetailPreview.vue
@@ -1,0 +1,164 @@
+<template>
+  <div>
+    <h1
+      class="govuk-heading-m govuk-!-margin-bottom-0"
+    >
+      Detail
+    </h1>
+    <div
+      class="listing-box"
+    >
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-xl">
+            {{ exercise.name }}
+          </h1>
+
+          <p v-if="exercise.immediateStart && showNumberOfVacancies">
+            <span class="govuk-body govuk-!-font-weight-bold">
+              Number of vacancies:
+            </span>
+            <span class="govuk-body">
+              {{ exercise.immediateStart }}
+            </span>
+          </p>
+
+          <p v-if="exercise.location && showLocation">
+            <span class="govuk-body govuk-!-font-weight-bold">Location:</span> <span class="govuk-body"> {{ exercise.location }}</span>
+          </p>
+
+          <p v-if="exercise.appointmentType == 'salaried' && showAppointmentType">
+            <span class="govuk-body govuk-!-font-weight-bold">
+              Salary:
+            </span>
+            <span
+              v-if="exercise.salaryGrouping"
+              class="govuk-body"
+            >
+              {{ exercise.salaryGrouping | lookup }}
+            </span>
+            <span
+              v-if="exercise.salary"
+              class="govuk-body"
+            >
+              {{ exercise.salary | formatCurrency }}
+            </span>
+          </p>
+
+          <p
+            v-if="exercise.exerciseMailbox"
+            class="govuk-!-margin-bottom-8"
+          >
+            <span class="govuk-body govuk-!-font-weight-bold">Contact: </span>
+            <a
+              :href="`mailto:${exercise.exerciseMailbox}?subject=Re:${exercise.referenceNumber}`"
+              class="govuk-body govuk-link"
+            >{{ exercise.exerciseMailbox }}</a>
+          </p>
+
+          <div
+            v-if="timeline.length && advertTypeFull"
+          >
+            <h2 class="govuk-heading-l">
+              Timeline
+            </h2>
+            <Timeline :data="timeline" />
+          </div>
+
+          <div v-if="!advertTypeFull">
+            <p>
+              <span
+                class="govuk-body govuk-!-font-weight-bold"
+              >
+                <span class="govuk-body govuk-!-font-weight-bold"> Launch Date: </span>
+              </span>
+              <span
+                v-if="exercise.applicationOpenDate"
+                class="govuk-body"
+              >
+                {{ exercise.applicationOpenDate | formatDate('datetime') }}
+              </span>
+              <span
+                v-else
+                class="govuk-body"
+              >
+                {{ exercise.estimatedLaunchDate | formatEstimatedDate }}
+              </span>
+            </p>
+            <p v-if="exercise.applicationCloseDate">
+              <span
+                class="govuk-body govuk-!-font-weight-bold"
+              >
+                <span class="govuk-body govuk-!-font-weight-bold"> Closing Date: </span>
+              </span>
+              <span
+                class="govuk-body"
+              >
+                {{ exercise.applicationCloseDate | formatDate('datetime') }}
+              </span>
+            </p>
+          </div>
+
+          <h2 class="govuk-heading-l">
+            Overview of the role
+          </h2>
+
+          <div
+            v-dompurify-html="exercise.aboutTheRole"
+            class="govuk-body"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import exerciseTimeline from '@/helpersTMP/Timeline/exerciseTimeline';
+import createTimeline from '@/helpersTMP/Timeline/createTimeline';
+import Timeline from '@jac-uk/jac-kit/draftComponents/Timeline';
+
+const ADVERT_TYPES = {
+  LISTING: 'listing',
+  BASIC: 'basic',
+  FULL: 'full',
+  EXTERNAL: 'external',
+};
+
+export default {
+  name: 'DetailPreview',
+  components: {
+    Timeline,
+  },
+  props: {
+    exercise: {
+      type: Object,
+      default: null,
+    },
+  },
+  computed: {
+    timeline() {
+      const timeline = exerciseTimeline(this.exercise);
+      return createTimeline(timeline);
+    },
+    showNumberOfVacancies() {
+      return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC ? true : false;
+    },
+    showLocation() {
+      return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC ? true : false;
+    },
+    advertType() {
+      return this.exercise.advertType ? this.exercise.advertType : ADVERT_TYPES.FULL;
+    },
+    advertTypeFull() {
+      return this.advertType === ADVERT_TYPES.FULL;
+    },
+  },
+};
+</script>
+
+<style scoped>
+  .listing-box {
+    border: 5px solid #a5a5a5 !important;
+    padding: 40px;
+  }
+</style>

--- a/src/components/Previews/DetailPreview.vue
+++ b/src/components/Previews/DetailPreview.vue
@@ -113,44 +113,19 @@
   </div>
 </template>
 <script>
-import exerciseTimeline from '@/helpersTMP/Timeline/exerciseTimeline';
-import createTimeline from '@/helpersTMP/Timeline/createTimeline';
 import Timeline from '@jac-uk/jac-kit/draftComponents/Timeline';
-
-const ADVERT_TYPES = {
-  LISTING: 'listing',
-  BASIC: 'basic',
-  FULL: 'full',
-  EXTERNAL: 'external',
-};
+import exerciseMixin from '@/views/Exercise/exerciseMixin.js';
 
 export default {
   name: 'DetailPreview',
   components: {
     Timeline,
   },
+  mixins: [exerciseMixin],
   props: {
     exercise: {
       type: Object,
       default: null,
-    },
-  },
-  computed: {
-    timeline() {
-      const timeline = exerciseTimeline(this.exercise);
-      return createTimeline(timeline);
-    },
-    showNumberOfVacancies() {
-      return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC ? true : false;
-    },
-    showLocation() {
-      return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC ? true : false;
-    },
-    advertType() {
-      return this.exercise.advertType ? this.exercise.advertType : ADVERT_TYPES.FULL;
-    },
-    advertTypeFull() {
-      return this.advertType === ADVERT_TYPES.FULL;
     },
   },
 };

--- a/src/components/Previews/ListingPreview.vue
+++ b/src/components/Previews/ListingPreview.vue
@@ -10,11 +10,13 @@
       class="listing-box"
     >
       <div v-if="!exercise.inviteOnly">
-        <div
-          class="govuk-heading-m govuk-!-font-weight-bold"
+        <a
+          class="govuk-heading-m govuk-!-font-weight-bold govuk-link"
+          href
+          @click.prevent
         >
           {{ exercise.name }}
-        </div>
+        </a>
         <p>
           <span
             class="govuk-body govuk-!-font-weight-bold"
@@ -94,6 +96,7 @@
   </div>
 </template>
 <script>
+
 export default {
   name: 'ListingPreview',
   props: {

--- a/src/components/Previews/ListingPreview.vue
+++ b/src/components/Previews/ListingPreview.vue
@@ -1,0 +1,113 @@
+<template>
+  <div>
+    <h1
+      class="govuk-heading-m govuk-!-margin-bottom-0"
+    >
+      Listing
+    </h1>
+    <div
+      :key="exercise.id"
+      class="listing-box"
+    >
+      <div v-if="!exercise.inviteOnly">
+        <div
+          class="govuk-heading-m govuk-!-font-weight-bold"
+        >
+          {{ exercise.name }}
+        </div>
+        <p>
+          <span
+            class="govuk-body govuk-!-font-weight-bold"
+          >
+            <span class="govuk-body govuk-!-font-weight-bold"> Launch Date: </span>
+          </span>
+          <span
+            v-if="exercise.applicationOpenDate"
+            class="govuk-body"
+          >
+            {{ exercise.applicationOpenDate | formatDate('datetime') }}
+          </span>
+          <span
+            v-else
+            class="govuk-body"
+          >
+            {{ exercise.estimatedLaunchDate | formatEstimatedDate }}
+          </span>
+        </p>
+        <p v-if="exercise.applicationCloseDate">
+          <span
+            class="govuk-body govuk-!-font-weight-bold"
+          >
+            <span class="govuk-body govuk-!-font-weight-bold"> Closing Date: </span>
+          </span>
+          <span
+            class="govuk-body"
+          >
+            {{ exercise.applicationCloseDate | formatDate('datetime') }}
+          </span>
+        </p>
+        <div
+          v-dompurify-html="exercise.roleSummary"
+        />
+      </div>
+
+      <div v-if="exercise.welshPosts">
+        <div v-if="!exercise.inviteOnly">
+          <p>
+            <span
+              class="govuk-body govuk-!-font-weight-bold"
+            >
+              <span class="govuk-body govuk-!-font-weight-bold"> Dyddiad lansio: </span>
+            </span>
+            <span
+              v-if="exercise.applicationOpenDate"
+              class="govuk-body"
+            >
+              {{ exercise.applicationOpenDate | formatDate('datetime') }}
+            </span>
+            <span
+              v-else
+              class="govuk-body"
+            >
+              {{ exercise.estimatedLaunchDate | formatEstimatedDate }}
+            </span>
+          </p>
+          <p v-if="exercise.applicationCloseDate">
+            <span
+              class="govuk-body govuk-!-font-weight-bold"
+            >
+              <span class="govuk-body govuk-!-font-weight-bold"> Dyddiad cau: </span>
+            </span>
+            <span
+              class="govuk-body"
+            >
+              {{ exercise.applicationCloseDate | formatDate('datetime') }}
+            </span>
+          </p>
+          <div
+            v-if="exercise.roleSummaryWelsh"
+            v-dompurify-html="exercise.roleSummaryWelsh"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  name: 'ListingPreview',
+  props: {
+    exercise: {
+      type: Object,
+      default: null,
+    },
+  },
+};
+</script>
+
+<style scoped>
+  .listing-box {
+    border: 5px solid #a5a5a5 !important;
+    padding: 40px;
+  }
+</style>

--- a/src/filters.js
+++ b/src/filters.js
@@ -60,8 +60,28 @@ const lookup = (value) => {
     'online-and-judge-led': 'Yes - online resources and judge-led discussion group course',
     'online-only': 'Yes - online resources only',
 
-    // 'xxx': 'xxx',
     archived: 'Archived',
+
+    // Outreach report headers
+    'NINumber': 'National Insurance Number',
+    'name': 'Name',
+    // gender
+    // ethnicity
+    disability: 'Disability',
+    exerciseReferenceNumber: 'Exercise',
+    exerciseName: 'Exercise Name',
+    stage: 'Stage',
+    status: 'Status',
+    id: 'exercise id',
+
+    // outreach report values
+    white: 'White',
+    bame: '"Black, Asian and minority ethnic"',
+    approvedForImmediateAppointment: 'Approved For Immediate Appointment',
+    passedSelection: 'Passed Selection',
+
+    // 'xxx': 'xxx',
+    null: '[No Answer Provided]',
   };
 
   lookup[ADVERT_TYPES.LISTING] = 'Listing';

--- a/src/helpersTMP/Timeline/createTimeline.js
+++ b/src/helpersTMP/Timeline/createTimeline.js
@@ -1,0 +1,20 @@
+const createTimeline = (timeline, maxEntriesNum) => {
+  const timelineArray = timeline.filter((item) => item.date !== null).sort(ascendingDate);
+
+  if (maxEntriesNum) {
+    return timelineArray.slice(0, maxEntriesNum);
+  }
+  return timelineArray;
+};
+
+const ascendingDate = ( item1, item2 ) => {
+  if (item1.date < item2.date) {
+    return -1;
+  } else if (item1.date > item2.date) {
+    return 1;
+  } else {
+    return 0;
+  }
+};
+
+export default createTimeline;

--- a/src/router.js
+++ b/src/router.js
@@ -209,16 +209,16 @@ const router = new Router({
             title: 'Candidate | View',
           },
         },
-        {
-          path: 'targeted-outreach-report',
-          component: TargetedOutreachReport,
-          name: 'targeted-outreach-report',
-          meta: {
-            requiresAuth: true,
-            title: 'Candidates | Targeted Oureach Report',
-          },
-        },
       ],
+    },
+    {
+      path: 'targeted-outreach-report',
+      component: TargetedOutreachReport,
+      name: 'targeted-outreach-report',
+      meta: {
+        requiresAuth: true,
+        title: 'Candidates | Targeted Oureach Report',
+      },
     },
     {
       path: '/create-exercise',

--- a/src/views/Candidates/TargetedOutreachReport.vue
+++ b/src/views/Candidates/TargetedOutreachReport.vue
@@ -61,8 +61,9 @@
           <th
             v-for="(column, index) in tableColumns"
             :key="index"
+            :class="(index + 1) === tableColumns.length ? 'govuk-table__cell text-left' : 'govuk-table__cell text-right'"
           >
-            {{ column.title }}
+            {{ filters.lookup(column.title) }}
           </th>
         </thead>
         <tbody class="govuk-table__body">
@@ -74,9 +75,9 @@
             <td
               v-for="(item, indexItem) in row"
               :key="indexItem"
-              class="govuk-table__cell text-right"
+              class="govuk-table__cell text-left"
             >
-              {{ item }}
+              {{ filters.lookup(item) }}
             </td>
           </tr>
         </tbody>
@@ -90,6 +91,7 @@ import { functions } from '@/firebase';
 import TextArea from '@jac-uk/jac-kit/draftComponents/Form/TextareaInput';
 import Form from '@jac-uk/jac-kit/draftComponents/Form/Form';
 import ErrorSummary from '@jac-uk/jac-kit/draftComponents/Form/ErrorSummary';
+import * as filters from '@/filters.js';
 
 export default {
   name: 'TargetedOutreachReport',
@@ -100,6 +102,7 @@ export default {
   extends: Form,
   data() {
     return {
+      filters: filters,
       nins: '',
       results: [],
       searching: false,
@@ -129,10 +132,11 @@ export default {
   methods: {
     downloadReport() {
       const header = Object.keys(this.tableColumns).map(col => this.tableColumns[col].title);
-      const csv = [[...header]];
+      const csv = [[...header.map(col => filters.lookup(col))]];
       this.results.map(item => {
         const returnItem = header.map(h => {
-          return item[h];
+          // sanitise for commas in string which could cause separation
+          return filters.lookup(`"${item[h]}"`);
         });
         csv.push(returnItem);
       });

--- a/src/views/Exercise/Details/Summary/Edit.vue
+++ b/src/views/Exercise/Details/Summary/Edit.vue
@@ -26,12 +26,12 @@
           required
         />
 
-        <Checkbox
+        <!-- <Checkbox
           id="invite-only"
           v-model="formData.inviteOnly"
           label="Invite only exercise"
           hint="When this is checked, only invited candidates will be able to apply to this exercise."
-        />
+        /> -->
 
         <DateInput
           id="estimated-launch-date"
@@ -97,6 +97,15 @@
           type="url"
         />
 
+        <ListingPreview
+          class="govuk-!-margin-bottom-4"
+          :exercise="{...exercise, ...formData }"
+        />
+        <DetailPreview
+          v-if="advertType !== 'listing'"
+          :exercise="{...exercise, ...formData }"
+        />
+
         <button class="govuk-button">
           Save and continue
         </button>
@@ -116,6 +125,9 @@ import { exerciseAdvertTypes } from '@/helpers/exerciseHelper';
 import { ADVERT_TYPES } from '@/helpers/constants';
 import BackLink from '@jac-uk/jac-kit/draftComponents/BackLink';
 import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox';
+import ListingPreview from '@/components/Previews/ListingPreview.vue';
+import DetailPreview from '@/components/Previews/DetailPreview.vue';
+import exerciseMixin from '@/views/Exercise/exerciseMixin.js';
 
 export default {
   name: 'SummaryEdit',
@@ -127,8 +139,11 @@ export default {
     Select,
     BackLink,
     Checkbox,
+    ListingPreview,
+    DetailPreview,
   },
   extends: Form,
+  mixins: [exerciseMixin],
   data() {
     const defaults = {
       name: null,
@@ -148,6 +163,9 @@ export default {
     };
   },
   computed: {
+    exercise() {
+      return this.$store.state.exerciseDocument.record;
+    },
     launchDate: {
       get() {
         return this.parseDate(this.formData.estimatedLaunchDate);

--- a/src/views/Exercise/Details/Summary/Edit.vue
+++ b/src/views/Exercise/Details/Summary/Edit.vue
@@ -102,7 +102,8 @@
           :exercise="{...exercise, ...formData }"
         />
         <DetailPreview
-          v-if="advertType !== 'listing'"
+          v-if="{...exercise, ...formData }.advertType !== 'listing'"
+          class="govuk-!-margin-bottom-4"
           :exercise="{...exercise, ...formData }"
         />
 
@@ -168,7 +169,7 @@ export default {
     },
     launchDate: {
       get() {
-        return this.parseDate(this.formData.estimatedLaunchDate);
+        return this.parseDate({ ...this.exercise, ...this.formData }.estimatedLaunchDate);
       },
       set(val) {
         if (!val || !(val instanceof Date)){

--- a/src/views/Exercise/Details/Summary/View.vue
+++ b/src/views/Exercise/Details/Summary/View.vue
@@ -21,14 +21,14 @@
         </dt>
         <dd class="govuk-summary-list__value">
           {{ exercise.name }}
-          <span
+          <!-- <span
             v-if="exercise.inviteOnly"
           >
             -
             <b>
               Invite only exercise
             </b>
-          </span>
+          </span> -->
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -133,12 +133,11 @@
       />
     </Modal>
     <ListingPreview
+      class="govuk-!-margin-bottom-4"
       :exercise="exercise"
     />
-    <div
-      class="govuk-!-margin-top-4"
-    />
     <DetailPreview
+      v-if="advertType !== 'listing'"
       :exercise="exercise"
     />
   </div>
@@ -154,6 +153,7 @@ import { ADVERT_TYPES } from '@/helpers/constants';
 import CustomHTML from '@/components/CustomHTML';
 import ListingPreview from '@/components/Previews/ListingPreview.vue';
 import DetailPreview from '@/components/Previews/DetailPreview.vue';
+import exerciseMixin from '@/views/Exercise/exerciseMixin.js';
 
 export default {
   name: 'SummaryView',
@@ -164,7 +164,7 @@ export default {
     ListingPreview,
     DetailPreview,
   },
-  mixins: [permissionMixin],
+  mixins: [permissionMixin, exerciseMixin],
   computed: {
     exercise() {
       return this.$store.state.exerciseDocument.record;
@@ -180,9 +180,6 @@ export default {
     },
     canPublish() {
       return this.exercise.progress && this.exercise.progress.exerciseSummary;
-    },
-    advertType() {
-      return this.exercise.advertType ? this.exercise.advertType : ADVERT_TYPES.FULL;
     },
   },
   methods: {

--- a/src/views/Exercise/Details/Summary/View.vue
+++ b/src/views/Exercise/Details/Summary/View.vue
@@ -132,6 +132,15 @@
         @close="$refs['modalChangeExerciseAdvertType'].closeModal()"
       />
     </Modal>
+    <ListingPreview
+      :exercise="exercise"
+    />
+    <div
+      class="govuk-!-margin-top-4"
+    />
+    <DetailPreview
+      :exercise="exercise"
+    />
   </div>
 </template>
 
@@ -143,6 +152,8 @@ import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 import ChangeExerciseAdvertType from '@/components/ModalViews/ChangeExerciseAdvertType';
 import { ADVERT_TYPES } from '@/helpers/constants';
 import CustomHTML from '@/components/CustomHTML';
+import ListingPreview from '@/components/Previews/ListingPreview.vue';
+import DetailPreview from '@/components/Previews/DetailPreview.vue';
 
 export default {
   name: 'SummaryView',
@@ -150,6 +161,8 @@ export default {
     Modal,
     ChangeExerciseAdvertType,
     CustomHTML,
+    ListingPreview,
+    DetailPreview,
   },
   mixins: [permissionMixin],
   computed: {
@@ -166,13 +179,17 @@ export default {
       return this.exercise.published;
     },
     canPublish() {
-      return this.exercise.progress && this.exercise.progress.vacancySummary;
+      return this.exercise.progress && this.exercise.progress.exerciseSummary;
     },
     advertType() {
       return this.exercise.advertType ? this.exercise.advertType : ADVERT_TYPES.FULL;
     },
   },
   methods: {
+    isAdvertTypeListing(value) {
+      const returnValue = value && value === ADVERT_TYPES.LISTING;
+      return returnValue;
+    },
     async publish() {
       await this.$store.dispatch('exerciseDocument/publish');
       logEvent('info', 'Exercise published', {

--- a/src/views/Exercise/Details/Vacancy/Edit.vue
+++ b/src/views/Exercise/Details/Vacancy/Edit.vue
@@ -398,6 +398,16 @@
           required
         />
 
+        <ListingPreview
+          class="govuk-!-margin-bottom-4"
+          :exercise="{...exercise, ...formData }"
+        />
+        <DetailPreview
+          v-if="{...exercise, ...formData }.advertType !== 'listing'"
+          class="govuk-!-margin-bottom-4"
+          :exercise="{...exercise, ...formData }"
+        />
+
         <button class="govuk-button">
           Save and continue
         </button>
@@ -418,6 +428,8 @@ import Currency from '@jac-uk/jac-kit/draftComponents/Form/Currency';
 import TextareaInput from '@jac-uk/jac-kit/draftComponents/Form/TextareaInput';
 import RichTextInput from '@jac-uk/jac-kit/draftComponents/Form/RichTextInput';
 import BackLink from '@jac-uk/jac-kit/draftComponents/BackLink';
+import ListingPreview from '@/components/Previews/ListingPreview.vue';
+import DetailPreview from '@/components/Previews/DetailPreview.vue';
 
 export default {
   components: {
@@ -431,6 +443,8 @@ export default {
     TextareaInput,
     RichTextInput,
     BackLink,
+    DetailPreview,
+    ListingPreview,
   },
   extends: Form,
   data() {
@@ -462,6 +476,9 @@ export default {
     };
   },
   computed: {
+    exercise() {
+      return this.$store.state.exerciseDocument.record;
+    },
     hasJourney() {
       return this.$store.getters['exerciseCreateJourney/hasJourney'];
     },

--- a/src/views/Exercise/Details/Vacancy/View.vue
+++ b/src/views/Exercise/Details/Vacancy/View.vue
@@ -167,6 +167,18 @@
         </dd>
       </div>
     </dl>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <ListingPreview
+          class="govuk-!-margin-bottom-4"
+          :exercise="exercise"
+        />
+        <DetailPreview
+          v-if="exercise.advertType !== 'listing'"
+          :exercise="exercise"
+        />
+      </dt>
+    </div>
   </div>
 </template>
 
@@ -175,12 +187,16 @@ import { isEditable } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
 import Banner from '@jac-uk/jac-kit/components/Banner/Banner.vue';
 import CustomHTML from '@/components/CustomHTML';
+import ListingPreview from '@/components/Previews/ListingPreview.vue';
+import DetailPreview from '@/components/Previews/DetailPreview.vue';
 
 export default {
   name: 'VacancyView',
   components: {
     CustomHTML,
     Banner,
+    DetailPreview,
+    ListingPreview,
   },
   mixins: [permissionMixin],
   computed: {

--- a/src/views/Exercise/exerciseMixin.js
+++ b/src/views/Exercise/exerciseMixin.js
@@ -1,0 +1,35 @@
+import exerciseTimeline from '@/helpersTMP/Timeline/exerciseTimeline';
+import createTimeline from '@/helpersTMP/Timeline/createTimeline';
+
+const ADVERT_TYPES = {
+  LISTING: 'listing',
+  BASIC: 'basic',
+  FULL: 'full',
+  EXTERNAL: 'external',
+};
+
+const exerciseMixin = {
+  computed: {
+    timeline() {
+      const timeline = exerciseTimeline(this.exercise);
+      return createTimeline(timeline);
+    },
+    showAppointmentType() {
+      return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC ? true : false;
+    },
+    showNumberOfVacancies() {
+      return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC ? true : false;
+    },
+    showLocation() {
+      return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC ? true : false;
+    },
+    advertType() {
+      return this.exercise.advertType ? this.exercise.advertType : ADVERT_TYPES.FULL;
+    },
+    advertTypeFull() {
+      return this.advertType === ADVERT_TYPES.FULL;
+    },
+  },
+};
+
+export default exerciseMixin;


### PR DESCRIPTION
## What's included?
Initial work for creating and implementing components to preview apply side exercise 'listing' and 'detail' sections before taking an exercise live.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Try a variety of exercise states, listing types, legal, non-legal and other configurations and check listing show successfully and correctly under the website listing section of an exercise.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this work contains new components which need thorough testing.

## Additional context
![image](https://user-images.githubusercontent.com/44227249/203356354-2f4edde2-07b0-48fe-a768-6d55a08085f5.png)

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
