### PR TITLE
#1998 Exercise Contacts - Not Clear Email Address is needed

### DIFF
--- a/src/components/RepeatableFields/AssignedCommissioner.vue
+++ b/src/components/RepeatableFields/AssignedCommissioner.vue
@@ -5,6 +5,7 @@
       v-model="row.name"
       type="email"
       label="Assigned commissioner"
+      hint="An email address is required."
       required
     />
     <slot name="removeButton" />

--- a/src/components/RepeatableFields/SelectionExerciseManager.vue
+++ b/src/components/RepeatableFields/SelectionExerciseManager.vue
@@ -5,6 +5,7 @@
       v-model="row.name"
       type="email"
       label="Selection exercise manager"
+      hint="An email address is required."
       required
     />
     <slot name="removeButton" />

--- a/src/components/RepeatableFields/SelectionExerciseOfficer.vue
+++ b/src/components/RepeatableFields/SelectionExerciseOfficer.vue
@@ -4,6 +4,7 @@
       :id="`selection_exercise_officer_${index}`"
       v-model="row.name"
       label="Selection exercise officer"
+      hint="An email address is required."
       type="email"
       required
       :pattern="patternJACEmail"

--- a/src/components/RepeatableFields/SeniorSelectionExerciseManager.vue
+++ b/src/components/RepeatableFields/SeniorSelectionExerciseManager.vue
@@ -5,6 +5,7 @@
       v-model="row.name"
       type="email"
       label="Senior selection exercise manager"
+      hint="An email address is required."
       required
     />
     <slot name="removeButton" />


### PR DESCRIPTION
## What's included?
Closes #1998 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to Contacts of an exercise and edit the following fields:
- Senior selection exercise manager
- Selection exercise manager
- Selection exercise officer
- Assigned commissioner
2. Check if the hint `An email address is required.` appears underneath the text box

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Screenshot:

<img width="1015" alt="Screenshot 2023-05-19 at 12 04 37" src="https://github.com/jac-uk/admin/assets/79906532/e4da6d5a-3ea6-4ecd-8e45-f85829dc6ade">

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
