### PR TITLE
#1967 Exercise copying improvements

### DIFF
--- a/src/components/ModalViews/OverrideExercise.vue
+++ b/src/components/ModalViews/OverrideExercise.vue
@@ -80,7 +80,7 @@ export default {
       this.errorMessage = '';
 
       if (!this.referenceNumber) {
-        this.errorMessage = 'Please enter reference number.';
+        this.errorMessage = 'Please select an exercise.';
         return;
       }
 
@@ -89,7 +89,7 @@ export default {
         this.$emit('confirmed', { exerciseId: exercise.id, referenceNumber: this.referenceNumber });
         this.errorMessage = '';
       } else {
-        this.errorMessage = 'Reference number does not exist.';
+        this.errorMessage = 'Exercise does not exist.';
       }
     },
   },

--- a/src/components/ModalViews/OverrideExercise.vue
+++ b/src/components/ModalViews/OverrideExercise.vue
@@ -1,0 +1,91 @@
+<template>
+  <div>
+    <div class="modal__title text-left govuk-!-padding-2 background-blue">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+        Override an exercise
+      </h2>
+    </div>
+    <div class="modal__content govuk-!-margin-6">
+      <div style="text-align: left;">
+        <p
+          v-if="errorMessage"
+          class="govuk-error-message"
+        >
+          {{ errorMessage }}
+        </p>
+        <TextField
+          id="reference-number"
+          v-model="referenceNumber"
+          label="Reference number"
+          required
+        />
+        <button
+          class="govuk-button govuk-!-margin-right-3"
+          :disabled="!referenceNumber"
+          @click="save"
+        >
+          Override
+        </button>
+        <button
+          type="button"
+          class="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+          @click="closeModal"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField';
+
+export default {
+  name: 'OverrideExercise',
+  components: {
+    TextField,
+  },
+  data() {
+    return {
+      referenceNumber: '',
+      errorMessage: '',
+    };
+  },
+  methods: {
+    closeModal() {
+      this.$emit('close');
+    },
+    async save() {
+      this.errorMessage = '';
+
+      if (!this.referenceNumber) {
+        this.errorMessage = 'Please enter reference number.';
+        return;
+      }
+
+      const content = this.$store.state.clipboard.data.content;
+      if (this.referenceNumber.replace(/\s/g, '') === content.referenceNumber) {
+        this.errorMessage = 'Reference number should not be the same.';
+        return;
+      }
+  
+      const exercise = await this.$store.dispatch('exerciseDocument/getDocumentDataByReferenceNumber', this.referenceNumber);
+      if (exercise?.id) {
+        this.$emit('confirmed', { exerciseId: exercise.id, referenceNumber: this.referenceNumber });
+        this.errorMessage = '';
+      } else {
+        this.errorMessage = 'Reference number does not exist.';
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+  fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+</style>

--- a/src/store/exercise/collection.js
+++ b/src/store/exercise/collection.js
@@ -33,6 +33,15 @@ export default {
     unbind: firestoreAction(({ unbindFirestoreRef }) => {
       return unbindFirestoreRef('records');
     }),
+    bindDraft: firestoreAction(({ bindFirestoreRef }) => {
+      const firestoreRef = firestore
+        .collection('exercises')
+        .where('state', '==', 'draft');
+      return bindFirestoreRef('draftRecords', firestoreRef, { serialize: vuexfireSerialize });
+    }),
+    unbindDraft: firestoreAction(({ unbindFirestoreRef }) => {
+      return unbindFirestoreRef('draftRecords');
+    }),
     showFavourites: ({ commit, dispatch }) => {
       commit('updateFavourites', true);
       commit('updateArchived', false);
@@ -112,6 +121,7 @@ export default {
   },
   state: {
     records: [],
+    draftRecords: [],
     isFavourites: false,
     isArchived: false,
     selectedItems: [],

--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -30,6 +30,18 @@ export default {
       const docRef = await collection.doc(id).get();
       return docRef.data();
     },
+    getDocumentDataByReferenceNumber: async (context, referenceNumber) => {
+      let exercise = null;
+      const snap = await collection.where('referenceNumber', '==', referenceNumber).limit(1).get();
+      if (snap.empty) return null;
+
+      snap.forEach(doc => {
+        const row = doc.data();
+        row.id = doc.id;
+        exercise = row;
+      });
+      return exercise;
+    },
     create: async ({ rootState, dispatch }, data) => {
       const metaRef = firestore.collection('meta').doc('stats');
       return firestore.runTransaction((transaction) => {
@@ -51,6 +63,9 @@ export default {
       }).then((newId) => {
         return dispatch('bind', newId);
       });
+    },
+    override: async (_, { exerciseId, data }) => {
+      await collection.doc(exerciseId).update(data);
     },
     save: async ({ state }, data) => {
       const saveData = clone(data);

--- a/src/views/CreateExercise.vue
+++ b/src/views/CreateExercise.vue
@@ -152,6 +152,7 @@ import BackLink from '@jac-uk/jac-kit/draftComponents/BackLink';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 import OverrideExercise from '@/components/ModalViews/OverrideExercise.vue';
+import { cloneDeep } from 'lodash';
 
 export default {
   name: 'CreateExercise',
@@ -202,9 +203,16 @@ export default {
       this.$refs.modalOverrideExercise.closeModal();
     },
     async overrideExercise({ exerciseId, referenceNumber }) {
-      const content = this.$store.state.clipboard.data.content;
-      // TODO: should we override all fielfs from clipboard?
+      const content = cloneDeep(this.$store.state.clipboard.data.content);
+      // keep reference number
       content.referenceNumber = referenceNumber;
+      content.state = 'draft';
+      // TODO: should we override all fielfs from clipboard?
+      const ignoredFields = ['_applicationContent', '_applicationRecords', '_applications', '_approval', '_lateApplicationRequests'];
+      for (const field of ignoredFields) {
+        delete content[field];
+      }
+
       await this.$store.dispatch('exerciseDocument/override', { exerciseId, data: content });
       await this.$store.dispatch('clipboard/empty');
       this.$store.dispatch('exerciseCreateJourney/start', []);

--- a/src/views/CreateExercise.vue
+++ b/src/views/CreateExercise.vue
@@ -29,6 +29,12 @@
             >
               Create exercise from clipboard
             </ActionButton>
+            <button
+              class="govuk-button govuk-button--secondary govuk-!-margin-left-3"
+              @click.prevent="openOverrideExerciseModal"
+            >
+              Override an exercise
+            </button>
           </div>
         </div>
 
@@ -124,6 +130,13 @@
         </button>
       </div>
     </form>
+
+    <Modal ref="modalOverrideExercise">
+      <OverrideExercise
+        @close="closeOverrideExerciseModal"
+        @confirmed="overrideExercise"
+      />
+    </Modal>
   </div>
 </template>
 
@@ -137,6 +150,8 @@ import CheckboxGroup from '@jac-uk/jac-kit/draftComponents/Form/CheckboxGroup';
 import CheckboxItem from '@jac-uk/jac-kit/draftComponents/Form/CheckboxItem';
 import BackLink from '@jac-uk/jac-kit/draftComponents/BackLink';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton';
+import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
+import OverrideExercise from '@/components/ModalViews/OverrideExercise.vue';
 
 export default {
   name: 'CreateExercise',
@@ -149,6 +164,8 @@ export default {
     CheckboxItem,
     BackLink,
     ActionButton,
+    Modal,
+    OverrideExercise,
   },
   extends: Form,
   data() {
@@ -177,6 +194,22 @@ export default {
         this.$store.dispatch('exerciseCreateJourney/start', selectedPages);
         this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']());
       }
+    },
+    openOverrideExerciseModal() {
+      this.$refs.modalOverrideExercise.openModal();
+    },
+    closeOverrideExerciseModal() {
+      this.$refs.modalOverrideExercise.closeModal();
+    },
+    async overrideExercise({ exerciseId, referenceNumber }) {
+      const content = this.$store.state.clipboard.data.content;
+      // TODO: should we override all fielfs from clipboard?
+      content.referenceNumber = referenceNumber;
+      await this.$store.dispatch('exerciseDocument/override', { exerciseId, data: content });
+      await this.$store.dispatch('clipboard/empty');
+      this.$store.dispatch('exerciseCreateJourney/start', []);
+      this.$router.push(`/exercise/${exerciseId}/dashboard`);
+      this.closeOverrideExerciseModal();
     },
     async copyFromClipboard() {
       const content = this.$store.state.clipboard.data.content;

--- a/src/views/CreateExercise.vue
+++ b/src/views/CreateExercise.vue
@@ -207,7 +207,7 @@ export default {
       // keep reference number
       content.referenceNumber = referenceNumber;
       content.state = 'draft';
-      // TODO: should we override all fielfs from clipboard?
+      // ignore fields that do not need to override
       const ignoredFields = ['_applicationContent', '_applicationRecords', '_applications', '_approval', '_lateApplicationRequests'];
       for (const field of ignoredFields) {
         delete content[field];

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -155,6 +155,9 @@ export default {
     exercise() {
       return this.$store.state.exerciseDocument.record;
     },
+    exerciseId() {
+      return this.$store.state.exerciseDocument.record ? this.$store.state.exerciseDocument.record.id : null;
+    },
     isEditable() {
       return isEditable(this.exercise);
     },

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -275,13 +275,18 @@ export default {
       }
     },
     async copyToClipboard() {
-      const exercise = await this.$store.dispatch('exerciseDocument/getDocumentData', this.exerciseId);
-      await this.$store.dispatch('clipboard/write', {
-        environment: this.$store.getters.appEnvironment,
-        type: 'exercise',
-        title: `${exercise.referenceNumber} ${exercise.name}`,
-        content: exercise,
-      });
+      try {
+        const exercise = await this.$store.dispatch('exerciseDocument/getDocumentData', this.exerciseId);
+        await this.$store.dispatch('clipboard/write', {
+          environment: this.$store.getters.appEnvironment,
+          type: 'exercise',
+          title: `${exercise.referenceNumber} ${exercise.name}`,
+          content: exercise,
+        });
+        return true;
+      } catch (error) {
+        return;
+      }
     },
     openArchiveModal() {
       this.$refs.archiveModal.openModal();


### PR DESCRIPTION
## What's included?
Add a dropdown to select which draft exercise will be overridden.

Closes #1967 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Find an exercise and hit the `Copy to clipboard` button.
2. Go to `Create Exercise` page.
3. Hit the `Override an exercise` button and select a target draft exercise. Only draft exercises will list in the dropdown.
4. Hit the `Override` button and check if the data is copied correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/233940590-3c543838-c558-42f4-961e-49fbb8619128.mov

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
