### PR TITLE
#1947 Welsh application - applied list

### DIFF
--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -82,6 +82,9 @@
           </RouterLink>
         </TableCell>
         <TableCell :title="tableColumns[2].title">
+          {{ row._language === 'cym' ? 'Yes' : 'No' }}
+        </TableCell>
+        <TableCell :title="tableColumns[3].title">
           {{ row.status | lookup }}
         </TableCell>
       </template>
@@ -144,6 +147,7 @@ export default {
       const cols = [];
       cols.push({ title: 'Reference number' });
       cols.push({ title: 'Name', sort: '_sort.fullNameUC', default: true });
+      cols.push({ title: 'Applied in Welsh' });
       cols.push({ title: 'Status' });
       return cols;
     },

--- a/src/views/InformationReview/AssessorsSummary.vue
+++ b/src/views/InformationReview/AssessorsSummary.vue
@@ -123,7 +123,7 @@
             Type
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ application.secondAssessorType | lookup}}
+            {{ application.secondAssessorType | lookup }}
           </dd>
         </div>
 


### PR DESCRIPTION
## What's included?
Closes #1947 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the application list of an exercise and check if the `Applied in Welsh` shows correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Screengrab:

<img width="1120" alt="Screenshot 2023-04-04 at 12 13 31" src="https://user-images.githubusercontent.com/79906532/229774897-e21937dc-f6ea-4283-913c-a7e0a650a222.png">

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
