### PR TITLE
#1846 Statutory consultation report 

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -59,6 +59,7 @@ import ExerciseReportsReasonableAdjustments from '@/views/Exercise/Reports/Reaso
 import ExerciseReportsQualifyingTestReports from '@/views/Exercise/Reports/QualifyingTestReports/QualifyingTestReports';
 import ExerciseReportsAgency from '@/views/Exercise/Reports/Agency';
 import ExerciseReportsHandover from '@/views/Exercise/Reports/Handover';
+import ExerciseReportsStatutoryConsultation from '@/views/Exercise/Reports/StatutoryConsultation';
 import QualifyingTestReportCreate from '@/views/Exercise/Reports/QualifyingTestReports/Create';
 import QualifyingTestReport from '@/views/Exercise/Reports/QualifyingTestReports/QualifyingTestReport';
 import QualifyingTestReports from '@/views/Exercise/Reports/QualifyingTestReports/QualifyingTestReports';
@@ -1258,6 +1259,14 @@ const router = new Router({
                 title: 'Handover | Exercise Reports',
               },
             },
+            {
+              path: 'statutory-consultation',
+              component: ExerciseReportsStatutoryConsultation,
+              meta: {
+                requiresAuth: true,
+                title: 'Statutory Consultation | Exercise Reports',
+              },
+            },  
           ],
         },
       ],

--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -59,6 +59,10 @@ export default {
           path: `${path}/handover`,
         },
         {
+          title: 'Statutory Consultation',
+          path: `${path}/statutory-consultation`,
+        },
+        {
           title: 'Custom',
           path: `${path}/custom`,
         },

--- a/src/views/Exercise/Reports/StatutoryConsultation.vue
+++ b/src/views/Exercise/Reports/StatutoryConsultation.vue
@@ -38,50 +38,6 @@
         </div>
       </div>
     </div>
-
-    <div class="govuk-grid-column-two-thirds clearfix">
-      <div class="govuk-button-group">
-        <Select
-          id="exercise-stage"
-          v-model="exerciseStage"
-          class="govuk-!-margin-right-2"
-        >
-          <option value="all">
-            All applications
-          </option>
-          <option
-            v-if="applicationRecordCounts.review"
-            value="review"
-          >
-            Review
-          </option>
-          <option
-            v-if="applicationRecordCounts.shortlisted"
-            value="shortlisted"
-          >
-            Shortlisted
-          </option>
-          <option
-            v-if="applicationRecordCounts.selected"
-            value="selected"
-          >
-            Selected
-          </option>
-          <option
-            v-if="applicationRecordCounts.recommended"
-            value="recommended"
-          >
-            Recommended
-          </option>
-          <option
-            v-if="applicationRecordCounts.handover"
-            value="handover"
-          >
-            Handover
-          </option>
-        </Select>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -91,18 +47,12 @@ import { firestore, functions } from '@/firebase';
 import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
 import { downloadXLSX } from '@jac-uk/jac-kit/helpers/export';
 import permissionMixin from '@/permissionMixin';
