### PR TITLE
#2039 Bugfix: Application View should show withdrawn status

### DIFF
--- a/src/views/Candidates/TargetedOutreachReport.vue
+++ b/src/views/Candidates/TargetedOutreachReport.vue
@@ -60,7 +60,10 @@
     <template
       v-if="results.length > 0"
     >
-      <FullScreenButton ref="fullscreenButtonRef" class="float-right govuk-!-margin-right-4" />
+      <FullScreenButton
+        ref="fullscreenButtonRef"
+        class="float-right govuk-!-margin-right-4"
+      />
       <div class="govuk-grid-column-full">
         <div class="overflow-table">
           <table

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -148,7 +148,7 @@
               <h2
                 class="govuk-heading-m govuk-!-margin-bottom-0"
               >
-                Draft
+                {{ application.status | lookup }}
               </h2>
             </div>
           </div>


### PR DESCRIPTION
## What's included?
Fixes application view so it shows the status correctly. Previously 'Withdrawn' applications were displaying as 'Draft'

Closes #2039 
Also includes a lint fix

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to application view for draft, applied and withdrawn applications.
Check that application view displays correctly for each application.
In particular for withdrawn application check that status says 'Withdrawn' rather than 'Draft'

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
