### PR TITLE
#1839 Bugfix: Update candidate login email

### DIFF
--- a/src/views/Candidates/Actions.vue
+++ b/src/views/Candidates/Actions.vue
@@ -126,11 +126,18 @@ export default {
               currentEmailAddress: this.currentEmailAddress,
               newEmailAddress: this.newEmailAddress });
 
-            if (response.data === false) {
-              this.setMessage('Failed to update email address.', 'warning');
-            } else {
+            const result = response.data;
+            if (result.status === 'success') {
               this.setMessage('Email address was updated.', 'success');
-              this.currentEmailAddress = response.data;
+              this.currentEmailAddress = result.data;
+            } else {
+              if (result.data.code === 'auth/email-already-exists') {
+                this.setMessage('An account already exists with this email address. To update the candidate login email address with this email address the other account will need to be removed. Please contact the Digital Team for assistance.', 'warning');
+              } else if (result.data.code === 'auth/invalid-email') {
+                this.setMessage(result.data.message, 'warning');
+              } else {
+                this.setMessage('Failed to update email address.', 'warning');
+              }
             }
           }
           catch (error) {


### PR DESCRIPTION
## What's included?
Update the error message when amending the candidate's login email address.

If the new email is already on the platform, the error message will be: 
```
An account already exists with this email address. To update the candidate login email address with this email address the other account will need to be removed. Please contact the Digital Team for assistance.
```

Note: this PR is related to [digital-platform: 1839 Error message when update candidate email](https://github.com/jac-uk/digital-platform/pull/832).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test
1. Find an email address already on the platform.
2. Go to a candidate page and update the candidate login email address with the email.
3. Check if the error message shows correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/214807551-0afbd58c-7ae9-40d7-8c5f-8db2e7a1edfa.mov

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
