### PR TITLE
#1976 Vacancy details in welsh

### DIFF
--- a/src/views/Exercise/Details/Vacancy/Edit.vue
+++ b/src/views/Exercise/Details/Vacancy/Edit.vue
@@ -390,9 +390,29 @@
         />
 
         <RichTextInput
+          v-if="formData.welshPosts"
+          id="brief-overview-welsh"
+          v-model="formData.roleSummaryWelsh"
+          label="Brief Overview (Welsh)"
+          hint="Fersywn Cymraeg"
+          class="custom-html"
+          required
+        />
+
+        <RichTextInput
           id="full-details"
           v-model="formData.aboutTheRole"
           label="Full Details"
+          hint="Add information about this role for the information page."
+          class="custom-html"
+          required
+        />
+
+        <RichTextInput
+          v-if="formData.welshPosts"
+          id="full-details-welsh"
+          v-model="formData.aboutTheRoleWelsh"
+          label="Full Details (Welsh)"
           hint="Add information about this role for the information page."
           class="custom-html"
           required
@@ -465,10 +485,13 @@ export default {
       otherJurisdiction: null,
       statutoryConsultationWaived: null,
       statutoryConsultationWaivedDetails: null,
+      welshPosts: null,
       welshRequirement: null,
       welshRequirementType: null,
       roleSummary: null,
+      roleSummaryWelsh: null,
       aboutTheRole: null,
+      aboutTheRoleWelsh: null,
     };
     const formData = this.$store.getters['exerciseDocument/data'](defaults);
     return {

--- a/src/views/Exercise/Details/Vacancy/View.vue
+++ b/src/views/Exercise/Details/Vacancy/View.vue
@@ -155,6 +155,20 @@
           />
         </dd>
       </div>
+      <div
+        v-if="exercise.welshPosts"
+        class="govuk-summary-list__row"
+      >
+        <dt class="govuk-summary-list__key">
+          Brief Overview (Welsh)
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <CustomHTML
+            class="govuk-body"
+            :value="exercise.roleSummaryWelsh"
+          />
+        </dd>
+      </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Full Details
@@ -163,6 +177,20 @@
           <CustomHTML
             class="govuk-body"
             :value="exercise.aboutTheRole"
+          />
+        </dd>
+      </div>
+      <div
+        v-if="exercise.welshPosts"
+        class="govuk-summary-list__row"
+      >
+        <dt class="govuk-summary-list__key">
+          Full Details (Welsh)
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <CustomHTML
+            class="govuk-body"
+            :value="exercise.aboutTheRoleWelsh"
           />
         </dd>
       </div>


### PR DESCRIPTION
## What's included?
At the moment users translate the vacancy information (brief overview, full details) into Welsh and either dump it into a word doc as a download or put it at the end of the English version. In this PR an input box will be added to allow users to store the Welsh version of vacancy information.

Closes #1976 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to an exercise with Welsh posts.
2. Go to Vacancy information and check if you can amend `Brief Overview (Welsh)` and `Full Details (Welsh)`.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/dec05b58-8ac2-4123-8eef-89e8b307f899

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
