### PR TITLE
Edit assessor type

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^16.0.0",
     "@ckeditor/ckeditor5-vue": "^1.0.3",
-    "@jac-uk/jac-kit": "^0.1.20",
+    "@jac-uk/jac-kit": "file:../jac-kit/src/packages",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.13.0",
     "@sentry/vue": "^7.13.0",

--- a/src/components/ModalViews/IndependentAssessorChange.vue
+++ b/src/components/ModalViews/IndependentAssessorChange.vue
@@ -8,6 +8,20 @@
         <form @submit.prevent="validateAndSave">
           <ErrorSummary :errors="errors" />
           <fieldset>
+            <Select
+              id="assessor-type"
+              v-model="type"
+              label="Assessor type"
+              required
+            >
+              <option
+                v-for="option in assessorTypes"
+                :key="option"
+                :value="option"
+              >
+                {{ option | lookup }}
+              </option>
+            </Select>
             <TextField
               id="full-name"
               v-model="fullName"
@@ -21,14 +35,14 @@
               required
             />
             <TextField
-              id="first-assessor-email"
+              id="assessor-email"
               v-model="email"
               label="Email"
               type="email"
               required
             />
             <TextField
-              id="first-assessor-Phone"
+              id="assessor-Phone"
               v-model="phone"
               label="Phone"
               type="tel"
@@ -57,12 +71,15 @@
 import Form from '@jac-uk/jac-kit/draftComponents/Form/Form';
 import ErrorSummary from '@jac-uk/jac-kit/draftComponents/Form/ErrorSummary';
 import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField';
+import Select from '@jac-uk/jac-kit/draftComponents/Form/Select';
+import { ASSESSOR_TYPES } from '@/helpers/constants';
 
 export default {
   name: 'IndependentAssessorChange',
   components: {
     ErrorSummary,
     TextField,
+    Select,
   },
   extends: Form,
   props: {
@@ -78,10 +95,12 @@ export default {
   },
   data() {
     return {
+      type: null,
       email: null,
       fullName: null,
       phone: null,
       title: null,
+      assessorTypes: Object.values(ASSESSOR_TYPES),
     };
   },
   computed: {
@@ -91,6 +110,7 @@ export default {
     },
   },
   created() {
+    this.type = this.$attrs.type;
     this.email = this.$attrs.email;
     this.fullName = this.$attrs.fullName;
     this.phone = this.$attrs.phone;
@@ -109,6 +129,7 @@ export default {
         let data = {};
         if (this.$attrs.AssessorNr == 1) {
           data = {
+            firstAssessorType: this.type,
             firstAssessorEmail: this.email,
             firstAssessorFullName: this.fullName,
             firstAssessorPhone: this.phone,
@@ -116,6 +137,7 @@ export default {
           };
         } else if (this.$attrs.AssessorNr == 2) {
           data = {
+            firstAssessorType: this.type,
             secondAssessorEmail: this.email,
             secondAssessorFullName: this.fullName,
             secondAssessorPhone: this.phone,

--- a/src/views/InformationReview/AssessorsSummary.vue
+++ b/src/views/InformationReview/AssessorsSummary.vue
@@ -29,6 +29,17 @@
           class="govuk-summary-list__row"
         >
           <dt class="govuk-summary-list__key">
+            Type
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ application.firstAssessorType }}
+          </dd>
+        </div>
+
+        <div
+          class="govuk-summary-list__row"
+        >
+          <dt class="govuk-summary-list__key">
             Full name
           </dt>
           <dd class="govuk-summary-list__value">
@@ -75,7 +86,7 @@
         >
           No information for First Assessor
         </dt>
-        <dd 
+        <dd
           v-if="editable"
           class="govuk-summary-list__value"
         >
@@ -102,6 +113,17 @@
             >
               Edit
             </button>
+          </dd>
+        </div>
+
+        <div
+          class="govuk-summary-list__row"
+        >
+          <dt class="govuk-summary-list__key">
+            Type
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ application.secondAssessorType }}
           </dd>
         </div>
 
@@ -155,7 +177,7 @@
         >
           No information for Second Assessor
         </dt>
-        <dd 
+        <dd
           v-if="editable"
           class="govuk-summary-list__value"
         >
@@ -256,7 +278,7 @@
         >
           No information for Leadership Judge
         </dt>
-        <dd 
+        <dd
           v-if="editable"
           class="govuk-summary-list__value"
         >


### PR DESCRIPTION
## What's included?
Assessor type is now an additional field for applicants. This wasn't reflected in the admin platform, meaning this info wasn't viewable to amendable. 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Find an application that has assessors.
- Check the type is viewable present on the application overview. 
- Edit the Assessor and check the type is editable

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
![image](https://user-images.githubusercontent.com/44227249/227580414-bc86cc76-ad50-4619-b920-23197a7d6559.png)
![image](https://user-images.githubusercontent.com/44227249/227580560-3059f739-05fd-4c36-ad6f-08c8eb3c0ac7.png)

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
