### PR TITLE
Feature/2096 custom report enhancements

### DIFF
--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -137,88 +137,6 @@
         </div>
       </div>
 
-      <div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-margin-bottom-3">
-        <div class="govuk-grid-column-full">
-          <CheckboxGroup
-            id="select-status"
-            v-model="statuses"
-            label="Status"
-          >
-            <CheckboxItem
-              v-for="(status) in STATUS"
-              :key="status"
-              :value="status"
-              :label="$filters.lookup(status)"
-            />
-          </CheckboxGroup>
-        </div>
-
-        <div class="govuk-grid-column-two-thirds">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-2">
-            Stage
-          </legend>
-          <div class="govuk-button-group">
-            <select
-              v-model="selectedStage"
-              class="govuk-select govuk-!-margin-right-3"
-            >
-              <option value="all">
-                All
-              </option>
-              <option
-                v-if="applicationRecordCounts.review"
-                value="review"
-              >
-                Review
-              </option>
-              <option
-                v-if="applicationRecordCounts.shortlisted"
-                value="shortlisted"
-              >
-                Shortlisted
-              </option>
-              <option
-                v-if="applicationRecordCounts.selected"
-                value="selected"
-              >
-                Selected
-              </option>
-              <option
-                v-if="applicationRecordCounts.recommended"
-                value="recommended"
-              >
-                Recommended
-              </option>
-              <option
-                v-if="applicationRecordCounts.handover"
-                value="handover"
-              >
-                Handover
-              </option>
-            </select>
-            
-            <select
-              v-if="availableStatuses && availableStatuses.length > 0"
-              v-model="selectedStageStatus"
-              class="govuk-select govuk-!-margin-right-3"
-            >
-              <option
-                value="all"
-              >
-                All
-              </option>
-              <option
-                v-for="item in availableStatuses"
-                :key="item"
-                :value="item"
-              >
-                {{ $filters.lookup(item) }}
-              </option>
-            </select>
-          </div>
-        </div>
-      </div>
-
       <div
         v-if="columns.length > 0"
         class="panel govuk-!-margin-bottom-3"
@@ -244,6 +162,88 @@
 
         <div class="govuk-hint govuk-!-margin-top-3 govuk-!-margin-bottom-0">
           Click to remove, drag to re-order
+        </div>
+
+        <div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+          <div class="govuk-grid-column-one-third">
+            <h2>Status</h2>
+            <CheckboxGroup
+              id="select-status"
+              v-model="statuses"
+              label=""
+            >
+              <CheckboxItem
+                v-for="(status) in STATUS"
+                :key="status"
+                :value="status"
+                :label="$filters.lookup(status)"
+              />
+            </CheckboxGroup>
+          </div>
+
+          <div class="govuk-grid-column-two-thirds">
+            <h2>Stage</h2>
+            <div class="govuk-button-group">
+              <select
+                v-model="selectedStage"
+                class="govuk-select"
+              >
+                <option value="all">
+                  All
+                </option>
+                <option
+                  v-if="applicationRecordCounts.review"
+                  value="review"
+                >
+                  Review
+                </option>
+                <option
+                  v-if="applicationRecordCounts.shortlisted"
+                  value="shortlisted"
+                >
+                  Shortlisted
+                </option>
+                <option
+                  v-if="applicationRecordCounts.selected"
+                  value="selected"
+                >
+                  Selected
+                </option>
+                <option
+                  v-if="applicationRecordCounts.recommended"
+                  value="recommended"
+                >
+                  Recommended
+                </option>
+                <option
+                  v-if="applicationRecordCounts.handover"
+                  value="handover"
+                >
+                  Handover
+                </option>
+              </select>
+            </div>
+            <div class="govuk-button-group">
+              <select
+                v-if="availableStatuses && availableStatuses.length > 0"
+                v-model="selectedStageStatus"
+                class="govuk-select"
+              >
+                <option
+                  value="all"
+                >
+                  All
+                </option>
+                <option
+                  v-for="item in availableStatuses"
+                  :key="item"
+                  :value="item"
+                >
+                  {{ $filters.lookup(item) }}
+                </option>
+              </select>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -137,6 +137,88 @@
         </div>
       </div>
 
