### PR TITLE
#1955 QT Merit List feedback

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -196,7 +196,7 @@ const lookup = (value) => {
   lookup[`${TASK_TYPE.SITUATIONAL_JUDGEMENT}`] = 'Situational Judgement Test';
   lookup[`${TASK_TYPE.SITUATIONAL_JUDGEMENT}Passed`] = 'Passed SJ';
   lookup[`${TASK_TYPE.SITUATIONAL_JUDGEMENT}Failed`] = 'Failed SJ';
-  lookup[`${TASK_TYPE.QUALIFYING_TEST}`] = 'CA + SJ Scoring';
+  lookup[`${TASK_TYPE.QUALIFYING_TEST}`] = 'QT Merit List';
   lookup[`${TASK_TYPE.QUALIFYING_TEST}Passed`] = 'Passed CA + SJ';
   lookup[`${TASK_TYPE.QUALIFYING_TEST}Failed`] = 'Failed CA + SJ';
   lookup[`${TASK_TYPE.SCENARIO}`] = 'Scenario Test';

--- a/src/views/Exercise/Tasks/Task/Finalised/View.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/View.vue
@@ -410,10 +410,8 @@ export default {
       const data = {};
       if (params.outcome === this.defaultOutcome) {
         data[`overrides.${this.getOppositeOutcome(params.outcome)}`] = firebase.firestore.FieldValue.arrayRemove(...this.selectedItems);
-        data[`overrides.${params.outcome}`] = [];
       } else {
         data[`overrides.${params.outcome}`] = firebase.firestore.FieldValue.arrayUnion(...this.selectedItems);
-        data[`overrides.${this.getOppositeOutcome(params.outcome)}`] = [];
       }
       await this.$store.dispatch('task/update', { exerciseId: this.exercise.id, type: this.type, data: data } );
     },

--- a/src/views/InformationReview/AssessorsSummary.vue
+++ b/src/views/InformationReview/AssessorsSummary.vue
@@ -123,7 +123,7 @@
             Type
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ application.secondAssessorType | lookup}}
+            {{ application.secondAssessorType | lookup }}
           </dd>
         </div>
 


### PR DESCRIPTION
## What's included?

A couple of changes following feedback from a SET:
- [x] Change 'CA + SJ Scoring' -> 'QT merit list'
- [x] Bug: when an override is in place all z scores below the override are also showing a fail

Part of #1955

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

For an exercise which has completed CAT and SJT:

 - Check that the side menu and page title now says 'QT merit list' where previously it said 'CA + SJ Scoring'
 - Check that overriding a candidate pass/fail status correctly displays on both the 'individual score' view and the 'list of all scores'

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
