### PR TITLE
#2129 Bugfix: Export contacts on Draft Applications

### DIFF
--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -25,7 +25,7 @@
               Send reminders
             </button>
             <ActionButton
-              v-if="status === 'applied' && hasPermissions([
+              v-if="hasPermissions([
                 PERMISSIONS.exercises.permissions.canReadExercises.value,
                 PERMISSIONS.applications.permissions.canReadApplications.value
               ])"


### PR DESCRIPTION

## What's included?
Following feedback from live SETs we have included the Export Contacts button on the Draft Applications list.

Closes #2129

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
For an exercise with draft applications - [example](https://jac-admin-develop--pr2132-bugfix-2129-asj2dmoc.web.app/exercise/2M7yxJySfXpINFwvhnnW/applications/draft) - navigate to Applications > Draft

 - Check that there is an Export Contacts button
 - Press the button and check that the download works and contains the expected content
 
_Note: you may need to click the `[ 1 2 3 4 ]` button in order to view applications on screen_

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

<img width="1217" alt="image" src="https://github.com/jac-uk/admin/assets/8524401/ee528ab9-aa82-429f-a0d3-6e2c39300ecb">



---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
