### PR TITLE
#1911 Enable QTs to be set up while exercise is still open

### DIFF
--- a/src/views/Exercise/Tasks/Task/New/default.vue
+++ b/src/views/Exercise/Tasks/Task/New/default.vue
@@ -11,20 +11,20 @@
     </p>
 
     <Checkbox
+      v-for="(timelineTask, index) in timelineTasks"
+      :id="`timelineTask-${index}`"
+      :key="`timelineTask-${index}`"
+      v-model="formData.timelineTasks[index]"
+    >
+      {{ timelineTask.entry }} will happen on {{ timelineTask.dateString }}
+    </Checkbox>
+
+    <Checkbox
       v-if="entryStatus"
       id="entryStatus"
       v-model="formData.entryStatus"
     >
-      Only '{{entryStatus | lookup}}' applications will be included
-    </Checkbox>
-
-    <Checkbox
-      v-for="(timelineTask, index) in timelineTasks"
-      :key="`timelineTask-${index}`"
-      :id="`timelineTask-${index}`"
-      v-model="formData.timelineTasks[index]"
-    >
-      {{timelineTask.entry}} will happen on {{timelineTask.dateString}}
+      Only '{{ entryStatus | lookup }}' applications will be included
     </Checkbox>
 
     <ActionButton

--- a/src/views/Exercise/Tasks/Task/New/default.vue
+++ b/src/views/Exercise/Tasks/Task/New/default.vue
@@ -5,45 +5,32 @@
     </h1>
 
     <p
-      class="govuk-body-l"
+      class="govuk-body"
     >
-      Please check the following details before continuing
+      Please confirm the following
     </p>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <div class="panel govuk-!-margin-bottom-5 govuk-!-padding-4 background-light-grey">
-          <div class="govuk-caption-m">
-            Applications <span v-if="entryStatus">({{ entryStatus | lookup }})</span>
-          </div>
-          <h2
-            class="govuk-heading-m govuk-!-margin-bottom-0"
-          >
-            {{ totalApplications }}
-          </h2>
-        </div>
-      </div>
+    <Checkbox
+      v-if="entryStatus"
+      id="entryStatus"
+      v-model="formData.entryStatus"
+    >
+      Only '{{entryStatus | lookup}}' applications will be included
+    </Checkbox>
 
-      <div
-        v-for="(timelineTask, index) in timelineTasks"
-        :key="`timelineTask-${index}`"
-        class="govuk-grid-column-one-half"
-      >
-        <div class="panel govuk-!-margin-bottom-5 govuk-!-padding-4 background-light-grey">
-          <span class="govuk-caption-m">{{ timelineTask.entry }}</span>
-          <h2
-            class="govuk-heading-m govuk-!-margin-bottom-0"
-          >
-            {{ timelineTask.dateString }}
-          </h2>
-        </div>
-      </div>
-    </div>
+    <Checkbox
+      v-for="(timelineTask, index) in timelineTasks"
+      :key="`timelineTask-${index}`"
+      :id="`timelineTask-${index}`"
+      v-model="formData.timelineTasks[index]"
+    >
+      {{timelineTask.entry}} will happen on {{timelineTask.dateString}}
+    </Checkbox>
 
     <ActionButton
       class="govuk-!-margin-bottom-0"
       type="primary"
-      :disabled="!totalApplications"
+      :disabled="!isFormCompleted"
       @click="btnInitialise"
     >
       Continue
@@ -56,17 +43,27 @@ import { btnNext } from '../helper';
 import { TASK_TYPE } from '@/helpers/constants';
 import { taskEntryStatus, previousTaskType, getTimelineTasks } from '@/helpers/exerciseHelper';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton';
+import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox';
 import { functions } from '@/firebase';
 
 export default {
   components: {
     ActionButton,
+    Checkbox,
   },
   props: {
     type: {
       required: true,
       type: String,
     },
+  },
+  data() {
+    return {
+      formData: {
+        entryStatus: null,
+        timelineTasks: [],
+      },
+    };
   },
   computed: {
     exercise() {
@@ -96,6 +93,17 @@ export default {
         return this.exercise._applicationRecords.review || 0;
       }
       return 0;
+    },
+    isFormCompleted() {
+      let expectedLength = 0;
+      let actualLength = 0;
+      if (this.entryStatus) {
+        expectedLength += 1;
+        if (this.formData.entryStatus === true) actualLength += 1;
+      }
+      expectedLength += this.timelineTasks.length;
+      actualLength += this.formData.timelineTasks.length;
+      return expectedLength === actualLength;
     },
   },
   methods: {

--- a/src/views/Exercise/Tasks/Task/TestActivated.vue
+++ b/src/views/Exercise/Tasks/Task/TestActivated.vue
@@ -3,13 +3,15 @@
     <h1 class="govuk-heading-l">
       {{ type | lookup }}
     </h1>
-    <p class="govuk-body-l govuk-!-margin-bottom-4">
-      This test is hosted on the
+    <p class="govuk-body govuk-!-margin-bottom-4">
+      Please log in to the
       <a
         :href="testAdminURL"
         target="_blank"
       >
-        QT Platform</a>.
+        QT Platform</a> to run and manage the {{ type | lookup }}.
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-4">
       When the test and mop-ups have been completed you may continue.
     </p>
     <ActionButton

--- a/src/views/Exercise/Tasks/Task/TestInitialised.vue
+++ b/src/views/Exercise/Tasks/Task/TestInitialised.vue
@@ -3,22 +3,24 @@
     <h1 class="govuk-heading-l">
       {{ type | lookup }}
     </h1>
-    <p class="govuk-body-l govuk-!-margin-bottom-4">
-      This test is hosted on the
+    <p class="govuk-body govuk-!-margin-bottom-4">
+      Please log in to the
       <a
         :href="testAdminURL"
         target="_blank"
       >
-        QT Platform</a>.
+        QT Platform</a> to set up the {{ type | lookup }}.
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-4">
       When all applications are ready please transfer them to the QT Platform.
     </p>
     <ActionButton
       type="primary"
       @click="updateTask"
     >
-      Transfer {{ totalApplications }} applications to the QT Platform
+      Transfer applications to the QT Platform
     </ActionButton>
-    <div class="panel govuk-!-margin-top-6 govuk-!-margin-bottom-6 govuk-!-padding-4 background-light-grey">
+    <!-- <div class="panel govuk-!-margin-top-6 govuk-!-margin-bottom-6 govuk-!-padding-4 background-light-grey">
       <div class="govuk-caption-m">
         URL for candidates to take this test
       </div>
@@ -33,7 +35,7 @@
       >
         Copy URL to clipboard
       </ActionButton>
-    </div>
+    </div> -->
   </div>
 </template>
 


### PR DESCRIPTION
## What's included?
Enable QTs to be set up while an exercise is still open or processing applications has not yet started.

Closes #1911 

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Locate an exercise which is open, has some applications, will be running a QT and is not yet closed for applications.
Navigate to Tasks and select Critical Analysis or Situational Judgement test.

**Before this change/fix**
It was not possible to 'Continue' with the task and prepare the live QT
![image.png](https://images.zenhubusercontent.com/5e412648a39708a606c962c9/338f04c3-59ab-4f54-8e80-4d280c7c1756)

**After this change/fix**
The user must confirm key details of the task and can then 'Continue' with the task and prepare the live QT
![image.png](https://images.zenhubusercontent.com/5e412648a39708a606c962c9/4b1f9d61-188d-4792-90d9-b38644c996c3)

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
