### PR TITLE
Bugfix: character checks dates not populated

### DIFF
--- a/src/views/Exercise/Tasks/CharacterChecks.vue
+++ b/src/views/Exercise/Tasks/CharacterChecks.vue
@@ -10,7 +10,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <template
-            v-if="exercise.characterChecks"
+            v-if="exercise.characterChecksDate"
           >
             {{ exercise.characterChecksDate | formatDate('long') }}
           </template>
@@ -23,7 +23,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <template
-            v-if="exercise.characterChecks"
+            v-if="exercise.characterChecksReturnDate"
           >
             {{ exercise.characterChecksReturnDate | formatDate('long') }}
           </template>
@@ -370,9 +370,6 @@ export default {
     },
     applicationRecordsCharacterChecksCompleted() {
       return this.$store.state.characterChecks.checksCompletedRecords;
-    },
-    hmrcCheckRequired() {
-      return this.exercise.characterChecks.HMRC;
     },
     characterChecksEnabled() {
       return (this.exercise.characterChecksEnabled && this.exercise.characterChecksEnabled === true);


### PR DESCRIPTION
## What's included?
In this PR [1840/remove HMRC check](https://github.com/jac-uk/admin/pull/1881) we removed HMRC checks and `CharacterChecksEdit.vue` component. Originally, it will create a field `characterChecks.HRMC` in the exercise document after `Will HMRC checks be required?` question is answered. Since we have removed `CharacterChecksEdit.vue` component, the field will not be created, which causes the contact and due date of character checks will not display. This PR will fix this problem.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Go to Character checks and check if the contact and due date display correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
