### PR TITLE
#2125 Diversity Monitoring Report

### DIFF
--- a/src/views/InformationReview/EqualityAndDiversityInformationSummary.vue
+++ b/src/views/InformationReview/EqualityAndDiversityInformationSummary.vue
@@ -415,7 +415,7 @@
           <InformationReviewRenderer
             v-else
             type="selection"
-            :options="['female', 'male', 'gender-neutral', 'other-gender', 'prefer-not-to-say']"
+            :options="['female', 'male', 'prefer-not-to-say']"
             field="gender"
             :edit="editable"
             :data="equalityAndDiversitySurvey.gender"


### PR DESCRIPTION
## What's included?
Removed 'gender-neutral' and 'other' from diversity summary so that admin users no longer have it as an option.

Closes #2125 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

**Test 1**

- Go to the following test for a user who has selected 'gender-neutral'.
See: https://admin-develop.judicialappointments.digital/exercise/4xP8RY7GeoaS1yKqYJLw/applications/applied/application/0GEfgpjwxEH679YTK2we
- Ensure the gender is displayed as: Gender neutral
- Click the 'Edit' button at the top of the page.
- Ensure the gender is still displayed as: Gender neutral
- Ensure when you click the gender dropdown neither 'gender neutral' nor 'other' appear

**Test 2**

- Go to the following test for a user who has selected 'gender-other'.
See: https://admin-develop.judicialappointments.digital/exercise/5r40soW2fFmv50UEmkxP/applications/applied/application/vvbVCWQXwlszF8S3wvfP
- Ensure the gender is displayed as: Other
- Click the 'Edit' button at the top of the page.
- Ensure the gender is still displayed as: Other
- Ensure when you click the gender dropdown neither 'gender neutral' nor 'other' appear

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
