### PR TITLE
1811/sra bsb templates

### DIFF
--- a/src/views/Exercise/Reports/Agency.vue
+++ b/src/views/Exercise/Reports/Agency.vue
@@ -642,14 +642,57 @@ export default {
 
       return reportData;
     },
+    gatherBSBReportData() {
+      const reportData = [];
+      const headers = [
+        { title: 'Surname', ref: 'lastName' },
+        { title: 'Forename(s)', ref: 'firstName' },
+        { title: 'BSB Number', ref: 'bsbNumber' },
+      ];
+      // get headers
+      reportData.push(headers.map(header => header.title));
+
+      // get rows
+      this.report.rows.forEach((row) => {
+        reportData.push(headers.map(header => row[header.ref] ? row[header.ref] : ''));
+      });
+
+      return reportData;
+    },
+    gatherSRAReportData() {
+      const reportData = [];
+      const headers = [
+        { title: 'Surname', ref: 'lastName' },
+        { title: 'Forename(s)', ref: 'firstName' },
+        { title: 'SRA Number', ref: 'sraNumber' },
+      ];
+      // get headers
+      reportData.push(headers.map(header => header.title));
+
+      // get rows
+      this.report.rows.forEach((row) => {
+        reportData.push(headers.map(header => row[header.ref] ? row[header.ref] : ''));
+      });
+
+      return reportData;
+    },
     exportData() {
       const title = 'Agency Report';
       let data = null;
+      let dataTag;
 
       if (this.activeTab === 'acro') {
+        dataTag = 'ACRO';
         data = this.gatherACROReportData();
       } else if (this.activeTab === 'hmrc') {
+        dataTag = 'HMRC';
         data = this.gatherHMRCReportData();
+      } else if (this.activeTab === 'bsb') {
+        dataTag = 'BSB';
+        data = this.gatherBSBReportData();
+      } else if (this.activeTab === 'sra') {
+        dataTag = 'SRA';
+        data = this.gatherSRAReportData();
       } else {
         data = this.gatherReportData();
       }
@@ -657,9 +700,9 @@ export default {
       downloadXLSX(
         data,
         {
-          title: `${this.exercise.referenceNumber} ${title}`,
+          title: `${this.exercise.referenceNumber} ${title} - ${dataTag}`,
           sheetName: title,
-          fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
+          fileName: `${this.exercise.referenceNumber} - ${title} - ${dataTag}.xlsx`,
         }
       );
     },

--- a/src/views/Exercise/Reports/Agency.vue
+++ b/src/views/Exercise/Reports/Agency.vue
@@ -701,7 +701,7 @@ export default {
         data,
         {
           title: `${this.exercise.referenceNumber} ${title} - ${dataTag}`,
-          sheetName: title,
+          sheetName: `${title} - ${dataTag} report`,
           fileName: `${this.exercise.referenceNumber} - ${title} - ${dataTag}.xlsx`,
         }
       );


### PR DESCRIPTION
## What's included?
Amendments to the downloaded SRA/BSB reports to adhere to the templates included in the ticket.

BSB now contains columns: **First name, Last name, BSB Number**
SRA now contains columns: **First name, Last name, SRA Number**

As well as including the titles where agency downloads differ from the overall agency report.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to [this exercise](https://jac-admin-develop--pr1915-1776-agency-report-b-pymsu4ql.web.app/exercise/11bv7ZTyyKhoqGYAPN7Y/reports/agency#bsb) under reports > agency report > BSB/SRA
- Refresh and download the XLSX reports
- Check the amended columns match the above and the download name contains 'SRA'/'BSB' appropriately 

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
