### PR TITLE
#2116 Hotfix Vacancy Information Values Changed

### DIFF
--- a/src/views/Exercise/Details/Preferences/View.vue
+++ b/src/views/Exercise/Details/Preferences/View.vue
@@ -29,7 +29,7 @@
           v-else
           class="govuk-summary-list__value"
         >
-          None
+          &nbsp;
         </dd>
       </div>
       <div
@@ -66,7 +66,7 @@
           v-else
           class="govuk-summary-list__value"
         >
-          None
+          &nbsp;
         </dd>
       </div>
       <div

--- a/src/views/Exercise/Details/Vacancy/View.vue
+++ b/src/views/Exercise/Details/Vacancy/View.vue
@@ -20,7 +20,7 @@
           Type of exercise
         </dt>
         <dd class="govuk-summary-list__value">
-          {{ $filters.lookup(exercise.typeOfExercise) }}
+          {{ exercise.typeOfExercise === APPLICATION_STATUS.SELECTION_INVITED ? '' : $filters.lookup(exercise.typeOfExercise) }}
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -28,7 +28,7 @@
           Is the vacancy for a court or tribunal?
         </dt>
         <dd class="govuk-summary-list__value">
-          {{ $filters.lookup(exercise.isCourtOrTribunal) }}
+          {{ exercise.isCourtOrTribunal === APPLICATION_STATUS.SELECTION_INVITED ? '' : $filters.lookup(exercise.isCourtOrTribunal) }}
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -61,9 +61,9 @@
           >
             Yes: {{ exercise.statutoryConsultationWaivedDetails }}
           </span>
-          <span v-else>
+          <!-- <span v-else>
             No
-          </span>
+          </span> -->
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -77,7 +77,7 @@
             <span v-if="exercise.salary">{{ $filters.formatCurrency(exercise.salary) }}</span>
           </span>
           <span v-else-if="exercise.appointmentType == 'fee-paid'">{{ $filters.lookup(exercise.appointmentType) }}: £{{ exercise.feePaidFee }}</span>
-          <span v-else>{{ $filters.lookup(exercise.appointmentType) }}</span>
+          <span v-else-if="exercise.appointmentType !== APPLICATION_STATUS.SELECTION_INVITED">{{ $filters.lookup(exercise.appointmentType) }}</span>
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -217,6 +217,8 @@ import Banner from '@jac-uk/jac-kit/components/Banner/Banner.vue';
 import CustomHTML from '@/components/CustomHTML.vue';
 import ListingPreview from '@/components/Previews/ListingPreview.vue';
 import DetailPreview from '@/components/Previews/DetailPreview.vue';
+//import { APPLICATION_STATUS } from '@jac-uk/jac-kit/helpers/constants';
+import { APPLICATION_STATUS } from '@/helpers/constants';
 
 export default {
   name: 'VacancyView',
@@ -227,6 +229,11 @@ export default {
     ListingPreview,
   },
   mixins: [permissionMixin],
+  data() {
+    return {
+      APPLICATION_STATUS: Object.freeze(APPLICATION_STATUS), // this makes vue not reactive on this data property
+    };
+  },
   computed: {
     exercise() {
       return this.$store.state.exerciseDocument.record;


### PR DESCRIPTION
## What's included?
On the exercise vacancy information page the default values displayed are misleading.

- All ‘Invited to selection day’ values should instead be blank
- 'Waived stat con' should be blank rather than defaulting to 'No'

In addition the Working preferences page should display blank rather than ‘None’.

Closes #2116 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Ensure the values in the page reflect the changes above instead of the previous values.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