-import Select from '@jac-uk/jac-kit/draftComponents/Form/Select';
-import { applicationRecordCounts } from '@/helpers/exerciseHelper';
 
 export default {
   name: 'StatutoryConsultation',
-  components: {
-    Select,
-  },
   mixins: [permissionMixin],
   data() {
     return {
-      exerciseStage: 'all',
       report: null,
       refreshingReport: false,
     };
@@ -111,9 +61,6 @@ export default {
     ...mapState({
       exercise: state => state.exerciseDocument.record,
     }),
-    applicationRecordCounts() {
-      return applicationRecordCounts(this.exercise);
-    },
     hasReportData() {
       return this.report && this.report.headers;
     },

--- a/src/views/Exercise/Reports/StatutoryConsultation.vue
+++ b/src/views/Exercise/Reports/StatutoryConsultation.vue
@@ -38,6 +38,50 @@
         </div>
       </div>
     </div>
+
+    <div class="govuk-grid-column-two-thirds clearfix">
+      <div class="govuk-button-group">
+        <Select
+          id="exercise-stage"
+          v-model="exerciseStage"
+          class="govuk-!-margin-right-2"
+        >
+          <option value="all">
+            All applications
+          </option>
+          <option
+            v-if="applicationRecordCounts.review"
+            value="review"
+          >
+            Review
+          </option>
+          <option
+            v-if="applicationRecordCounts.shortlisted"
+            value="shortlisted"
+          >
+            Shortlisted
+          </option>
+          <option
+            v-if="applicationRecordCounts.selected"
+            value="selected"
+          >
+            Selected
+          </option>
+          <option
+            v-if="applicationRecordCounts.recommended"
+            value="recommended"
+          >
+            Recommended
+          </option>
+          <option
+            v-if="applicationRecordCounts.handover"
+            value="handover"
+          >
+            Handover
+          </option>
+        </Select>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -47,12 +91,18 @@ import { firestore, functions } from '@/firebase';
 import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
 import { downloadXLSX } from '@jac-uk/jac-kit/helpers/export';
 import permissionMixin from '@/permissionMixin';
+import Select from '@jac-uk/jac-kit/draftComponents/Form/Select';
+import { applicationRecordCounts } from '@/helpers/exerciseHelper';
 
 export default {
-  name: 'Agency',
+  name: 'StatutoryConsultation',
+  components: {
+    Select,
+  },
   mixins: [permissionMixin],
   data() {
     return {
+      exerciseStage: 'all',
       report: null,
       refreshingReport: false,
     };
@@ -61,6 +111,9 @@ export default {
     ...mapState({
       exercise: state => state.exerciseDocument.record,
     }),
+    applicationRecordCounts() {
+      return applicationRecordCounts(this.exercise);
+    },
     hasReportData() {
       return this.report && this.report.headers;
     },

--- a/src/views/Exercise/Reports/StatutoryConsultation.vue
+++ b/src/views/Exercise/Reports/StatutoryConsultation.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="govuk-grid-column-full">
+    <div class="moj-page-header-actions">
+      <div class="moj-page-header-actions__title">
+        <h2 class="govuk-heading-l">
+          Statutory Consultation
+        </h2>
+      </div>
+
+      <div
+        class="moj-page-header-actions__actions float-right"
+      >
+        <div class="moj-button-menu">
+          <div class="moj-button-menu__wrapper">
+            <button
+              class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
+              data-module="govuk-button"
+              :disabled="!hasReportData"
+              @click="exportData()"
+            >
+              Export data
+            </button>
+            <button
+              v-if="hasPermissions([
+                PERMISSIONS.applications.permissions.canReadApplications.value,
+                PERMISSIONS.exercises.permissions.canReadExercises.value
+              ])"
+              class="govuk-button moj-button-menu__item moj-page-header-actions__action"
+              data-module="govuk-button"
+              @click="refreshReport"
+            >
+              <span
+                v-if="refreshingReport"
+                class="spinner-border spinner-border-sm"
+              /> Refresh
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import { firestore, functions } from '@/firebase';
+import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
+import { downloadXLSX } from '@jac-uk/jac-kit/helpers/export';
+import permissionMixin from '@/permissionMixin';
+
+export default {
+  name: 'Agency',
+  mixins: [permissionMixin],
+  data() {
+    return {
+      report: null,
+      refreshingReport: false,
+    };
+  },
+  computed: {
+    ...mapState({
+      exercise: state => state.exerciseDocument.record,
+    }),
+    hasReportData() {
+      return this.report && this.report.headers;
+    },
+  },
+  created() {
+    this.unsubscribe = firestore.doc(`exercises/${this.exercise.id}/reports/statutoryConsultation`)
+      .onSnapshot((snap) => {
+        if (snap.exists) {
+          this.report = vuexfireSerialize(snap);
+        }
+      });
+  },
+  destroyed() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+    }
+  },
+  methods: {
+    async refreshReport() {
+      this.refreshingReport = true;
+      try {
+        await functions.httpsCallable('generateStatutoryConsultationReport')({ exerciseId: this.exercise.id });
+      } catch (error) {
+        console.error(error);
+      }
+      this.refreshingReport = false;
+    },
+    gatherReportData() {
+      const reportData = [];
+      // get headers
+      reportData.push(this.report.headers.map(header => header.title));
+      // get rows
+      this.report.rows.forEach((row) => {
+        reportData.push(this.report.headers.map(header => row[header.ref]));
+      });
+
+      return reportData;
+    },
+    exportData() {
+      const title = 'Statutory Consultation Report';
+      const data = this.gatherReportData();
+      downloadXLSX(
+        data,
+        {
+          title: `${this.exercise.referenceNumber} ${title}`,
+          sheetName: title,
+          fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
+        }
+      );
+    },
+  },
+};
+</script>


### PR DESCRIPTION
## What's included?
1. Add statutory consultation under the reports section.
2. Add a button to export the statutory consultation report.

Sample excel file: https://app.zenhub.com/files/201485031/3d829019-e50f-4daa-9a53-f70597b28eb6/download

Note: this PR is related to [digital-platform: Generate statutory consultation report #823](https://github.com/jac-uk/digital-platform/pull/823).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Find an exercise and go to `Statutory Consultation` under the reports section.
2. Click `Refresh` and `Export data` to download the excel file. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/212359326-8a4f7961-1cb7-4abf-86c3-5fb7eb4e995c.mov

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
