### PR TITLE
Bugfix: exercise tasks should use $filters

### DIFF
--- a/src/views/Exercise/Tasks/Task/Data/Initialised.vue
+++ b/src/views/Exercise/Tasks/Task/Data/Initialised.vue
@@ -28,7 +28,7 @@
         data-key="ref"
         :data="group.children"
         :columns="[
-          { title: $options.filters.lookup(group.ref) },
+          { title: $filters.lookup(group.ref) },
           { title: '' },
           { title: '' },
         ]"

--- a/src/views/Exercise/Tasks/Task/Finalised/List.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/List.vue
@@ -85,7 +85,7 @@ export default {
       tableColumns: [
         { title: 'Rank' },
         { title: 'Count' },
-        { title: this.$options.filters.lookup(this.scoreType) },
+        { title: this.$filters.lookup(this.scoreType) },
         { title: 'Female' },
         { title: 'Ethnic Minority' },
         { title: 'Solicitor' },

--- a/src/views/Exercise/Tasks/Task/Finalised/View.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/View.vue
@@ -318,7 +318,7 @@ export default {
           this.selectionCategories.forEach(() => this.capabilities.forEach(cap => columns.push({ title: cap, class: 'text-center table-cell-score' })));
         }
       }
-      columns.push({ title: this.$options.filters.lookup(this.scoreType), class: 'text-center' });
+      columns.push({ title: this.$filters.lookup(this.scoreType), class: 'text-center' });
       columns.push({ title: 'Female' });
       columns.push({ title: 'Ethnic Minority' });
       columns.push({ title: 'Solicitor' });


### PR DESCRIPTION
## What's included?
Some exercises are showing white screens, here we are fixing that!

Example:
<img width="898" alt="image" src="https://github.com/jac-uk/admin/assets/8524401/49653821-2843-4a87-a1ff-b823db526d29">

Error message:
<img width="485" alt="image" src="https://github.com/jac-uk/admin/assets/8524401/d4c24f64-d2e3-43da-b8e7-af9359e39d4f">

## Who should test?
✅ Developers

## How to test?
Here's an exercise that currently has a white screen:
https://admin.judicialappointments.digital/exercise/BpEL3HgHEyHCvDMI5E9s/tasks/qualifyingTest/finalised

Check the following preview url to see that the page has been fixed:
https://jac-apply-admin-production--pr2112-bugfix-exercise-tas-87qzwr51.web.app/exercise/BpEL3HgHEyHCvDMI5E9s/tasks/qualifyingTest/finalised

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:PRODUCTION
_can be OFF, DEVELOP or STAGING_