+      <div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+        <div class="govuk-grid-column-one-third">
+          <h2>Application status</h2>
+          <CheckboxGroup
+            id="select-status"
+            v-model="statuses"
+            label=""
+          >
+            <CheckboxItem
+              v-for="(status) in STATUS"
+              :key="status"
+              :value="status"
+              :label="$filters.lookup(status)"
+            />
+          </CheckboxGroup>
+        </div>
+
+        <div class="govuk-grid-column-two-thirds">
+          <h2>Stage</h2>
+          <div class="govuk-button-group">
+            <select
+              v-model="selectedStage"
+              class="govuk-select"
+            >
+              <option value="all">
+                All
+              </option>
+              <option
+                v-if="applicationRecordCounts.review"
+                value="review"
+              >
+                Review
+              </option>
+              <option
+                v-if="applicationRecordCounts.shortlisted"
+                value="shortlisted"
+              >
+                Shortlisted
+              </option>
+              <option
+                v-if="applicationRecordCounts.selected"
+                value="selected"
+              >
+                Selected
+              </option>
+              <option
+                v-if="applicationRecordCounts.recommended"
+                value="recommended"
+              >
+                Recommended
+              </option>
+              <option
+                v-if="applicationRecordCounts.handover"
+                value="handover"
+              >
+                Handover
+              </option>
+            </select>
+          </div>
+          <div class="govuk-button-group">
+            <select
+              v-if="availableStatuses && availableStatuses.length > 0"
+              v-model="selectedStageStatus"
+              class="govuk-select"
+            >
+              <option
+                value="all"
+              >
+                All
+              </option>
+              <option
+                v-for="item in availableStatuses"
+                :key="item"
+                :value="item"
+              >
+                {{ $filters.lookup(item) }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+
       <div
         v-if="columns.length > 0"
         class="panel govuk-!-margin-bottom-3"
@@ -149,6 +231,7 @@
           v-if="columns.length"
           v-model="columns"
           item-key="getDraggableKey"
+          @click="removeColumn"
         >
           <template #item="{element, index}">
             <div
@@ -162,88 +245,6 @@
 
         <div class="govuk-hint govuk-!-margin-top-3 govuk-!-margin-bottom-0">
           Click to remove, drag to re-order
-        </div>
-
-        <div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-margin-bottom-3">
-          <div class="govuk-grid-column-one-third">
-            <h2>Status</h2>
-            <CheckboxGroup
-              id="select-status"
-              v-model="statuses"
-              label=""
-            >
-              <CheckboxItem
-                v-for="(status) in STATUS"
-                :key="status"
-                :value="status"
-                :label="$filters.lookup(status)"
-              />
-            </CheckboxGroup>
-          </div>
-
-          <div class="govuk-grid-column-two-thirds">
-            <h2>Stage</h2>
-            <div class="govuk-button-group">
-              <select
-                v-model="selectedStage"
-                class="govuk-select"
-              >
-                <option value="all">
-                  All
-                </option>
-                <option
-                  v-if="applicationRecordCounts.review"
-                  value="review"
-                >
-                  Review
-                </option>
-                <option
-                  v-if="applicationRecordCounts.shortlisted"
-                  value="shortlisted"
-                >
-                  Shortlisted
-                </option>
-                <option
-                  v-if="applicationRecordCounts.selected"
-                  value="selected"
-                >
-                  Selected
-                </option>
-                <option
-                  v-if="applicationRecordCounts.recommended"
-                  value="recommended"
-                >
-                  Recommended
-                </option>
-                <option
-                  v-if="applicationRecordCounts.handover"
-                  value="handover"
-                >
-                  Handover
-                </option>
-              </select>
-            </div>
-            <div class="govuk-button-group">
-              <select
-                v-if="availableStatuses && availableStatuses.length > 0"
-                v-model="selectedStageStatus"
-                class="govuk-select"
-              >
-                <option
-                  value="all"
-                >
-                  All
-                </option>
-                <option
-                  v-for="item in availableStatuses"
-                  :key="item"
-                  :value="item"
-                >
-                  {{ $filters.lookup(item) }}
-                </option>
-              </select>
-            </div>
-          </div>
         </div>
       </div>
 

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -189,6 +189,7 @@
       <div
         v-if="data && type === 'showData'"
         class="govuk-!-margin-top-9"
+        style="overflow: auto;"
       >
         <table class="govuk-table">
           <thead class="govuk-table__head">


### PR DESCRIPTION
## What's included?
Closes #2096 

- Add a filter for the columns: `Application status`, `Stage`, `Status (admin)`
- Fix the bug of removing a column.
- Fix the data spilling over to the next row.

Note: this work is related to [digital-platform: Admin#2096 Custom report enhancements](https://github.com/jac-uk/digital-platform/pull/923)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Sample exercise: https://jac-admin-develop--pr2107-feature-2096-custom-gsjltwc4.web.app/exercise/euHYlnsu1DdSlSkve2BW/reports/custom

1. Go to the custom report section of an exercise.
2. Select multiple columns to display.
3. Apply some filters (e.g. Draft, Applied)
4. Check if the data displays correctly.
5. Click the column tag to Check if the selected column can be removed.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/595782b5-b5df-47bc-b22b-c1cb7ff80d91

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
