### PR TITLE
#1834 Bugfix: show no qualifications after amend

### DIFF
--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -952,10 +952,18 @@ export default {
         changedObj = obj;
       }
 
-      const updatedApplication = {
-        [obj.field]: {
-          ...this.application[obj.field], ...changedObj },
-      };
+      let updatedApplication = null;
+      // check if field is array
+      if (Array.isArray(this.application[obj.field])) {
+        updatedApplication = {
+          [obj.field]: changedObj,
+        };
+      } else {
+        updatedApplication = {
+          [obj.field]: {
+            ...this.application[obj.field], ...changedObj },
+        };
+      }
 
       this.$emit('updateApplication', updatedApplication);
 


### PR DESCRIPTION
## What's included?
When an admin user amends a candidate's qualifications on the admin site, it will not show correctly on the apply site due to the data structure changing from array to object in Firestore. This PR will fix this problem.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Scenario 1
1. [admin] Find an application and add new qualifications
2. [apply] Go to the qualification section and check if the information shows correctly.

Scenario 2
1. [apply] Go to the qualification section and fill in some qualifications
2. [admin] Go to the application and check if the information shows correctly.
3. [admin] Amend the qualifications (e.g. location, date)
4. [apply] Go to the qualification section and check if the information has been amended correctly.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
1. Add new qualifications

https://user-images.githubusercontent.com/79906532/208093284-5c42689c-1dec-4b68-98f5-fd2ae42f92e6.mov

4. Amend current qualifications

https://user-images.githubusercontent.com/79906532/208093342-b3980fa3-8f86-468f-9196-941798d726b0.mov

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
