### PR TITLE
Check can read msgs before loading msgs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -194,7 +194,7 @@
       </div>
     </div>
 
-    <Messages />
+    <Messages v-if="canReadMessages" />
   </div>
 </template>
 
@@ -233,6 +233,9 @@ export default {
     fullScreen() {
       return this.$store.state.ui.fullScreen;
     },
+    canReadMessages() {
+      return this.hasPermissions([this.PERMISSIONS.messages.permissions.canReadMessages.value]);
+    },
   },
   watch: {
     async isSignedIn() {
@@ -257,7 +260,9 @@ export default {
       await this.$store.dispatch('services/bind');
       const email = auth.currentUser.email;
       this.authorisedToPerformAction = await authorisedToPerformAction(email);
-      await this.getMessages();
+      if (this.canReadMessages) {
+        await this.getMessages();
+      }
     },
     signOut() {
       auth.signOut();


### PR DESCRIPTION
## What's included?
Add check that user can read messages before including the Messages component and fetching the messages

Closes #1962 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Note the following:

- permissions can be set via the 'Users' section of the site.
- a message is generated for a late application request
- below, for clarity, we'll refer to the two users as User A and User B
- no errors should appear in the chrome/firefox developer console

Go into the Users section and remove the 'read message' permission for a user who receives messages for late application requests (User A)
Login as a user who can create a late application request (User B) and create one, then logout.
Login as User A and ensure that they don't see a message for late application requests.

Then add the 'read message' permission for User A then logout.
Login as User B and create another late application request then logout.
Login as User A and you should see a message informing you about the late application request.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
