### PR TITLE
#1942 Bugfix: Process (late) applications button

### DIFF
--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -516,10 +516,12 @@ export default {
     },
     async startProcessing() {
       await functions.httpsCallable('initialiseApplicationRecords')({ exerciseId: this.exerciseId });
+      return true;
     },
     async updateProcessing() {
       // this is temporary function to cover late applications to existing exercises. It can be removed when we automatically create applicationRecords and existing exercises have been processed
       await functions.httpsCallable('initialiseMissingApplicationRecords')({ exerciseId: this.exerciseId });
+      return true;
     },
     changeState() {
       this.$refs['modalChangeExerciseState'].openModal();


### PR DESCRIPTION
## What's included?
Fixes recent problems with the 'Process (late) applications' button.
<img width="248" alt="image" src="https://user-images.githubusercontent.com/8524401/230444928-e47822e9-db5b-4cb8-bf03-5fbd8585a5d9.png">

Closes #1942 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Visit an exercise which has applications, but processing hasn't been started yet.

Press the 'Process late applications' button. Observe that:
 - There are no on screen errors
 - The Stages & Status menu appears and applications are available in Review stage

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
