### PR TITLE
Feature/2092 Exercise contacts - Assigned commissioner field

### DIFF
--- a/src/components/RepeatableFields/AssignedCommissioner.vue
+++ b/src/components/RepeatableFields/AssignedCommissioner.vue
@@ -8,11 +8,11 @@
       required
     >
       <option
-        v-for="user in users"
-        :key="user.uid"
-        :value="user.email"
+        v-for="email in emails"
+        :key="email"
+        :value="email"
       >
-        {{ user.email }}
+        {{ email }}
       </option>
     </Select>
     <slot name="removeButton" />
@@ -21,7 +21,6 @@
 
 <script>
 import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
-import { mapGetters } from 'vuex';
 
 export default {
   name: 'AssignedCommissioner',
@@ -39,9 +38,9 @@ export default {
     },
   },
   computed: {
-    ...mapGetters({
-      users: 'users/enabledMicrosoftUsers',
-    }),
+    emails() {
+      return this.$store.getters['services/getEmails']('commissioners');
+    },
   },
 };
 </script>

--- a/src/components/RepeatableFields/AssignedCommissioner.vue
+++ b/src/components/RepeatableFields/AssignedCommissioner.vue
@@ -39,15 +39,18 @@ export default {
   },
   computed: {
     emails() {
-      const emails = this.$store.getters['services/getEmails']('commissioners');
+      const originalEmails = this.$store.getters['services/getEmails']('commissioners');
+      // make a copy of the array so we don't mutate the original
+      const emails = [...originalEmails];
       // sort emails alphabetically
-      return emails.map(e => e).sort((a, b) => {
+      emails.sort((a, b) => {
         a = a.toLowerCase();
         b = b.toLowerCase();
         if (a < b) return -1;
         if (a > b) return 1;
         return 0;
       });
+      return emails;
     },
   },
 };

--- a/src/components/RepeatableFields/AssignedCommissioner.vue
+++ b/src/components/RepeatableFields/AssignedCommissioner.vue
@@ -39,7 +39,15 @@ export default {
   },
   computed: {
     emails() {
-      return this.$store.getters['services/getEmails']('commissioners');
+      const emails = this.$store.getters['services/getEmails']('commissioners');
+      // sort emails alphabetically
+      return emails.map(e => e).sort((a, b) => {
+        a = a.toLowerCase();
+        b = b.toLowerCase();
+        if (a < b) return -1;
+        if (a > b) return 1;
+        return 0;
+      });
     },
   },
 };


### PR DESCRIPTION
## What's included?
Closes #2092 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Sample exercise: https://jac-admin-develop--pr2093-feature-2092-exercis-5ffew8rm.web.app/exercise/FzIIFtYhcv0wVXGfDvks/details/overview

1. Go to "Contacts" of an exercise and click "Update exercise contacts" button.
2. Go to "Assigned commissioner" field and check if the commissioner's email addresses appear in the dropdown list.
3. Edit "Assigned commissioner" and click "Save and continue" button.
4. Check if the selected email address appears correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/fd5fcc5e-75a4-4944-8d88-770ed103a151

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
