### PR TITLE
Bugfix: table pagination with optional page size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^16.0.0",
         "@ckeditor/ckeditor5-vue": "^1.0.3",
-        "@jac-uk/jac-kit": "^0.1.12",
+        "@jac-uk/jac-kit": "^0.1.13",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.13.0",
         "@sentry/vue": "^7.13.0",
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "0.1.12",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.12/a7e041432abc905fd747a26cd7f8d2b6b8d42c89",
-      "integrity": "sha512-OVLILbnLu8Nz2v+ruWZdCOHa0OmcwYnlvU0i09H9HMKMNo1SFA2H8Uu0XB9oM55hQi7ubsKE1y/w9eavmx9FPg=="
+      "version": "0.1.13",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.13/40e2d2700b347bb568f865a7d740faad60cae366",
+      "integrity": "sha512-0Scla2HWqTsXvflYn1VfXoPXFnPE3Y6DWqjd4rDnuZjQUeJGQVXsJGRyMD0zZPYwbvWdBPxlppvWuF1WjJYGlg=="
     },
     "node_modules/@jest/console": {
       "version": "27.5.1",
@@ -22180,9 +22180,9 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "0.1.12",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.12/a7e041432abc905fd747a26cd7f8d2b6b8d42c89",
-      "integrity": "sha512-OVLILbnLu8Nz2v+ruWZdCOHa0OmcwYnlvU0i09H9HMKMNo1SFA2H8Uu0XB9oM55hQi7ubsKE1y/w9eavmx9FPg=="
+      "version": "0.1.13",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.13/40e2d2700b347bb568f865a7d740faad60cae366",
+      "integrity": "sha512-0Scla2HWqTsXvflYn1VfXoPXFnPE3Y6DWqjd4rDnuZjQUeJGQVXsJGRyMD0zZPYwbvWdBPxlppvWuF1WjJYGlg=="
     },
     "@jest/console": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^16.0.0",
     "@ckeditor/ckeditor5-vue": "^1.0.3",
-    "@jac-uk/jac-kit": "^0.1.12",
+    "@jac-uk/jac-kit": "^0.1.13",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.13.0",
     "@sentry/vue": "^7.13.0",


### PR DESCRIPTION
## What's included?
Upgrade `jac-kit` to `0.1.13` to fix the table pagination with the optional page size.

Note: this PR is related to [jac-kit: #90 Bugfix: Page size should be an optional prop](https://github.com/jac-uk/jac-kit/pull/91)

Before:

![Screenshot 2023-01-24 at 12 17 40](https://user-images.githubusercontent.com/79906532/214289810-b77e7e50-a8cc-42a1-8125-9a1f66dc5535.png)

After:

![Screenshot 2023-01-24 at 12 17 54](https://user-images.githubusercontent.com/79906532/214289848-e0e00105-3931-4b01-bf81-01de9e19702d.png)

## Who should test?
✅ Product owner
✅ Developers

## How to test?
1. Go to the `Notes` tab under a candidate and check if the `Next` button does not show.
2. Go to the `Qualifying Test Report` tab under the Reports section of an exercise and check if the `Next` button does not show.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
