### PR TITLE
#2065 Editing Live Exercises

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -288,7 +288,7 @@ function isReadyForApprovalFromAdvertType(data) {
 }
 function isApprovalRejected(data) {
   if (data === null) return false;
-  return data.state === 'draft' && data._approval && data._approval.status === 'rejected';
+  return ['draft', 'ready'].includes(data.state) && data._approval && data._approval.status === 'rejected';
 }
 function isEditable(data) {
   if (data === null) return false;

--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -67,7 +67,7 @@ export default {
     override: async (_, { exerciseId, data }) => {
       await collection.doc(exerciseId).update(data);
     },
-    save: async ({ state }, data) => { 
+    save: async ({ state }, data) => {
       await collection.doc(state.record.id).update(getExerciseSaveData(state.record, data));
     },
     updateApprovalProcess: async ({ state }, { userId, userName, decision, rejectionReason }) => {
@@ -86,12 +86,10 @@ export default {
           data['state'] = 'approved';
         break;
         case 'rejected':
-          data['_approval.approved'] = null;
           data['_approval.rejected.message'] = rejectionReason;
           data['state'] = 'draft';
         break;
         default:  // 'requested'
-          data['_approval.approved'] = null;
           data['_approval.rejected'] = null;
           data['state'] = 'ready';
       }
@@ -129,9 +127,7 @@ export default {
       const ref = collection.doc(id);
       const data = {
         state: 'draft',
-        published: false,
         testingState: null,
-        _approval: null,
       };
       await ref.update(data);
     },


### PR DESCRIPTION
## What's included?
When an exercise has been unlocked for editing the vacancy should not be updated.
To achieve this I did the following:
Prevent exercise _approval from being reset when approval is rejected/requested so that it persists and we can use it to check if the exercise was previously approved.
Also prevent published and _approval from being reset when an exercise is unlocked.
(In exercise helper isApprovalRejected should also include the 'ready' state - this is a bugfix!)

THIS TICKET RELIES ON CHANGES IN THE DIGITAL PLATFORM PR: https://github.com/jac-uk/digital-platform/pull/907

Closes #2065

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

On Admin Site:
- Create a new exercise
- Get the exercise approved and published
- Unlock the exercise
- Modify the exercise title

On Apply
- Check that the exercise title **HASN'T** changed

On Admin
- Get the exercise approved

On Apply
- Check that the exercise title **HAS** changed

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
