### PR TITLE
Prevent running of tests when github runs the merge and manual deployment workflows

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Lint
         run: npm run lint-ci
       - name: Test
-        run: npm run test-ci
+        run: echo "tests disabled" #npm run test-ci
       - name: Create env file
         run: |
           touch .env.${{ env.environment }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Lint
         run: npm run lint-ci
       - name: Test
-        run: npm run test-ci
+        run: echo "tests disabled" #npm run test-ci
 
   deploy_to_develop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed the command to run the tests from the manual deployment and merge github workflows. This is until we have tests running with vite.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
