### PR TITLE
Fix events list

### DIFF
--- a/src/store/events.js
+++ b/src/store/events.js
@@ -7,21 +7,21 @@ export default {
   namespaced: true,
   actions: {
     bindInfo: firestoreAction(({ bindFirestoreRef, state }, params) => {
-      const firestoreRef = tableQuery(state.queue, firestore.collection('logs/info/events'), params);
+      const firestoreRef = tableQuery(state.info, firestore.collection('logs/info/events'), params);
       return bindFirestoreRef('info', firestoreRef, { serialize: vuexfireSerialize });
     }),
     unbindInfo: firestoreAction(({ unbindFirestoreRef }) => {
       return unbindFirestoreRef('info');
     }),
     bindWarnings: firestoreAction(({ bindFirestoreRef, state }, params) => {
-      const firestoreRef = tableQuery(state.queue, firestore.collection('logs/warnings/events'), params);
+      const firestoreRef = tableQuery(state.warnings, firestore.collection('logs/warnings/events'), params);
       return bindFirestoreRef('warnings', firestoreRef, { serialize: vuexfireSerialize });
     }),
     unbindWarnings: firestoreAction(({ unbindFirestoreRef }) => {
       return unbindFirestoreRef('warnings');
     }),
     bindErrors: firestoreAction(({ bindFirestoreRef, state }, params) => {
-      const firestoreRef = tableQuery(state.queue, firestore.collection('logs/errors/events'), params);
+      const firestoreRef = tableQuery(state.errors, firestore.collection('logs/errors/events'), params);
       return bindFirestoreRef('errors', firestoreRef, { serialize: vuexfireSerialize });
     }),
     unbindErrors: firestoreAction(({ unbindFirestoreRef }) => {


### PR DESCRIPTION
## What's included?
the `events.js` store was seemingly copied over from the `notifications.js` store and as a consequence was using some incorrect variables which weren't defined.
This fix should mean pagination on the `events`, `warnings`, and `errors` lists work.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
use pagination on the events list.
next,prev - next, next, prev, prev - etc

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
