### PR TITLE
Bugfix: user permissions not updated

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -70,7 +70,7 @@ auth.onAuthStateChanged(async (user) => {
         } else {
           const userRole = {
             roleId: userRoleId,
-            rolePermissions: res.data,
+            rolePermissions: permissions,
           };
           store.dispatch('auth/setUserRole', userRole);
         }

--- a/src/main.js
+++ b/src/main.js
@@ -62,11 +62,18 @@ auth.onAuthStateChanged(async (user) => {
       const userRoleId = idTokenResult.claims && idTokenResult.claims.r ? idTokenResult.claims.r : null;
       if (userRoleId) {
         const res = await functions.httpsCallable('adminSyncUserRolePermissions')();
-        const userRole = {
-          roleId: userRoleId,
-          rolePermissions: res.data,
-        };
-        store.dispatch('auth/setUserRole', userRole);
+        const permissions = res.data;
+        if (JSON.stringify(idTokenResult.claims.rp) !== JSON.stringify(permissions)) {
+          // need to sign in again as the current user token will be revoked if the permissions have been changed
+          auth.signOut();
+          window.location.href = '/';
+        } else {
+          const userRole = {
+            roleId: userRoleId,
+            rolePermissions: res.data,
+          };
+          store.dispatch('auth/setUserRole', userRole);
+        }
       }
     } catch (error) {
       // console.error(error);


### PR DESCRIPTION
## What's included?
Force admin users to sign out and then sign in again as the current user token will be revoked by the cloud function `adminSyncUserRolePermissions` if the permissions have been changed.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
1. Change the user role or permission of an user.
2. Refresh the page and check if it redirects to the sign in page.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/2c880244-63ee-4540-9a12-fe1498480eb2

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
