### PR TITLE
#2130 Bugfix: Application list should default to regular paging

### DIFF
--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -52,7 +52,7 @@
       :data="applications"
       :columns="tableColumns"
       search-map="_search"
-      page-item-type="uppercase-letter"
+      :page-item-type="pageItemType"
       :page-size="50"
       :total="exercise._applications[status]"
       @change="getTableData"
@@ -149,6 +149,17 @@ export default {
     },
     tableStatus() {
       return this.status;
+    },
+    pageItemType() {
+      if (
+        this.exercise && 
+        this.exercise._applications && 
+        this.exercise._applications[this.status] && 
+        this.exercise._applications[this.status] > 500
+      ) {
+        return 'uppercase-letter';
+      }
+      return '';
     },
     exercise() {
       return this.$store.state.exerciseDocument.record;


### PR DESCRIPTION
## What's included?

Fixes a bug / misconfiguration where the applications list was defaulting to A - Z paging. This is particularly confusing if there are only a few applications as it looks like there are no applications (as the list defaults to only show applications with surname beginning A)

We now default to showing all records, showing 50 at a time and if there are 500 or more applications then we default to A-Z paging.

Closes #2130

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
From the Exercises list choose an exercise with more than 500 applications - [example](https://jac-admin-develop--pr2131-bugfix-2130-u23d7fjh.web.app/exercise/4xP8RY7GeoaS1yKqYJLw/applications/applied)

 - Check that the Applications lists use A-Z paging

From the Exercises list choose an exercise with only a few (less than 500) applications - [example](https://jac-admin-develop--pr2131-bugfix-2130-u23d7fjh.web.app/exercise/2M7yxJySfXpINFwvhnnW/applications/applied)

 - Check that the Applications lists use regular paging (all records, 50 records per page)


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

**Before**
<img width="626" alt="image" src="https://github.com/jac-uk/admin/assets/8524401/0e0c1586-b24b-4314-a463-60e0a31fc393">

**After - exercise with less than 500 applications**
<img width="620" alt="image" src="https://github.com/jac-uk/admin/assets/8524401/bd10cc29-cfad-4ab5-98b0-a5b46060dfa9">

**After - exercise with 500 or more applications**
<img width="227" alt="image" src="https://github.com/jac-uk/admin/assets/8524401/ec6df55a-a276-4708-9291-904091c2aee2">


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
