### PR TITLE
Hotfix: panel candidates not show

### DIFF
--- a/src/store/panels.js
+++ b/src/store/panels.js
@@ -96,7 +96,7 @@ export default {
       // TODO: add isSift to PanelsNew.vue and PanelsView.vue
       let route = false;
       if (url) {
-        route = url.includes('/tasks/sift');
+        route = url.includes('/reports/sift');
       }
       return route;
     },
@@ -104,14 +104,14 @@ export default {
       // TODO: add isSelectionDay to PanelsNew.vue and PanelsView.vue
       let route = false;
       if (url) {
-        route = url.includes('/tasks/selection');
+        route = url.includes('/reports/selection');
       }
       return route;
     },
     isScenario: () => (url) => {
       let route = false;
       if (url) {
-        route = url.includes('/tasks/scenario');
+        route = url.includes('/reports/scenario');
       }
       return route;
     },


### PR DESCRIPTION
## What's included?
Fix the issue that candidates do not load properly since we moved it from Tasks to Reports.

![image](https://github.com/jac-uk/admin/assets/79906532/60ba12fc-bafa-4d53-88f4-b9514715ae92)

![image](https://github.com/jac-uk/admin/assets/79906532/55eeaa8c-3546-46b6-8a36-345d7e71fd81)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to Sift, Selection under Reports and check if candidates show properly. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
