### PR TITLE
Bugfix: previous and next buttons not show in default pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^16.0.0",
         "@ckeditor/ckeditor5-vue": "^1.0.3",
-        "@jac-uk/jac-kit": "^0.1.11",
+        "@jac-uk/jac-kit": "^0.1.12",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.13.0",
         "@sentry/vue": "^7.13.0",
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "0.1.11",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.11/155b405a45e739848ee5200bc809cf2249d9f453",
-      "integrity": "sha512-siymdzFdIvjvv+jAawIWR/26jTgGUSbhBUYWa0dfh8ecyU/gc4r88KCxKZAI853IjTo9KIe9HAle2EPny8K8XA=="
+      "version": "0.1.12",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.12/a7e041432abc905fd747a26cd7f8d2b6b8d42c89",
+      "integrity": "sha512-OVLILbnLu8Nz2v+ruWZdCOHa0OmcwYnlvU0i09H9HMKMNo1SFA2H8Uu0XB9oM55hQi7ubsKE1y/w9eavmx9FPg=="
     },
     "node_modules/@jest/console": {
       "version": "27.5.1",
@@ -22180,9 +22180,9 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "0.1.11",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.11/155b405a45e739848ee5200bc809cf2249d9f453",
-      "integrity": "sha512-siymdzFdIvjvv+jAawIWR/26jTgGUSbhBUYWa0dfh8ecyU/gc4r88KCxKZAI853IjTo9KIe9HAle2EPny8K8XA=="
+      "version": "0.1.12",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.12/a7e041432abc905fd747a26cd7f8d2b6b8d42c89",
+      "integrity": "sha512-OVLILbnLu8Nz2v+ruWZdCOHa0OmcwYnlvU0i09H9HMKMNo1SFA2H8Uu0XB9oM55hQi7ubsKE1y/w9eavmx9FPg=="
     },
     "@jest/console": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^16.0.0",
     "@ckeditor/ckeditor5-vue": "^1.0.3",
-    "@jac-uk/jac-kit": "^0.1.11",
+    "@jac-uk/jac-kit": "^0.1.12",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.13.0",
     "@sentry/vue": "^7.13.0",


### PR DESCRIPTION
## What's included?
Fix the `Previous` and `Next` buttons do not show when using the default pagination.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
[Default pagination]
1. Go to the exercises page (with over 50 exercises) and check if `Previous` and `Next` buttons work properly.
2. Go to the selected list under `Stages` section (with over 50 applications) and check if `Previous` and `Next` buttons work properly.

[Letter pagination]
1. Go to `Applications` tab of an exercise and check if there are no `Previous` and `Next` buttons.


## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
