### PR TITLE
Bugfix: Remove broken link to 'View key dates of all exercises'

### DIFF
--- a/src/views/Exercise/Details/Timeline/Edit.vue
+++ b/src/views/Exercise/Details/Timeline/Edit.vue
@@ -18,7 +18,7 @@
           :show-save-button="true"
           @save="save"
         />
-
+<!--
         <div class="govuk_body govuk-!-margin-bottom-2">
           <p class="govuk-body-l govuk-!-margin-bottom-2">
             You can return to this page later to add or change dates.
@@ -32,7 +32,7 @@
           <span class="govuk-hint">
             This can help you plan your own key dates (opens in a new tab).
           </span>
-        </div>
+        </div> -->
 
         <h2 class="govuk-heading-l">
           Application dates


### PR DESCRIPTION
## What's included?
Removes the 'View key dates...' link from Exercise Timeline as it doesn't go anywhere!
<img width="630" alt="image" src="https://user-images.githubusercontent.com/8524401/230434011-b4802eef-d652-424c-8edf-2e0225160013.png">


## Who should test?
✅ Product owner
✅ Developers

## How to test?
Navigate to Exercise > Timeline > Edit and see that the link and associated text has been removed

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
