### PR TITLE
#2029 Barrister - Pupilage Exemption Manage Upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "patternomaly": "^1.3.2",
         "save-file": "^2.3.1",
         "stream-browserify": "^3.0.0",
-        "unique-filename": "^3.0.0",
         "vue": "^2.6.12",
         "vue-chartjs": "^5.2.0",
         "vue-dompurify-html": "^2.6.0",
@@ -10465,6 +10464,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -19021,28 +19021,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unique-filename": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-      "dependencies": {
-        "unique-slug": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/universalify": {
@@ -28905,7 +28883,8 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -35439,22 +35418,6 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
-      }
-    },
-    "unique-filename": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-      "requires": {
-        "unique-slug": "^4.0.0"
-      }
-    },
-    "unique-slug": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-      "requires": {
-        "imurmurhash": "^0.1.4"
       }
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^16.0.0",
         "@ckeditor/ckeditor5-vue": "^1.0.3",
-        "@jac-uk/jac-kit": "^0.1.22",
+        "@jac-uk/jac-kit": "^0.1.24",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.13.0",
         "@sentry/vue": "^7.13.0",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "0.1.22",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.22/16bd156ff89ae470701f24bce6d6acf20d484b33",
-      "integrity": "sha512-NWS3SHq0pQz7KAfJ867hhjL89O6rwmddxicsBCJG8giNAIsrku4stdJVPwSfQSNBzqXpVcB67Uruje1NE/Mewg=="
+      "version": "0.1.24",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.24/dcb4691954f4feef1c19350fe82db764cb0c31ce",
+      "integrity": "sha512-+eLsRP0bN4cN6D1f+7EAVJqQbHA2T8URuP/o2yAeItR/ro/H7KcVTj/heiK3K+gEMi4Iki+HDKJnQykoWEVloQ=="
     },
     "node_modules/@jest/console": {
       "version": "27.5.1",
@@ -22901,9 +22901,9 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "0.1.22",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.22/16bd156ff89ae470701f24bce6d6acf20d484b33",
-      "integrity": "sha512-NWS3SHq0pQz7KAfJ867hhjL89O6rwmddxicsBCJG8giNAIsrku4stdJVPwSfQSNBzqXpVcB67Uruje1NE/Mewg=="
+      "version": "0.1.24",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.1.24/dcb4691954f4feef1c19350fe82db764cb0c31ce",
+      "integrity": "sha512-+eLsRP0bN4cN6D1f+7EAVJqQbHA2T8URuP/o2yAeItR/ro/H7KcVTj/heiK3K+gEMi4Iki+HDKJnQykoWEVloQ=="
     },
     "@jest/console": {
       "version": "27.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "patternomaly": "^1.3.2",
         "save-file": "^2.3.1",
         "stream-browserify": "^3.0.0",
+        "unique-filename": "^3.0.0",
         "vue": "^2.6.12",
         "vue-chartjs": "^5.2.0",
         "vue-dompurify-html": "^2.6.0",
@@ -57,6 +58,7 @@
         "firebase-mock": "^2.3.2",
         "jest-canvas-mock": "^2.3.1",
         "jest-extended": "^0.11.5",
+        "path-browserify": "^1.0.1",
         "postcss": "8.2.15",
         "process": "^0.11.10",
         "sass": "^1.32.13",
@@ -10463,7 +10465,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -15870,6 +15871,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -19014,6 +19021,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "dependencies": {
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/universalify": {
@@ -28876,8 +28905,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -33074,6 +33102,12 @@
       "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -35405,6 +35439,22 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      }
+    },
+    "unique-filename": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "requires": {
+        "unique-slug": "^4.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "requires": {
+        "imurmurhash": "^0.1.4"
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "firebase-mock": "^2.3.2",
     "jest-canvas-mock": "^2.3.1",
     "jest-extended": "^0.11.5",
+    "path-browserify": "^1.0.1",
     "postcss": "8.2.15",
     "process": "^0.11.10",
     "sass": "^1.32.13",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^16.0.0",
     "@ckeditor/ckeditor5-vue": "^1.0.3",
-    "@jac-uk/jac-kit": "^0.1.22",
+    "@jac-uk/jac-kit": "^0.1.24",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.13.0",
     "@sentry/vue": "^7.13.0",

--- a/src/components/ModalViews/UploadFiles.vue
+++ b/src/components/ModalViews/UploadFiles.vue
@@ -76,11 +76,6 @@ export default {
       this.fileName = val;
       this.save('');
     },
-    getNumericalFileName() {
-      const dateNow = new Date();
-      const dateToNumber = `${dateNow.getFullYear()}${dateNow.getMonth() + 1}${dateNow.getUTCDate()}${dateNow.getHours()}${dateNow.getMinutes()}${dateNow.getSeconds()}`;
-      return dateToNumber;
-    },
     async save(action) {
       let originalData = this.$attrs.data[this.$attrs.id] || null;
       if (this.$attrs.fileRef) {

--- a/src/components/ModalViews/UploadFiles.vue
+++ b/src/components/ModalViews/UploadFiles.vue
@@ -14,7 +14,7 @@
           v-if="fileTitle"
           :id="$attrs.id"
           v-model="fileName"
-          :name="`${$attrs.name}-${getNumericalFileName()}`"
+          :name="$attrs.name"
           :path="buildFileFolder"
           :file-path="$attrs.filePath"
           label=""

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -224,6 +224,7 @@
                       ref="exemption-certificate"
                       v-model="application.uploadedExemptionCertificate"
                       name="exemption-certificate"
+                      :enable-delete="true"
                       :path="uploadPath"
                       @input="val => doFileUpload(val, 'uploadedExemptionCertificate')"
                     />
@@ -257,6 +258,7 @@
                       ref="practicing-certificate"
                       v-model="application.uploadedPracticingCertificate"
                       name="practicing-certificate"
+                      :enable-delete="true"
                       :path="uploadPath"
                       @input="val => doFileUpload(val, 'uploadedPracticingCertificate')"
                     />

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -268,7 +268,6 @@
             </div>
           </dl>
         </template>
-
       </div>
       <div
         class="govuk-body"

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -198,6 +198,73 @@
             </div>
           </div>
         </dl>
+
+        <dl>
+          <div
+            class="govuk-summary-list govuk-!-margin-bottom-0"
+          >
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key widerColumn">
+                Uploaded Pupillage Exemption Certificate
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <div v-if="application.uploadedExemptionCertificate">
+                  <DownloadLink
+                    :file-name="application.uploadedExemptionCertificate"
+                    :exercise-id="exercise.id"
+                    :user-id="application.userId"
+                    :title="application.uploadedExemptionCertificate"
+                  />
+                </div>
+                <span v-else>Not yet received</span>
+                <div v-if="editable">
+                  <FileUpload
+                    id="exemption-certificate-upload"
+                    ref="exemption-certificate"
+                    v-model="application.uploadedExemptionCertificate"
+                    name="exemption-certificate"
+                    :path="uploadPath"
+                    @input="val => doFileUpload(val, 'uploadedExemptionCertificate')"
+                  />
+                </div>
+              </dd>
+            </div>
+          </div>
+        </dl>
+
+        <dl>
+          <div
+            class="govuk-summary-list govuk-!-margin-bottom-0"
+          >
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key widerColumn">
+                Uploaded Pupillage Practicing Certificate
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <div v-if="application.uploadedPracticingCertificate">
+                  <DownloadLink
+                    :file-name="application.uploadedPracticingCertificate"
+                    :exercise-id="exercise.id"
+                    :user-id="application.userId"
+                    :title="application.uploadedPracticingCertificate"
+                  />
+                </div>
+                <span v-else>Not yet received</span>
+                <div v-if="editable">
+                  <FileUpload
+                    id="practicing-certificate-upload"
+                    ref="practicing-certificate"
+                    v-model="application.uploadedPracticingCertificate"
+                    name="practicing-certificate"
+                    :path="uploadPath"
+                    @input="val => doFileUpload(val, 'uploadedPracticingCertificate')"
+                  />
+                </div>
+              </dd>
+            </div>
+          </div>
+        </dl>
+
       </div>
       <div
         class="govuk-body"
@@ -808,11 +875,12 @@ import InformationReviewRenderer from '@/components/Page/InformationReviewRender
 import ModalInner from '@jac-uk/jac-kit/components/Modal/ModalInner';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
 import { NOT_COMPLETE_PUPILLAGE_REASONS } from '@jac-uk/jac-kit/helpers/constants';
-
 import {
   hasRelevantMemberships,
   isNonLegal
 } from '@/helpers/exerciseHelper';
+import DownloadLink from '@jac-uk/jac-kit/draftComponents/DownloadLink';
+import FileUpload from '@jac-uk/jac-kit/draftComponents/Form/FileUpload';
 
 const membershipNumbers = {
   barrister: 'Bar membership number',
@@ -826,6 +894,8 @@ export default {
     InformationReviewRenderer,
     Modal,
     ModalInner,
+    DownloadLink,
+    FileUpload,
   },
   props: {
     application: {
@@ -870,6 +940,9 @@ export default {
     },
     applicationId() {
       return this.$route.params.applicationId;
+    },
+    uploadPath() {
+      return `/exercise/${this.exercise.id}/user/${this.application.userId}`;
     },
     hasRelevantMemberships() {
       return hasRelevantMemberships(this.exercise);
@@ -1007,6 +1080,11 @@ export default {
     openModal(index) {
       this.currentIndex = index;
       this.$refs.removeModal.openModal();
+    },
+    doFileUpload(val, field) {
+      if (val) {
+        this.$emit('updateApplication', { [field]: val });
+      }
     },
   },
 };

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -199,71 +199,73 @@
           </div>
         </dl>
 
-        <dl>
-          <div
-            class="govuk-summary-list govuk-!-margin-bottom-0"
-          >
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key widerColumn">
-                Uploaded Pupillage Exemption Certificate
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <div v-if="application.uploadedExemptionCertificate">
-                  <DownloadLink
-                    :file-name="application.uploadedExemptionCertificate"
-                    :exercise-id="exercise.id"
-                    :user-id="application.userId"
-                    :title="application.uploadedExemptionCertificate"
-                  />
-                </div>
-                <span v-else>Not yet received</span>
-                <div v-if="editable">
-                  <FileUpload
-                    id="exemption-certificate-upload"
-                    ref="exemption-certificate"
-                    v-model="application.uploadedExemptionCertificate"
-                    name="exemption-certificate"
-                    :path="uploadPath"
-                    @input="val => doFileUpload(val, 'uploadedExemptionCertificate')"
-                  />
-                </div>
-              </dd>
+        <template v-if="notCompletedPupillage">
+          <dl>
+            <div
+              class="govuk-summary-list govuk-!-margin-bottom-0"
+            >
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key widerColumn">
+                  Uploaded Pupillage Exemption Certificate
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <div v-if="application.uploadedExemptionCertificate">
+                    <DownloadLink
+                      :file-name="application.uploadedExemptionCertificate"
+                      :exercise-id="exercise.id"
+                      :user-id="application.userId"
+                      title="Exemption Certificate"
+                    />
+                  </div>
+                  <span v-else>Not yet received</span>
+                  <div v-if="editable">
+                    <FileUpload
+                      id="exemption-certificate-upload"
+                      ref="exemption-certificate"
+                      v-model="application.uploadedExemptionCertificate"
+                      name="exemption-certificate"
+                      :path="uploadPath"
+                      @input="val => doFileUpload(val, 'uploadedExemptionCertificate')"
+                    />
+                  </div>
+                </dd>
+              </div>
             </div>
-          </div>
-        </dl>
+          </dl>
 
-        <dl>
-          <div
-            class="govuk-summary-list govuk-!-margin-bottom-0"
-          >
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key widerColumn">
-                Uploaded Pupillage Practicing Certificate
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <div v-if="application.uploadedPracticingCertificate">
-                  <DownloadLink
-                    :file-name="application.uploadedPracticingCertificate"
-                    :exercise-id="exercise.id"
-                    :user-id="application.userId"
-                    :title="application.uploadedPracticingCertificate"
-                  />
-                </div>
-                <span v-else>Not yet received</span>
-                <div v-if="editable">
-                  <FileUpload
-                    id="practicing-certificate-upload"
-                    ref="practicing-certificate"
-                    v-model="application.uploadedPracticingCertificate"
-                    name="practicing-certificate"
-                    :path="uploadPath"
-                    @input="val => doFileUpload(val, 'uploadedPracticingCertificate')"
-                  />
-                </div>
-              </dd>
+          <dl>
+            <div
+              class="govuk-summary-list govuk-!-margin-bottom-0"
+            >
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key widerColumn">
+                  Uploaded Pupillage Practicing Certificate
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <div v-if="application.uploadedPracticingCertificate">
+                    <DownloadLink
+                      :file-name="application.uploadedPracticingCertificate"
+                      :exercise-id="exercise.id"
+                      :user-id="application.userId"
+                      title="Practicing Certificate"
+                    />
+                  </div>
+                  <span v-else>Not yet received</span>
+                  <div v-if="editable">
+                    <FileUpload
+                      id="practicing-certificate-upload"
+                      ref="practicing-certificate"
+                      v-model="application.uploadedPracticingCertificate"
+                      name="practicing-certificate"
+                      :path="uploadPath"
+                      @input="val => doFileUpload(val, 'uploadedPracticingCertificate')"
+                    />
+                  </div>
+                </dd>
+              </div>
             </div>
-          </div>
-        </dl>
+          </dl>
+        </template>
 
       </div>
       <div
@@ -881,6 +883,7 @@ import {
 } from '@/helpers/exerciseHelper';
 import DownloadLink from '@jac-uk/jac-kit/draftComponents/DownloadLink';
 import FileUpload from '@jac-uk/jac-kit/draftComponents/Form/FileUpload';
+import _has from 'lodash/has';
 
 const membershipNumbers = {
   barrister: 'Bar membership number',
@@ -982,6 +985,17 @@ export default {
     scheduleApplies(){
       return (this.exercise.appliedSchedule == 'schedule-2-3' && this.application.applyingUnderSchedule2Three) ||
         (this.exercise.appliedSchedule == 'schedule-2-d' && this.application.applyingUnderSchedule2d);
+    },
+    notCompletedPupillage() {
+      if (_has(this.application, 'qualifications') && Array.isArray(this.application.qualifications)) {
+        const matches = this.application.qualifications.filter(qualification => {
+          return qualification.type === 'barrister'
+            && 'completedPupillage' in qualification
+            && qualification.completedPupillage === false;
+        });
+        return matches.length > 0;
+      }
+      return null;
     },
   },
   methods: {


### PR DESCRIPTION
## What's included?
Currently, when a candidate states "No" to completing pupillage in their application they will need to upload an exemption and/or practicing certificate. These documents should also be made available on admin, so admins can see and manage this information.
Added the ability to view and replace the files uploaded in association with no pupilage.

This PR is linked to the associated admin changes in the following PR: https://github.com/jac-uk/apply/pull/1022

Closes #2029 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Apply for a vacancy and when you get to the Relevant Qualifications do the following:
- Set the qualification to 'Barrister'
- Set "No" to completing pupillage
- FIll in the other inputs
- When you get to the bottom of the form only upload a single file for 'Exemption Certificate'
- Press Save And Continue button
- Submit the application

Then go to the admin section and view the application.
See the attached video for how to test:

https://github.com/jac-uk/admin/assets/115651787/30c144d4-bbe1-42e0-9358-75cb0dd03e78

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
