### PR TITLE
selection process outcome date format

### DIFF
--- a/src/helpersTMP/Timeline/exerciseTimeline.js
+++ b/src/helpersTMP/Timeline/exerciseTimeline.js
@@ -266,7 +266,7 @@ const exerciseTimeline = (data) => {
       {
         entry: 'Selection process outcome',
         date: data.finalOutcome,
-        dateString: getDateString(data.finalOutcome),
+        dateString: getDateString(data.finalOutcome, 'month'),
       }
     );
   }


### PR DESCRIPTION
## What's included?
On admin side view of exercise timeline, selection process outcome was shown to the day, this has been formatted to match input: showing month and year rather than day, month and year.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to timeline page on any exercise
- view the selection process outcome date 
- ensure it shows month and year, but not day

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

<!---
## Additional context
Include screen grabs, video demo, notes etc.
--->

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
