### PR TITLE
JAC-KIT#107 Use latest version of jac-kit which trims whitespace from inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^16.0.0",
         "@ckeditor/ckeditor5-vue": "^1.0.3",
-        "@jac-uk/jac-kit": "^0.1.21",
+        "@jac-uk/jac-kit": "^0.1.22",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.13.0",
         "@sentry/vue": "^7.13.0",
@@ -2448,9 +2448,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "0.1.21",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.21/4385e85fd6e946cf734d6a11e5062123a7beba7c",
-      "integrity": "sha512-uMfEHv/a66MmD0ZKmrDE73p6axl0ufk5LjX/BEfoCXlCpdL9jgqDMnNJZ5ZDuxjVPUgPWwiZxVp8n2WRqmXgag=="
+      "version": "0.1.22",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.22/16bd156ff89ae470701f24bce6d6acf20d484b33",
+      "integrity": "sha512-NWS3SHq0pQz7KAfJ867hhjL89O6rwmddxicsBCJG8giNAIsrku4stdJVPwSfQSNBzqXpVcB67Uruje1NE/Mewg=="
     },
     "node_modules/@jest/console": {
       "version": "27.5.1",
@@ -20808,9 +20808,9 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "0.1.21",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.21/4385e85fd6e946cf734d6a11e5062123a7beba7c",
-      "integrity": "sha512-uMfEHv/a66MmD0ZKmrDE73p6axl0ufk5LjX/BEfoCXlCpdL9jgqDMnNJZ5ZDuxjVPUgPWwiZxVp8n2WRqmXgag=="
+      "version": "0.1.22",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.22/16bd156ff89ae470701f24bce6d6acf20d484b33",
+      "integrity": "sha512-NWS3SHq0pQz7KAfJ867hhjL89O6rwmddxicsBCJG8giNAIsrku4stdJVPwSfQSNBzqXpVcB67Uruje1NE/Mewg=="
     },
     "@jest/console": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^16.0.0",
     "@ckeditor/ckeditor5-vue": "^1.0.3",
-    "@jac-uk/jac-kit": "^0.1.21",
+    "@jac-uk/jac-kit": "^0.1.22",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.13.0",
     "@sentry/vue": "^7.13.0",


### PR DESCRIPTION
## What's included?
Use latest version of jac-kit which trims whitespace from inputs.
Closes jac-uk/jac-kit#107

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Add whitespace at beginning or end of any text or textarea input field. When the data is re-displayed you should see no whitespace at the beginning nor end of the data. eg update the candidate first name with leading or trailing whitespace and ensure it doesnt appear when re-displayed.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- 
---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
