### PR TITLE
#1953 Bugfix: 'Publish on website' button is always disabled

### DIFF
--- a/src/views/Exercise/Details/Summary/View.vue
+++ b/src/views/Exercise/Details/Summary/View.vue
@@ -179,7 +179,7 @@ export default {
       return this.exercise.published;
     },
     canPublish() {
-      return this.exercise.progress && this.exercise.progress.exerciseSummary;
+      return this.exercise.progress && this.exercise.progress.vacancySummary;
     },
   },
   methods: {

--- a/src/views/InformationReview/AssessorsSummary.vue
+++ b/src/views/InformationReview/AssessorsSummary.vue
@@ -123,7 +123,7 @@
             Type
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ application.secondAssessorType | lookup}}
+            {{ application.secondAssessorType | lookup }}
           </dd>
         </div>
 


### PR DESCRIPTION
## What's included?
On the website list page the 'Publish on website' button was always disabled. This PR fixes that so that the button will be enabled (providing the exercise has completed data for 'Website listing').

Closes #1953 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
View an exercise via the preview URL and https://admin-develop/judicialappointments.digital so that you can compare and see the fix.

Navigate to Website listing
See that the 'Publish on website' button works (providing the exercise has completed the Website Listing data).
Previously the button was always disabled.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
