### PR TITLE
#2120 Exercise page alignment is breaking after on-screen error messages are displayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "admin",
       "version": "1.8.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "3.0.30",
+        "@jac-uk/jac-kit": "3.0.37",
         "@ministryofjustice/frontend": "0.2.4",
         "@rollup/plugin-inject": "^5.0.3",
         "@sentry/tracing": "^7.61.1",
@@ -59,6 +59,17 @@
         "postcss": "8.2.15"
       }
     },
+    "../jac-kit/src/packages": {
+      "name": "@jac-uk/jac-kit",
+      "version": "3.0.37",
+      "dependencies": {
+        "@ckeditor/ckeditor5-build-classic": "^38.1.0",
+        "@ckeditor/ckeditor5-vue": "^5.1.0",
+        "save-file": "^2.3.1",
+        "stream-browserify": "^3.0.0",
+        "xlsx-populate": "^1.21.0"
+      }
+    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -77,459 +88,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-38.1.1.tgz",
-      "integrity": "sha512-TDv6xOkcXws0RmfkBJ6vfuH4vwj3mbI8S++9czLKrHmwp24jSrxiRwP1ZUlJSImy+/3sTjec4u8I5fq0HA2UOA==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-38.1.1.tgz",
-      "integrity": "sha512-Ppxxp0qprhENktpKv3lkVFchS9iZt0GbCVLPg8ffTb5dCAQgeXyC/TdR1b3zpbdjgSyai07OYgU59oTNUOwtog==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-38.1.1.tgz",
-      "integrity": "sha512-+mky2W983jaSlYpvQ31af0ethMQxXUxuBkd2IzRi2cchvSK9YbQtBSkV0EM595uoJa1S3doyCJn7Y8bOdE+v3A==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-38.1.1.tgz",
-      "integrity": "sha512-YPSw+qTE71mvQTo5OA2M9oQp1jpUJrj1d15mbVE5DIyvc2CMWRltqV49GoM15ZpzgQWbaF3VZ8ZT0+vZlfS0lw==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-build-classic": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-38.1.1.tgz",
-      "integrity": "sha512-TaVK+kVX2hMZD8imbfsQHKTiMo4seBkmZvu8KgNPn8tNarmJacO27EYmPmzL04KyctP2pv4rt2UTzPfuFZyqvg==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "38.1.1",
-        "@ckeditor/ckeditor5-autoformat": "38.1.1",
-        "@ckeditor/ckeditor5-basic-styles": "38.1.1",
-        "@ckeditor/ckeditor5-block-quote": "38.1.1",
-        "@ckeditor/ckeditor5-ckbox": "38.1.1",
-        "@ckeditor/ckeditor5-ckfinder": "38.1.1",
-        "@ckeditor/ckeditor5-cloud-services": "38.1.1",
-        "@ckeditor/ckeditor5-easy-image": "38.1.1",
-        "@ckeditor/ckeditor5-editor-classic": "38.1.1",
-        "@ckeditor/ckeditor5-essentials": "38.1.1",
-        "@ckeditor/ckeditor5-heading": "38.1.1",
-        "@ckeditor/ckeditor5-image": "38.1.1",
-        "@ckeditor/ckeditor5-indent": "38.1.1",
-        "@ckeditor/ckeditor5-link": "38.1.1",
-        "@ckeditor/ckeditor5-list": "38.1.1",
-        "@ckeditor/ckeditor5-media-embed": "38.1.1",
-        "@ckeditor/ckeditor5-paragraph": "38.1.1",
-        "@ckeditor/ckeditor5-paste-from-office": "38.1.1",
-        "@ckeditor/ckeditor5-table": "38.1.1",
-        "@ckeditor/ckeditor5-typing": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-38.1.1.tgz",
-      "integrity": "sha512-+R3Vz2QL/K2pdWzOZpFtrLwFHefxQfDT99sYQSUZiOQaXA6rSoLT4x6lhIdrQRjsI/ofCIGseQxuTHc8t86urA==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-38.1.1.tgz",
-      "integrity": "sha512-58139l/uKcMD6KZzd5uPzv8IwJYNnDFsT8N6DlecTZuh3ViKmg9t/pbRWu8epOboySwHeJoA3q12m2j05C1+JQ==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-38.1.1.tgz",
-      "integrity": "sha512-FN6QxWw0ZcoMsCkm6FuN2do//qjNGofnsFernKWJPbL2E056dvB4WmhYHa4fCvGASCROcJ17yUV7oYI+1ah/og==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "@ckeditor/ckeditor5-widget": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-38.1.1.tgz",
-      "integrity": "sha512-M4MykJmA9JqlZEDCJfcGwEKq6Y1AuDf8Kxbl0LfMZu6BKv74up+c0wSD/WX7isot3eqDdSQckVjHlJvmS31EOA==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-38.1.1.tgz",
-      "integrity": "sha512-5yC+oSoCnjfOrvmECbwtu4zBt9S5dJfOYsAzfIGEbmD9DVGIyLBDKEjJ9IbAKAy1HG6CgAkZyv1YyEc5G5g3ew==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-38.1.1.tgz",
-      "integrity": "sha512-kusGv9hBkFNm3/ZSr69fgdJ3V94feL0oXQoRUsCTsv2usda6KOIY3D5XMK8vvBpa7+0gFan98AvX9KM5IvrMkQ==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-38.1.1.tgz",
-      "integrity": "sha512-LSh60tSuR8pGnLswy+Smx7x0NtFjbVX2dGiEkMyh4O0JLok/YgS3IU6UmoEd9FTjGqnOZ3644h3SpkSu84uDYA==",
-      "dependencies": {
-        "ckeditor5": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-38.1.1.tgz",
-      "integrity": "sha512-Z0LYg7B4vN3ZNUf3utmBRXQBn3JNy81Xs+45sQ09Fpf5p6aKer37vxEA315O17PnWYndildeKNRUNdjI942HcQ==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-38.1.1.tgz",
-      "integrity": "sha512-jzlTvyBwBw4TLr03NXwVeZD87pOSjisx8WCEahWM8Rxrw77k+7rg3blAWmmpw9cHUp2WkpxCztfvQtQouT9Jpw==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-38.1.1.tgz",
-      "integrity": "sha512-8Upvcjqny39pEZM5JbdyM8MESGjC6IkAJpjvqEFkbZsFcFzXjPolbxPReI3Xbl74XaMGYpwfraTv7ozkCxD7eA==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-38.1.1.tgz",
-      "integrity": "sha512-uEh62XWpw5uIpaslJfn8YZ+9DfViCRR5auAz5SdiYDY+tdLjwKS308S1um5i5G/CLjp1M3uXlvDieOopit9nYg==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-38.1.1.tgz",
-      "integrity": "sha512-iXUlw38Eoo5zwj3h9eKULenEDPYoohPLT/74UDYw1V7Q3QY3dN4fCovcWwQx7VFPMPFUtd5T1S/ki/3UpLQhSA==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "ckeditor5": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-38.1.1.tgz",
-      "integrity": "sha512-Wr0lAiTVGVAD4N/4zqFSGdO40uZEUdVaPFBNzRz2XeohLlMiu5poaWQkEmwtShyl8CFG5MYIayw0JBDw7uHPbA==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-38.1.1.tgz",
-      "integrity": "sha512-CMIPPaUIOvVPW/gIEmcZ00bYbQyy3/YenxPrzmdMkYjDWoPqfhDnn4FTrgEBYyWRXTNXXrS7D08VGeGCDOyYPA==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "ckeditor5": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-38.1.1.tgz",
-      "integrity": "sha512-FzBdAZWaBXjUYmtd7fDzIJ4evXM6n1RbNYG7ICzoviarlKL99mv/wLEkEvNDH0japdu/G11JtV36tRtBCzwoDQ==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-38.1.1.tgz",
-      "integrity": "sha512-jWZUsJNRwVBfeTroSHcssEijCmNLgs2pJwKzJTcltyJr44se2V2kTEieCT3r0qpQvbdyw90n+MfrrlWb+S1bnQ==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-38.1.1.tgz",
-      "integrity": "sha512-IsiCDTMK5s9T1QWwiLW90VFKsNfsTUlYy8tnr/sH5t2QFP8LOkF2ZL2igb/BqyuROrGVvS8At+BTnlH3hqAW/Q==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-38.1.1.tgz",
-      "integrity": "sha512-xCAw3HwxfFgsZPINf6jb29MObDN2wDzZFpiMkChdjzmHqaCugd2SAssZQo/flxdy5fkMXju8gCa0bfM2g1HTkQ==",
-      "dependencies": {
-        "ckeditor5": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-38.1.1.tgz",
-      "integrity": "sha512-e/JUdGsBkf902rG0g+6ii/QhDP+LFV2W9bxhrGppLahzPX09NT5BCJh2/bTtUPw0cIRpk49ji7hNBzDjCKqctQ==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-38.1.1.tgz",
-      "integrity": "sha512-QOTc+Re3K5mY6GHC2vmglNb8k5D49cCjVlO2ORvr3Pk/Nepmk6asW3NoSfox8YJZSAfJyloD+t56FagZSokP+g==",
-      "dependencies": {
-        "ckeditor5": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-38.1.1.tgz",
-      "integrity": "sha512-KU0wF1ueWFwK3BnkGB2v2vpjISgwmC0OxpPM0RLHCDG5iSvIkPbu1tUj9rbxRx45JM6xgpTP1C9kEFSm5w5MoQ==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-38.1.1.tgz",
-      "integrity": "sha512-lTqOaciupH66Zz7BSRGOm5DyjLURJwmFfZyCYCKD6+ZbTsxcP1asdiUm8y3bOx2maRCZTrHMhuAANp3qFWXoLQ==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "color-convert": "2.0.1",
-        "color-parse": "1.4.2",
-        "lodash-es": "^4.17.15",
-        "vanilla-colorful": "0.7.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-38.1.1.tgz",
-      "integrity": "sha512-21XCRb4XKYrK2bAkNTbOUb3Cmbu4FB11cqG3ncIg2rWSHSJJOijMdvZpZBvNpXVEsvJgA2Ol7bCiSXgdVUR/yQ==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-38.1.1.tgz",
-      "integrity": "sha512-c7zau/N4cGJKpNPoRj0QEAQKOiIQzrSK2UCG0JsPtfF9jzTWa5fIJ/6hSHquwjtnhkB7zAL0PKXwcTNpdlyibA==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-38.1.1.tgz",
-      "integrity": "sha512-+dSCchr8sseqWSfCuuOk5uajCo2Tr71IXmn3EGalEHE6Fc1GjWElO90GAA4Pbezrt1zG1tDqhh+bZHULAcK8wQ==",
-      "dependencies": {
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-vue": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-5.1.0.tgz",
-      "integrity": "sha512-KEx4Tj2Irr4ZbLG8LnaKpb0Dgd8qmLmKFWeiKkQwM3RAAeYRYOCcBVB2Y168I9KA8wRosPxgOO9jbQ92yopYHA==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-38.1.1.tgz",
-      "integrity": "sha512-NijdWJsl+vnzdtyhI0u0Ln2TEVaSLa2VEHyB7J1r57cUN9Bq5tqRH4/BhvvqGKGc9lkpbvcSFduH2c6StHm0rw==",
-      "dependencies": {
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-38.1.1.tgz",
-      "integrity": "sha512-WAQhYBRfpu5jhV7Subc8pVkHYFCgXyJ65bQg5Jn8Em86lySejXQEi/GowjKwkwzlSrceqDrELEJV9jcCaUZlaA==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-enter": "38.1.1",
-        "@ckeditor/ckeditor5-typing": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
@@ -1078,16 +636,8 @@
       "dev": true
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "3.0.30",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/3.0.30/30982266472d238646c0752a34575d4de4ae33d5",
-      "integrity": "sha512-xIaNqCXqomFedsjrBagwbmffFdHXft2oAUrtxYEFI7jPvBm5H4HfiFAI2u0fUiUwhS1DUXQa4Qr4uZv/0SLx6A==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-build-classic": "^38.1.0",
-        "@ckeditor/ckeditor5-vue": "^5.1.0",
-        "save-file": "^2.3.1",
-        "stream-browserify": "^3.0.0",
-        "xlsx-populate": "^1.21.0"
-      }
+      "resolved": "../jac-kit/src/packages",
+      "link": true
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
@@ -1557,14 +1107,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1952,18 +1494,6 @@
         }
       ]
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2030,30 +1560,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/ckeditor5": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-38.1.1.tgz",
-      "integrity": "sha512-KE6H2WGLlhlI4F//AZn+fv52DhbwAeVv+ZeSIsa5gC81/3ZCzuYc3+IMur/70IBE9Gze8gKwFP9elh/TIaQ5Hw==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "38.1.1",
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-enter": "38.1.1",
-        "@ckeditor/ckeditor5-paragraph": "38.1.1",
-        "@ckeditor/ckeditor5-select-all": "38.1.1",
-        "@ckeditor/ckeditor5-typing": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-undo": "38.1.1",
-        "@ckeditor/ckeditor5-upload": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "@ckeditor/ckeditor5-watchdog": "38.1.1",
-        "@ckeditor/ckeditor5-widget": "38.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=5.7.1"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2089,14 +1595,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
-      "dependencies": {
-        "color-name": "^1.0.0"
-      }
-    },
     "node_modules/colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -2117,22 +1615,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -3599,11 +3081,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
-    },
     "node_modules/immutable": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
@@ -4004,49 +3481,6 @@
         "json5": "lib/cli.js"
       }
     },
-    "node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/jszip/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/jszip/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/jszip/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/jszip/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -4069,14 +3503,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4096,11 +3522,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.assign": {
       "version": "4.2.0",
@@ -4634,11 +4055,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4756,11 +4172,6 @@
       "engines": {
         "node": ">= 0.6.0"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/promise-polyfill": {
       "version": "8.1.3",
@@ -5060,11 +4471,6 @@
         "write": "^1.0.0"
       }
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5073,11 +4479,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5503,11 +4904,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/vanilla-colorful": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
-      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg=="
-    },
     "node_modules/vite": {
       "version": "2.9.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
@@ -5867,17 +5263,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/xlsx-populate": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/xlsx-populate/-/xlsx-populate-1.21.0.tgz",
-      "integrity": "sha512-8v2Gm8BehXo6LU7KT802QoXTPkYY1SKk5V8g/UuYZnNB3JzXqud/P99Pxr2yXeKyt+sKlCatmidz6jQNie1hRw==",
-      "dependencies": {
-        "cfb": "^1.1.3",
-        "jszip": "^3.2.2",
-        "lodash": "^4.17.15",
-        "sax": "^1.2.4"
-      }
-    },
     "node_modules/xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -5949,326 +5334,6 @@
       "version": "7.22.14",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
       "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ=="
-    },
-    "@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-38.1.1.tgz",
-      "integrity": "sha512-TDv6xOkcXws0RmfkBJ6vfuH4vwj3mbI8S++9czLKrHmwp24jSrxiRwP1ZUlJSImy+/3sTjec4u8I5fq0HA2UOA==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-autoformat": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-38.1.1.tgz",
-      "integrity": "sha512-Ppxxp0qprhENktpKv3lkVFchS9iZt0GbCVLPg8ffTb5dCAQgeXyC/TdR1b3zpbdjgSyai07OYgU59oTNUOwtog==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-basic-styles": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-38.1.1.tgz",
-      "integrity": "sha512-+mky2W983jaSlYpvQ31af0ethMQxXUxuBkd2IzRi2cchvSK9YbQtBSkV0EM595uoJa1S3doyCJn7Y8bOdE+v3A==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-block-quote": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-38.1.1.tgz",
-      "integrity": "sha512-YPSw+qTE71mvQTo5OA2M9oQp1jpUJrj1d15mbVE5DIyvc2CMWRltqV49GoM15ZpzgQWbaF3VZ8ZT0+vZlfS0lw==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-build-classic": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-38.1.1.tgz",
-      "integrity": "sha512-TaVK+kVX2hMZD8imbfsQHKTiMo4seBkmZvu8KgNPn8tNarmJacO27EYmPmzL04KyctP2pv4rt2UTzPfuFZyqvg==",
-      "requires": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "38.1.1",
-        "@ckeditor/ckeditor5-autoformat": "38.1.1",
-        "@ckeditor/ckeditor5-basic-styles": "38.1.1",
-        "@ckeditor/ckeditor5-block-quote": "38.1.1",
-        "@ckeditor/ckeditor5-ckbox": "38.1.1",
-        "@ckeditor/ckeditor5-ckfinder": "38.1.1",
-        "@ckeditor/ckeditor5-cloud-services": "38.1.1",
-        "@ckeditor/ckeditor5-easy-image": "38.1.1",
-        "@ckeditor/ckeditor5-editor-classic": "38.1.1",
-        "@ckeditor/ckeditor5-essentials": "38.1.1",
-        "@ckeditor/ckeditor5-heading": "38.1.1",
-        "@ckeditor/ckeditor5-image": "38.1.1",
-        "@ckeditor/ckeditor5-indent": "38.1.1",
-        "@ckeditor/ckeditor5-link": "38.1.1",
-        "@ckeditor/ckeditor5-list": "38.1.1",
-        "@ckeditor/ckeditor5-media-embed": "38.1.1",
-        "@ckeditor/ckeditor5-paragraph": "38.1.1",
-        "@ckeditor/ckeditor5-paste-from-office": "38.1.1",
-        "@ckeditor/ckeditor5-table": "38.1.1",
-        "@ckeditor/ckeditor5-typing": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-ckbox": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-38.1.1.tgz",
-      "integrity": "sha512-+R3Vz2QL/K2pdWzOZpFtrLwFHefxQfDT99sYQSUZiOQaXA6rSoLT4x6lhIdrQRjsI/ofCIGseQxuTHc8t86urA==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-ckfinder": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-38.1.1.tgz",
-      "integrity": "sha512-58139l/uKcMD6KZzd5uPzv8IwJYNnDFsT8N6DlecTZuh3ViKmg9t/pbRWu8epOboySwHeJoA3q12m2j05C1+JQ==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-clipboard": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-38.1.1.tgz",
-      "integrity": "sha512-FN6QxWw0ZcoMsCkm6FuN2do//qjNGofnsFernKWJPbL2E056dvB4WmhYHa4fCvGASCROcJ17yUV7oYI+1ah/og==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "@ckeditor/ckeditor5-widget": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-cloud-services": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-38.1.1.tgz",
-      "integrity": "sha512-M4MykJmA9JqlZEDCJfcGwEKq6Y1AuDf8Kxbl0LfMZu6BKv74up+c0wSD/WX7isot3eqDdSQckVjHlJvmS31EOA==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-core": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-38.1.1.tgz",
-      "integrity": "sha512-5yC+oSoCnjfOrvmECbwtu4zBt9S5dJfOYsAzfIGEbmD9DVGIyLBDKEjJ9IbAKAy1HG6CgAkZyv1YyEc5G5g3ew==",
-      "requires": {
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-easy-image": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-38.1.1.tgz",
-      "integrity": "sha512-kusGv9hBkFNm3/ZSr69fgdJ3V94feL0oXQoRUsCTsv2usda6KOIY3D5XMK8vvBpa7+0gFan98AvX9KM5IvrMkQ==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-editor-classic": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-38.1.1.tgz",
-      "integrity": "sha512-LSh60tSuR8pGnLswy+Smx7x0NtFjbVX2dGiEkMyh4O0JLok/YgS3IU6UmoEd9FTjGqnOZ3644h3SpkSu84uDYA==",
-      "requires": {
-        "ckeditor5": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-engine": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-38.1.1.tgz",
-      "integrity": "sha512-Z0LYg7B4vN3ZNUf3utmBRXQBn3JNy81Xs+45sQ09Fpf5p6aKer37vxEA315O17PnWYndildeKNRUNdjI942HcQ==",
-      "requires": {
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-enter": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-38.1.1.tgz",
-      "integrity": "sha512-jzlTvyBwBw4TLr03NXwVeZD87pOSjisx8WCEahWM8Rxrw77k+7rg3blAWmmpw9cHUp2WkpxCztfvQtQouT9Jpw==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-essentials": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-38.1.1.tgz",
-      "integrity": "sha512-8Upvcjqny39pEZM5JbdyM8MESGjC6IkAJpjvqEFkbZsFcFzXjPolbxPReI3Xbl74XaMGYpwfraTv7ozkCxD7eA==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-heading": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-38.1.1.tgz",
-      "integrity": "sha512-uEh62XWpw5uIpaslJfn8YZ+9DfViCRR5auAz5SdiYDY+tdLjwKS308S1um5i5G/CLjp1M3uXlvDieOopit9nYg==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-image": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-38.1.1.tgz",
-      "integrity": "sha512-iXUlw38Eoo5zwj3h9eKULenEDPYoohPLT/74UDYw1V7Q3QY3dN4fCovcWwQx7VFPMPFUtd5T1S/ki/3UpLQhSA==",
-      "requires": {
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "ckeditor5": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-indent": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-38.1.1.tgz",
-      "integrity": "sha512-Wr0lAiTVGVAD4N/4zqFSGdO40uZEUdVaPFBNzRz2XeohLlMiu5poaWQkEmwtShyl8CFG5MYIayw0JBDw7uHPbA==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-link": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-38.1.1.tgz",
-      "integrity": "sha512-CMIPPaUIOvVPW/gIEmcZ00bYbQyy3/YenxPrzmdMkYjDWoPqfhDnn4FTrgEBYyWRXTNXXrS7D08VGeGCDOyYPA==",
-      "requires": {
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "ckeditor5": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-list": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-38.1.1.tgz",
-      "integrity": "sha512-FzBdAZWaBXjUYmtd7fDzIJ4evXM6n1RbNYG7ICzoviarlKL99mv/wLEkEvNDH0japdu/G11JtV36tRtBCzwoDQ==",
-      "requires": {
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-media-embed": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-38.1.1.tgz",
-      "integrity": "sha512-jWZUsJNRwVBfeTroSHcssEijCmNLgs2pJwKzJTcltyJr44se2V2kTEieCT3r0qpQvbdyw90n+MfrrlWb+S1bnQ==",
-      "requires": {
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-paragraph": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-38.1.1.tgz",
-      "integrity": "sha512-IsiCDTMK5s9T1QWwiLW90VFKsNfsTUlYy8tnr/sH5t2QFP8LOkF2ZL2igb/BqyuROrGVvS8At+BTnlH3hqAW/Q==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-paste-from-office": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-38.1.1.tgz",
-      "integrity": "sha512-xCAw3HwxfFgsZPINf6jb29MObDN2wDzZFpiMkChdjzmHqaCugd2SAssZQo/flxdy5fkMXju8gCa0bfM2g1HTkQ==",
-      "requires": {
-        "ckeditor5": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-select-all": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-38.1.1.tgz",
-      "integrity": "sha512-e/JUdGsBkf902rG0g+6ii/QhDP+LFV2W9bxhrGppLahzPX09NT5BCJh2/bTtUPw0cIRpk49ji7hNBzDjCKqctQ==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-table": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-38.1.1.tgz",
-      "integrity": "sha512-QOTc+Re3K5mY6GHC2vmglNb8k5D49cCjVlO2ORvr3Pk/Nepmk6asW3NoSfox8YJZSAfJyloD+t56FagZSokP+g==",
-      "requires": {
-        "ckeditor5": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-typing": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-38.1.1.tgz",
-      "integrity": "sha512-KU0wF1ueWFwK3BnkGB2v2vpjISgwmC0OxpPM0RLHCDG5iSvIkPbu1tUj9rbxRx45JM6xgpTP1C9kEFSm5w5MoQ==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-ui": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-38.1.1.tgz",
-      "integrity": "sha512-lTqOaciupH66Zz7BSRGOm5DyjLURJwmFfZyCYCKD6+ZbTsxcP1asdiUm8y3bOx2maRCZTrHMhuAANp3qFWXoLQ==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "color-convert": "2.0.1",
-        "color-parse": "1.4.2",
-        "lodash-es": "^4.17.15",
-        "vanilla-colorful": "0.7.2"
-      }
-    },
-    "@ckeditor/ckeditor5-undo": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-38.1.1.tgz",
-      "integrity": "sha512-21XCRb4XKYrK2bAkNTbOUb3Cmbu4FB11cqG3ncIg2rWSHSJJOijMdvZpZBvNpXVEsvJgA2Ol7bCiSXgdVUR/yQ==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-upload": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-38.1.1.tgz",
-      "integrity": "sha512-c7zau/N4cGJKpNPoRj0QEAQKOiIQzrSK2UCG0JsPtfF9jzTWa5fIJ/6hSHquwjtnhkB7zAL0PKXwcTNpdlyibA==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1"
-      }
-    },
-    "@ckeditor/ckeditor5-utils": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-38.1.1.tgz",
-      "integrity": "sha512-+dSCchr8sseqWSfCuuOk5uajCo2Tr71IXmn3EGalEHE6Fc1GjWElO90GAA4Pbezrt1zG1tDqhh+bZHULAcK8wQ==",
-      "requires": {
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-vue": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-5.1.0.tgz",
-      "integrity": "sha512-KEx4Tj2Irr4ZbLG8LnaKpb0Dgd8qmLmKFWeiKkQwM3RAAeYRYOCcBVB2Y168I9KA8wRosPxgOO9jbQ92yopYHA=="
-    },
-    "@ckeditor/ckeditor5-watchdog": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-38.1.1.tgz",
-      "integrity": "sha512-NijdWJsl+vnzdtyhI0u0Ln2TEVaSLa2VEHyB7J1r57cUN9Bq5tqRH4/BhvvqGKGc9lkpbvcSFduH2c6StHm0rw==",
-      "requires": {
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@ckeditor/ckeditor5-widget": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-38.1.1.tgz",
-      "integrity": "sha512-WAQhYBRfpu5jhV7Subc8pVkHYFCgXyJ65bQg5Jn8Em86lySejXQEi/GowjKwkwzlSrceqDrELEJV9jcCaUZlaA==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-enter": "38.1.1",
-        "@ckeditor/ckeditor5-typing": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "lodash-es": "^4.17.15"
-      }
     },
     "@esbuild/linux-loong64": {
       "version": "0.14.54",
@@ -6695,9 +5760,7 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "3.0.30",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/3.0.30/30982266472d238646c0752a34575d4de4ae33d5",
-      "integrity": "sha512-xIaNqCXqomFedsjrBagwbmffFdHXft2oAUrtxYEFI7jPvBm5H4HfiFAI2u0fUiUwhS1DUXQa4Qr4uZv/0SLx6A==",
+      "version": "file:../jac-kit/src/packages",
       "requires": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",
@@ -7092,11 +6155,6 @@
       "dev": true,
       "requires": {}
     },
-    "adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -7328,15 +6386,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
       "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q=="
     },
-    "cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "requires": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      }
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7382,26 +6431,6 @@
         }
       }
     },
-    "ckeditor5": {
-      "version": "38.1.1",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-38.1.1.tgz",
-      "integrity": "sha512-KE6H2WGLlhlI4F//AZn+fv52DhbwAeVv+ZeSIsa5gC81/3ZCzuYc3+IMur/70IBE9Gze8gKwFP9elh/TIaQ5Hw==",
-      "requires": {
-        "@ckeditor/ckeditor5-clipboard": "38.1.1",
-        "@ckeditor/ckeditor5-core": "38.1.1",
-        "@ckeditor/ckeditor5-engine": "38.1.1",
-        "@ckeditor/ckeditor5-enter": "38.1.1",
-        "@ckeditor/ckeditor5-paragraph": "38.1.1",
-        "@ckeditor/ckeditor5-select-all": "38.1.1",
-        "@ckeditor/ckeditor5-typing": "38.1.1",
-        "@ckeditor/ckeditor5-ui": "38.1.1",
-        "@ckeditor/ckeditor5-undo": "38.1.1",
-        "@ckeditor/ckeditor5-upload": "38.1.1",
-        "@ckeditor/ckeditor5-utils": "38.1.1",
-        "@ckeditor/ckeditor5-watchdog": "38.1.1",
-        "@ckeditor/ckeditor5-widget": "38.1.1"
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -7431,14 +6460,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
-      "requires": {
-        "color-name": "^1.0.0"
-      }
-    },
     "colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -7454,16 +6475,6 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
       "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -8454,11 +7465,6 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
-    },
     "immutable": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
@@ -8734,51 +7740,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "requires": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-        },
-        "readable-stream": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -8798,14 +7759,6 @@
         "type-check": "~0.4.0"
       }
     },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "requires": {
-        "immediate": "~3.0.5"
-      }
-    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8819,11 +7772,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -9260,11 +8208,6 @@
         "p-limit": "^3.0.2"
       }
     },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9348,11 +8291,6 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-polyfill": {
       "version": "8.1.3",
@@ -9538,21 +8476,11 @@
         "write": "^1.0.0"
       }
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -9863,11 +8791,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "vanilla-colorful": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
-      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg=="
-    },
     "vite": {
       "version": "2.9.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
@@ -10095,17 +9018,6 @@
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "requires": {
         "mkdirp": "^0.5.1"
-      }
-    },
-    "xlsx-populate": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/xlsx-populate/-/xlsx-populate-1.21.0.tgz",
-      "integrity": "sha512-8v2Gm8BehXo6LU7KT802QoXTPkYY1SKk5V8g/UuYZnNB3JzXqud/P99Pxr2yXeKyt+sKlCatmidz6jQNie1hRw==",
-      "requires": {
-        "cfb": "^1.1.3",
-        "jszip": "^3.2.2",
-        "lodash": "^4.17.15",
-        "sax": "^1.2.4"
       }
     },
     "xmlhttprequest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,17 +59,6 @@
         "postcss": "8.2.15"
       }
     },
-    "../jac-kit/src/packages": {
-      "name": "@jac-uk/jac-kit",
-      "version": "3.0.37",
-      "dependencies": {
-        "@ckeditor/ckeditor5-build-classic": "^38.1.0",
-        "@ckeditor/ckeditor5-vue": "^5.1.0",
-        "save-file": "^2.3.1",
-        "stream-browserify": "^3.0.0",
-        "xlsx-populate": "^1.21.0"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -80,14 +69,467 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.14",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
-      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-38.1.1.tgz",
+      "integrity": "sha512-TDv6xOkcXws0RmfkBJ6vfuH4vwj3mbI8S++9czLKrHmwp24jSrxiRwP1ZUlJSImy+/3sTjec4u8I5fq0HA2UOA==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-38.1.1.tgz",
+      "integrity": "sha512-Ppxxp0qprhENktpKv3lkVFchS9iZt0GbCVLPg8ffTb5dCAQgeXyC/TdR1b3zpbdjgSyai07OYgU59oTNUOwtog==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-38.1.1.tgz",
+      "integrity": "sha512-+mky2W983jaSlYpvQ31af0ethMQxXUxuBkd2IzRi2cchvSK9YbQtBSkV0EM595uoJa1S3doyCJn7Y8bOdE+v3A==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-38.1.1.tgz",
+      "integrity": "sha512-YPSw+qTE71mvQTo5OA2M9oQp1jpUJrj1d15mbVE5DIyvc2CMWRltqV49GoM15ZpzgQWbaF3VZ8ZT0+vZlfS0lw==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-classic": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-38.1.1.tgz",
+      "integrity": "sha512-TaVK+kVX2hMZD8imbfsQHKTiMo4seBkmZvu8KgNPn8tNarmJacO27EYmPmzL04KyctP2pv4rt2UTzPfuFZyqvg==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "38.1.1",
+        "@ckeditor/ckeditor5-autoformat": "38.1.1",
+        "@ckeditor/ckeditor5-basic-styles": "38.1.1",
+        "@ckeditor/ckeditor5-block-quote": "38.1.1",
+        "@ckeditor/ckeditor5-ckbox": "38.1.1",
+        "@ckeditor/ckeditor5-ckfinder": "38.1.1",
+        "@ckeditor/ckeditor5-cloud-services": "38.1.1",
+        "@ckeditor/ckeditor5-easy-image": "38.1.1",
+        "@ckeditor/ckeditor5-editor-classic": "38.1.1",
+        "@ckeditor/ckeditor5-essentials": "38.1.1",
+        "@ckeditor/ckeditor5-heading": "38.1.1",
+        "@ckeditor/ckeditor5-image": "38.1.1",
+        "@ckeditor/ckeditor5-indent": "38.1.1",
+        "@ckeditor/ckeditor5-link": "38.1.1",
+        "@ckeditor/ckeditor5-list": "38.1.1",
+        "@ckeditor/ckeditor5-media-embed": "38.1.1",
+        "@ckeditor/ckeditor5-paragraph": "38.1.1",
+        "@ckeditor/ckeditor5-paste-from-office": "38.1.1",
+        "@ckeditor/ckeditor5-table": "38.1.1",
+        "@ckeditor/ckeditor5-typing": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-38.1.1.tgz",
+      "integrity": "sha512-+R3Vz2QL/K2pdWzOZpFtrLwFHefxQfDT99sYQSUZiOQaXA6rSoLT4x6lhIdrQRjsI/ofCIGseQxuTHc8t86urA==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-38.1.1.tgz",
+      "integrity": "sha512-58139l/uKcMD6KZzd5uPzv8IwJYNnDFsT8N6DlecTZuh3ViKmg9t/pbRWu8epOboySwHeJoA3q12m2j05C1+JQ==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-38.1.1.tgz",
+      "integrity": "sha512-FN6QxWw0ZcoMsCkm6FuN2do//qjNGofnsFernKWJPbL2E056dvB4WmhYHa4fCvGASCROcJ17yUV7oYI+1ah/og==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "@ckeditor/ckeditor5-widget": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-38.1.1.tgz",
+      "integrity": "sha512-M4MykJmA9JqlZEDCJfcGwEKq6Y1AuDf8Kxbl0LfMZu6BKv74up+c0wSD/WX7isot3eqDdSQckVjHlJvmS31EOA==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-core": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-38.1.1.tgz",
+      "integrity": "sha512-5yC+oSoCnjfOrvmECbwtu4zBt9S5dJfOYsAzfIGEbmD9DVGIyLBDKEjJ9IbAKAy1HG6CgAkZyv1YyEc5G5g3ew==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-38.1.1.tgz",
+      "integrity": "sha512-kusGv9hBkFNm3/ZSr69fgdJ3V94feL0oXQoRUsCTsv2usda6KOIY3D5XMK8vvBpa7+0gFan98AvX9KM5IvrMkQ==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-38.1.1.tgz",
+      "integrity": "sha512-LSh60tSuR8pGnLswy+Smx7x0NtFjbVX2dGiEkMyh4O0JLok/YgS3IU6UmoEd9FTjGqnOZ3644h3SpkSu84uDYA==",
+      "dependencies": {
+        "ckeditor5": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-38.1.1.tgz",
+      "integrity": "sha512-Z0LYg7B4vN3ZNUf3utmBRXQBn3JNy81Xs+45sQ09Fpf5p6aKer37vxEA315O17PnWYndildeKNRUNdjI942HcQ==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-38.1.1.tgz",
+      "integrity": "sha512-jzlTvyBwBw4TLr03NXwVeZD87pOSjisx8WCEahWM8Rxrw77k+7rg3blAWmmpw9cHUp2WkpxCztfvQtQouT9Jpw==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-38.1.1.tgz",
+      "integrity": "sha512-8Upvcjqny39pEZM5JbdyM8MESGjC6IkAJpjvqEFkbZsFcFzXjPolbxPReI3Xbl74XaMGYpwfraTv7ozkCxD7eA==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-38.1.1.tgz",
+      "integrity": "sha512-uEh62XWpw5uIpaslJfn8YZ+9DfViCRR5auAz5SdiYDY+tdLjwKS308S1um5i5G/CLjp1M3uXlvDieOopit9nYg==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-38.1.1.tgz",
+      "integrity": "sha512-iXUlw38Eoo5zwj3h9eKULenEDPYoohPLT/74UDYw1V7Q3QY3dN4fCovcWwQx7VFPMPFUtd5T1S/ki/3UpLQhSA==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "ckeditor5": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-38.1.1.tgz",
+      "integrity": "sha512-Wr0lAiTVGVAD4N/4zqFSGdO40uZEUdVaPFBNzRz2XeohLlMiu5poaWQkEmwtShyl8CFG5MYIayw0JBDw7uHPbA==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-38.1.1.tgz",
+      "integrity": "sha512-CMIPPaUIOvVPW/gIEmcZ00bYbQyy3/YenxPrzmdMkYjDWoPqfhDnn4FTrgEBYyWRXTNXXrS7D08VGeGCDOyYPA==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "ckeditor5": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-38.1.1.tgz",
+      "integrity": "sha512-FzBdAZWaBXjUYmtd7fDzIJ4evXM6n1RbNYG7ICzoviarlKL99mv/wLEkEvNDH0japdu/G11JtV36tRtBCzwoDQ==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-38.1.1.tgz",
+      "integrity": "sha512-jWZUsJNRwVBfeTroSHcssEijCmNLgs2pJwKzJTcltyJr44se2V2kTEieCT3r0qpQvbdyw90n+MfrrlWb+S1bnQ==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paragraph": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-38.1.1.tgz",
+      "integrity": "sha512-IsiCDTMK5s9T1QWwiLW90VFKsNfsTUlYy8tnr/sH5t2QFP8LOkF2ZL2igb/BqyuROrGVvS8At+BTnlH3hqAW/Q==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-38.1.1.tgz",
+      "integrity": "sha512-xCAw3HwxfFgsZPINf6jb29MObDN2wDzZFpiMkChdjzmHqaCugd2SAssZQo/flxdy5fkMXju8gCa0bfM2g1HTkQ==",
+      "dependencies": {
+        "ckeditor5": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-38.1.1.tgz",
+      "integrity": "sha512-e/JUdGsBkf902rG0g+6ii/QhDP+LFV2W9bxhrGppLahzPX09NT5BCJh2/bTtUPw0cIRpk49ji7hNBzDjCKqctQ==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-38.1.1.tgz",
+      "integrity": "sha512-QOTc+Re3K5mY6GHC2vmglNb8k5D49cCjVlO2ORvr3Pk/Nepmk6asW3NoSfox8YJZSAfJyloD+t56FagZSokP+g==",
+      "dependencies": {
+        "ckeditor5": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-38.1.1.tgz",
+      "integrity": "sha512-KU0wF1ueWFwK3BnkGB2v2vpjISgwmC0OxpPM0RLHCDG5iSvIkPbu1tUj9rbxRx45JM6xgpTP1C9kEFSm5w5MoQ==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-38.1.1.tgz",
+      "integrity": "sha512-lTqOaciupH66Zz7BSRGOm5DyjLURJwmFfZyCYCKD6+ZbTsxcP1asdiUm8y3bOx2maRCZTrHMhuAANp3qFWXoLQ==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "color-convert": "2.0.1",
+        "color-parse": "1.4.2",
+        "lodash-es": "^4.17.15",
+        "vanilla-colorful": "0.7.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-38.1.1.tgz",
+      "integrity": "sha512-21XCRb4XKYrK2bAkNTbOUb3Cmbu4FB11cqG3ncIg2rWSHSJJOijMdvZpZBvNpXVEsvJgA2Ol7bCiSXgdVUR/yQ==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-38.1.1.tgz",
+      "integrity": "sha512-c7zau/N4cGJKpNPoRj0QEAQKOiIQzrSK2UCG0JsPtfF9jzTWa5fIJ/6hSHquwjtnhkB7zAL0PKXwcTNpdlyibA==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-38.1.1.tgz",
+      "integrity": "sha512-+dSCchr8sseqWSfCuuOk5uajCo2Tr71IXmn3EGalEHE6Fc1GjWElO90GAA4Pbezrt1zG1tDqhh+bZHULAcK8wQ==",
+      "dependencies": {
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-vue": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-5.1.0.tgz",
+      "integrity": "sha512-KEx4Tj2Irr4ZbLG8LnaKpb0Dgd8qmLmKFWeiKkQwM3RAAeYRYOCcBVB2Y168I9KA8wRosPxgOO9jbQ92yopYHA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-38.1.1.tgz",
+      "integrity": "sha512-NijdWJsl+vnzdtyhI0u0Ln2TEVaSLa2VEHyB7J1r57cUN9Bq5tqRH4/BhvvqGKGc9lkpbvcSFduH2c6StHm0rw==",
+      "dependencies": {
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-38.1.1.tgz",
+      "integrity": "sha512-WAQhYBRfpu5jhV7Subc8pVkHYFCgXyJ65bQg5Jn8Em86lySejXQEi/GowjKwkwzlSrceqDrELEJV9jcCaUZlaA==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-enter": "38.1.1",
+        "@ckeditor/ckeditor5-typing": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
@@ -121,9 +563,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
-      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.0.tgz",
+      "integrity": "sha512-zJmuCWj2VLBt4c25CfBIbMZLGLyhkvs7LznyVX5HfpzeocThgIj5XQK4L+g3U36mMcx8bPMhGyPpwCATamC4jQ==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -153,9 +595,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
-      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
+      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -490,9 +932,9 @@
       "integrity": "sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A=="
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.2.tgz",
-      "integrity": "sha512-Lf2pUhNTaviEdEaGgjU+29qw3arX7Qd/45q66F3z1EV5hroE6wM9xSHPvjB8EY+b1RmKZgwnLWXQorC6fZ9g5g==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.4.tgz",
+      "integrity": "sha512-oEnzYiDuEsBydZBtP84BkpduLsE1nSAO4KrhTLHRzNrIQE647fhchmosTQsJdCo8X9zBBt+l5+fNk+m/yCFJ/Q==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -502,9 +944,9 @@
       }
     },
     "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.9.tgz",
-      "integrity": "sha512-YJsOehVXzgurc+lLAxYnlSMc1p/Gu6VAvnfx0ATi2nzvr0YZcjhmZDeY8SeAKv1M7zE3aEJH0Xo9mK1iZ8GYoQ==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -636,8 +1078,16 @@
       "dev": true
     },
     "node_modules/@jac-uk/jac-kit": {
-      "resolved": "../jac-kit/src/packages",
-      "link": true
+      "version": "3.0.37",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/3.0.37/2a23e8c56240dc8f0258a260899adc53c3631144",
+      "integrity": "sha512-VF2BGDMz1U72Y/Adasct5a83I8xhAZSpQsEtZegPwdmXZijxGuDitKv8FtW6hKl2+9lJeom+sFrrz7PTztd72A==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-build-classic": "^38.1.0",
+        "@ckeditor/ckeditor5-vue": "^5.1.0",
+        "save-file": "^2.3.1",
+        "stream-browserify": "^3.0.0",
+        "xlsx-populate": "^1.21.0"
+      }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
@@ -792,13 +1242,13 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.66.0.tgz",
-      "integrity": "sha512-3vCgC2hC3T45pn53yTDVcRpHoJTBxelDPPZVsipAbZnoOVPkj7n6dNfDhj3I3kwWCBPahPkXmE+R4xViR8VqJg==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.72.0.tgz",
+      "integrity": "sha512-DToryaRSHk9R5RLgN4ktYEXZjQdqncOAWPqyyIurji8lIobXFRfmLtGL1wjoCK6sQNgWsjhSM9kXxwGnva1DNw==",
       "dependencies": {
-        "@sentry/core": "7.66.0",
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0",
+        "@sentry/core": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -806,15 +1256,15 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.66.0.tgz",
-      "integrity": "sha512-rW037rf8jkhyykG38+HUdwkRCKHJEMM5NkCqPIO5zuuxfLKukKdI2rbvgJ93s3/9UfsTuDFcKFL1u43mCn6sDw==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.72.0.tgz",
+      "integrity": "sha512-fcFDTzqhPd3VZAmmYW3KvBTBaEfrKjPmRhlAsfhkGWYLCHqVkNtzsFER4cmUNRGNxjyt9tcG3WlTTqgLRucycQ==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.66.0",
-        "@sentry/core": "7.66.0",
-        "@sentry/replay": "7.66.0",
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0",
+        "@sentry-internal/tracing": "7.72.0",
+        "@sentry/core": "7.72.0",
+        "@sentry/replay": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -822,12 +1272,12 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.66.0.tgz",
-      "integrity": "sha512-WMAEPN86NeCJ1IT48Lqiz4MS5gdDjBwP4M63XP4msZn9aujSf2Qb6My5uT87AJr9zBtgk8MyJsuHr35F0P3q1w==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.72.0.tgz",
+      "integrity": "sha512-G03JdQ5ZsFNRjcNNi+QvCjqOuBvYqU92Gs1T2iK3GE8dSBTu2khThydMpG4xrKZQLIpHOyiIhlFZiuPtZ66W8w==",
       "dependencies": {
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -835,43 +1285,43 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.66.0.tgz",
-      "integrity": "sha512-5Y2SlVTOFTo3uIycv0mRneBakQtLgWkOnsJaC5LB0Ip0TqVKiMCbQ578vvXp+yvRj4LcS1gNd98xTTNojBoQNg==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.72.0.tgz",
+      "integrity": "sha512-dHH/mYCFBwJ/kYmL9L5KihjwQKcefiuvcH0otHSwKSpbbeEoM/BV+SHQoYGd6OMSYnL9fq1dHfF7Zo26p5Yu0Q==",
       "dependencies": {
-        "@sentry/core": "7.66.0",
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0"
+        "@sentry/core": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/tracing": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.66.0.tgz",
-      "integrity": "sha512-9bnz2EcOwjeMZAuYJnrwcRrImu9c10p7A0iDB8b2HLcp7gpuCkJbJyGoC1xeKD7reVD0BPq3VIbeHSwCcQufoQ==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.72.0.tgz",
+      "integrity": "sha512-DOMlyviMLNwWgN4gJw/TrHaAdBcZWvm8xLbgwMwrihRn/m84kmH2Ui1FUYpL30o/mH+mQS+53IHZukrgQjHkZA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.66.0"
+        "@sentry-internal/tracing": "7.72.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.66.0.tgz",
-      "integrity": "sha512-uUMSoSiar6JhuD8p7ON/Ddp4JYvrVd2RpwXJRPH1A4H4Bd4DVt1mKJy1OLG6HdeQv39XyhB1lPZckKJg4tATPw==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.72.0.tgz",
+      "integrity": "sha512-g6u0mk62yGshx02rfFADIfyR/S9VXcf3RG2qQPuvykrWtOfN/BOTrZypF7I+MiqKwRW76r3Pcu2C/AB+6z9XQA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.66.0.tgz",
-      "integrity": "sha512-9GYUVgXjK66uXXcLXVMXVzlptqMtq1eJENCuDeezQiEFrNA71KkLDg00wESp+LL+bl3wpVTBApArpbF6UEG5hQ==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.72.0.tgz",
+      "integrity": "sha512-o/MtqI7WJXuswidH0bSgBP40KN2lrnyQEIx5uoyJUJi/QEaboIsqbxU62vaFJpde8SYrbA+rTnP3J3ujF2gUag==",
       "dependencies": {
-        "@sentry/types": "7.66.0",
+        "@sentry/types": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -879,14 +1329,14 @@
       }
     },
     "node_modules/@sentry/vue": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.66.0.tgz",
-      "integrity": "sha512-yuqS8w8pILm8r686ldAnWTlxCtyAomZdEemUIbnkYvvBbURnpYwVakJPyhFOwpuLgBAJ0FALyPV0ULDd5OAzrQ==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.72.0.tgz",
+      "integrity": "sha512-XTJK7C8WH370jBhXzKwPS3TgG5w5tT+qW25IQ+ypyBv4vclcaKeeGMlIehuH2n3hVI9ut/f4Wjj1EwCrQE4ORw==",
       "dependencies": {
-        "@sentry/browser": "7.66.0",
-        "@sentry/core": "7.66.0",
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0",
+        "@sentry/browser": "7.72.0",
+        "@sentry/core": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -897,9 +1347,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.44.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
-      "integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
+      "version": "8.44.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.3.tgz",
+      "integrity": "sha512-iM/WfkwAhwmPff3wZuPLYiHX18HI24jU8k1ZSH7P8FHwxTjZ2P6CoX2wnF43oprR+YXJM6UUxATkNvyv/JHd+g==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -907,14 +1357,14 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -929,9 +1379,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "20.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
+      "version": "20.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
+      "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg=="
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "1.10.2",
@@ -1107,6 +1557,14 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1178,15 +1636,15 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -1216,14 +1674,14 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -1234,14 +1692,14 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
-      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -1252,14 +1710,15 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
-      "integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+      "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "get-intrinsic": "^1.2.1",
         "is-array-buffer": "^3.0.2",
         "is-shared-array-buffer": "^1.0.2"
@@ -1277,9 +1736,9 @@
       "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.15",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
-      "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1296,8 +1755,8 @@
       ],
       "dependencies": {
         "browserslist": "^4.21.10",
-        "caniuse-lite": "^1.0.30001520",
-        "fraction.js": "^4.2.0",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -1387,9 +1846,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.0.tgz",
+      "integrity": "sha512-v+Jcv64L2LbfTC6OnRcaxtqJNJuQAVhZKSJfR/6hn7lhnChUXl4amwVviqN1k411BB+3rRoKMitELRn1CojeRA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1405,10 +1864,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
+        "caniuse-lite": "^1.0.30001539",
+        "electron-to-chromium": "^1.4.530",
         "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1476,9 +1935,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001525",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
-      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
+      "version": "1.0.30001541",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+      "integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1493,6 +1952,18 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1560,6 +2031,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ckeditor5": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-38.1.1.tgz",
+      "integrity": "sha512-KE6H2WGLlhlI4F//AZn+fv52DhbwAeVv+ZeSIsa5gC81/3ZCzuYc3+IMur/70IBE9Gze8gKwFP9elh/TIaQ5Hw==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "38.1.1",
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-enter": "38.1.1",
+        "@ckeditor/ckeditor5-paragraph": "38.1.1",
+        "@ckeditor/ckeditor5-select-all": "38.1.1",
+        "@ckeditor/ckeditor5-typing": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-undo": "38.1.1",
+        "@ckeditor/ckeditor5-upload": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "@ckeditor/ckeditor5-watchdog": "38.1.1",
+        "@ckeditor/ckeditor5-widget": "38.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1595,6 +2090,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/color-parse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
+      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "dependencies": {
+        "color-name": "^1.0.0"
+      }
+    },
     "node_modules/colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -1615,6 +2118,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -1671,12 +2190,27 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+    "node_modules/define-data-property": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
+      "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
       "dev": true,
       "dependencies": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -1726,9 +2260,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.508",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
-      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg=="
+      "version": "1.4.532",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.532.tgz",
+      "integrity": "sha512-piIR0QFdIGKmOJTSNg5AwxZRNWQSXlRYycqDB9Srstx4lip8KpcmRxVP6zuFWExWziHYZpJ0acX7TxqX95KBpg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1736,18 +2270,18 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/es-abstract": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
-      "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
+      "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.2",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.5",
+        "function.prototype.name": "^1.1.6",
         "get-intrinsic": "^1.2.1",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
@@ -1763,23 +2297,23 @@
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.10",
+        "is-typed-array": "^1.1.12",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.0",
-        "safe-array-concat": "^1.0.0",
+        "regexp.prototype.flags": "^1.5.1",
+        "safe-array-concat": "^1.0.1",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.7",
-        "string.prototype.trimend": "^1.0.6",
-        "string.prototype.trimstart": "^1.0.6",
+        "string.prototype.trim": "^1.2.8",
+        "string.prototype.trimend": "^1.0.7",
+        "string.prototype.trimstart": "^1.0.7",
         "typed-array-buffer": "^1.0.0",
         "typed-array-byte-length": "^1.0.0",
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.10"
+        "which-typed-array": "^1.1.11"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2184,16 +2718,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
-      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
+      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.48.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/js": "8.50.0",
+        "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.12.4",
@@ -2751,9 +3285,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
     "node_modules/flatten-vertex-data": {
@@ -2774,9 +3308,9 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.5.tgz",
-      "integrity": "sha512-58DncB2bO/8ZvTHapG7U2KEbeFFyUbbrFFkHakecpdUSqJrQnEuBeTUPEggIVkx5cnugZJ4IVzk2Nbb32MOxBg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==",
       "engines": {
         "node": "*"
       },
@@ -2908,9 +3442,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "version": "13.22.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
+      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3080,6 +3614,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/immutable": {
       "version": "4.3.4",
@@ -3481,6 +4020,49 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -3503,6 +4085,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3522,6 +4112,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.assign": {
       "version": "4.2.0",
@@ -4055,6 +4650,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4173,6 +4773,11 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/promise-polyfill": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
@@ -4258,14 +4863,14 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+      "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
-        "functions-have-names": "^1.2.3"
+        "set-function-name": "^2.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4295,9 +4900,9 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
+      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -4391,13 +4996,13 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
-      "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
+        "get-intrinsic": "^1.2.1",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -4442,9 +5047,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.66.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
-      "integrity": "sha512-50c+zTsZOJVgFfTgwwEzkjA3/QACgdNsKueWPyAR0mRINIvLAStVQBbPg14iuqEQ74NPDbXzJARJ/O4SI1zftA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.68.0.tgz",
+      "integrity": "sha512-Lmj9lM/fef0nQswm1J2HJcEsBUba4wgNx2fea6yJHODREoMFnwRpZydBnX/RjyXw2REIwdkbqE4hrTo4qfDBUA==",
       "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -4471,6 +5076,11 @@
         "write": "^1.0.0"
       }
     },
+    "node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4479,6 +5089,25 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4584,14 +5213,14 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
-      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4601,28 +5230,28 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4849,9 +5478,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4903,6 +5532,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vanilla-colorful": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
+      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg=="
     },
     "node_modules/vite": {
       "version": "2.9.16",
@@ -4969,9 +5603,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.4.29",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
-      "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
+      "version": "8.4.30",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
+      "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
       "funding": [
         {
           "type": "opencollective",
@@ -5105,9 +5739,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.4.tgz",
-      "integrity": "sha512-9PISkmaCO02OzPVOMq2w82ilty6+xJmQrarYZDkjZBfl4RvYAlt4PKnEX21oW4KTtWfa9OuO/b3qk1Od3AEdCQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.5.tgz",
+      "integrity": "sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==",
       "dependencies": {
         "@vue/devtools-api": "^6.5.0"
       },
@@ -5263,6 +5897,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/xlsx-populate": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/xlsx-populate/-/xlsx-populate-1.21.0.tgz",
+      "integrity": "sha512-8v2Gm8BehXo6LU7KT802QoXTPkYY1SKk5V8g/UuYZnNB3JzXqud/P99Pxr2yXeKyt+sKlCatmidz6jQNie1hRw==",
+      "dependencies": {
+        "cfb": "^1.1.3",
+        "jszip": "^3.2.2",
+        "lodash": "^4.17.15",
+        "sax": "^1.2.4"
+      }
+    },
     "node_modules/xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -5331,9 +5976,329 @@
       "dev": true
     },
     "@babel/parser": {
-      "version": "7.22.14",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
-      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ=="
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
+    },
+    "@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-38.1.1.tgz",
+      "integrity": "sha512-TDv6xOkcXws0RmfkBJ6vfuH4vwj3mbI8S++9czLKrHmwp24jSrxiRwP1ZUlJSImy+/3sTjec4u8I5fq0HA2UOA==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-autoformat": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-38.1.1.tgz",
+      "integrity": "sha512-Ppxxp0qprhENktpKv3lkVFchS9iZt0GbCVLPg8ffTb5dCAQgeXyC/TdR1b3zpbdjgSyai07OYgU59oTNUOwtog==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-basic-styles": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-38.1.1.tgz",
+      "integrity": "sha512-+mky2W983jaSlYpvQ31af0ethMQxXUxuBkd2IzRi2cchvSK9YbQtBSkV0EM595uoJa1S3doyCJn7Y8bOdE+v3A==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-block-quote": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-38.1.1.tgz",
+      "integrity": "sha512-YPSw+qTE71mvQTo5OA2M9oQp1jpUJrj1d15mbVE5DIyvc2CMWRltqV49GoM15ZpzgQWbaF3VZ8ZT0+vZlfS0lw==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-build-classic": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-38.1.1.tgz",
+      "integrity": "sha512-TaVK+kVX2hMZD8imbfsQHKTiMo4seBkmZvu8KgNPn8tNarmJacO27EYmPmzL04KyctP2pv4rt2UTzPfuFZyqvg==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "38.1.1",
+        "@ckeditor/ckeditor5-autoformat": "38.1.1",
+        "@ckeditor/ckeditor5-basic-styles": "38.1.1",
+        "@ckeditor/ckeditor5-block-quote": "38.1.1",
+        "@ckeditor/ckeditor5-ckbox": "38.1.1",
+        "@ckeditor/ckeditor5-ckfinder": "38.1.1",
+        "@ckeditor/ckeditor5-cloud-services": "38.1.1",
+        "@ckeditor/ckeditor5-easy-image": "38.1.1",
+        "@ckeditor/ckeditor5-editor-classic": "38.1.1",
+        "@ckeditor/ckeditor5-essentials": "38.1.1",
+        "@ckeditor/ckeditor5-heading": "38.1.1",
+        "@ckeditor/ckeditor5-image": "38.1.1",
+        "@ckeditor/ckeditor5-indent": "38.1.1",
+        "@ckeditor/ckeditor5-link": "38.1.1",
+        "@ckeditor/ckeditor5-list": "38.1.1",
+        "@ckeditor/ckeditor5-media-embed": "38.1.1",
+        "@ckeditor/ckeditor5-paragraph": "38.1.1",
+        "@ckeditor/ckeditor5-paste-from-office": "38.1.1",
+        "@ckeditor/ckeditor5-table": "38.1.1",
+        "@ckeditor/ckeditor5-typing": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-ckbox": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-38.1.1.tgz",
+      "integrity": "sha512-+R3Vz2QL/K2pdWzOZpFtrLwFHefxQfDT99sYQSUZiOQaXA6rSoLT4x6lhIdrQRjsI/ofCIGseQxuTHc8t86urA==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-ckfinder": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-38.1.1.tgz",
+      "integrity": "sha512-58139l/uKcMD6KZzd5uPzv8IwJYNnDFsT8N6DlecTZuh3ViKmg9t/pbRWu8epOboySwHeJoA3q12m2j05C1+JQ==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-clipboard": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-38.1.1.tgz",
+      "integrity": "sha512-FN6QxWw0ZcoMsCkm6FuN2do//qjNGofnsFernKWJPbL2E056dvB4WmhYHa4fCvGASCROcJ17yUV7oYI+1ah/og==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "@ckeditor/ckeditor5-widget": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-cloud-services": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-38.1.1.tgz",
+      "integrity": "sha512-M4MykJmA9JqlZEDCJfcGwEKq6Y1AuDf8Kxbl0LfMZu6BKv74up+c0wSD/WX7isot3eqDdSQckVjHlJvmS31EOA==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-core": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-38.1.1.tgz",
+      "integrity": "sha512-5yC+oSoCnjfOrvmECbwtu4zBt9S5dJfOYsAzfIGEbmD9DVGIyLBDKEjJ9IbAKAy1HG6CgAkZyv1YyEc5G5g3ew==",
+      "requires": {
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-easy-image": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-38.1.1.tgz",
+      "integrity": "sha512-kusGv9hBkFNm3/ZSr69fgdJ3V94feL0oXQoRUsCTsv2usda6KOIY3D5XMK8vvBpa7+0gFan98AvX9KM5IvrMkQ==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-classic": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-38.1.1.tgz",
+      "integrity": "sha512-LSh60tSuR8pGnLswy+Smx7x0NtFjbVX2dGiEkMyh4O0JLok/YgS3IU6UmoEd9FTjGqnOZ3644h3SpkSu84uDYA==",
+      "requires": {
+        "ckeditor5": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-engine": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-38.1.1.tgz",
+      "integrity": "sha512-Z0LYg7B4vN3ZNUf3utmBRXQBn3JNy81Xs+45sQ09Fpf5p6aKer37vxEA315O17PnWYndildeKNRUNdjI942HcQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-enter": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-38.1.1.tgz",
+      "integrity": "sha512-jzlTvyBwBw4TLr03NXwVeZD87pOSjisx8WCEahWM8Rxrw77k+7rg3blAWmmpw9cHUp2WkpxCztfvQtQouT9Jpw==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-essentials": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-38.1.1.tgz",
+      "integrity": "sha512-8Upvcjqny39pEZM5JbdyM8MESGjC6IkAJpjvqEFkbZsFcFzXjPolbxPReI3Xbl74XaMGYpwfraTv7ozkCxD7eA==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-heading": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-38.1.1.tgz",
+      "integrity": "sha512-uEh62XWpw5uIpaslJfn8YZ+9DfViCRR5auAz5SdiYDY+tdLjwKS308S1um5i5G/CLjp1M3uXlvDieOopit9nYg==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-image": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-38.1.1.tgz",
+      "integrity": "sha512-iXUlw38Eoo5zwj3h9eKULenEDPYoohPLT/74UDYw1V7Q3QY3dN4fCovcWwQx7VFPMPFUtd5T1S/ki/3UpLQhSA==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "ckeditor5": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-indent": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-38.1.1.tgz",
+      "integrity": "sha512-Wr0lAiTVGVAD4N/4zqFSGdO40uZEUdVaPFBNzRz2XeohLlMiu5poaWQkEmwtShyl8CFG5MYIayw0JBDw7uHPbA==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-link": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-38.1.1.tgz",
+      "integrity": "sha512-CMIPPaUIOvVPW/gIEmcZ00bYbQyy3/YenxPrzmdMkYjDWoPqfhDnn4FTrgEBYyWRXTNXXrS7D08VGeGCDOyYPA==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "ckeditor5": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-list": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-38.1.1.tgz",
+      "integrity": "sha512-FzBdAZWaBXjUYmtd7fDzIJ4evXM6n1RbNYG7ICzoviarlKL99mv/wLEkEvNDH0japdu/G11JtV36tRtBCzwoDQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-media-embed": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-38.1.1.tgz",
+      "integrity": "sha512-jWZUsJNRwVBfeTroSHcssEijCmNLgs2pJwKzJTcltyJr44se2V2kTEieCT3r0qpQvbdyw90n+MfrrlWb+S1bnQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-paragraph": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-38.1.1.tgz",
+      "integrity": "sha512-IsiCDTMK5s9T1QWwiLW90VFKsNfsTUlYy8tnr/sH5t2QFP8LOkF2ZL2igb/BqyuROrGVvS8At+BTnlH3hqAW/Q==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-paste-from-office": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-38.1.1.tgz",
+      "integrity": "sha512-xCAw3HwxfFgsZPINf6jb29MObDN2wDzZFpiMkChdjzmHqaCugd2SAssZQo/flxdy5fkMXju8gCa0bfM2g1HTkQ==",
+      "requires": {
+        "ckeditor5": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-select-all": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-38.1.1.tgz",
+      "integrity": "sha512-e/JUdGsBkf902rG0g+6ii/QhDP+LFV2W9bxhrGppLahzPX09NT5BCJh2/bTtUPw0cIRpk49ji7hNBzDjCKqctQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-table": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-38.1.1.tgz",
+      "integrity": "sha512-QOTc+Re3K5mY6GHC2vmglNb8k5D49cCjVlO2ORvr3Pk/Nepmk6asW3NoSfox8YJZSAfJyloD+t56FagZSokP+g==",
+      "requires": {
+        "ckeditor5": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-typing": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-38.1.1.tgz",
+      "integrity": "sha512-KU0wF1ueWFwK3BnkGB2v2vpjISgwmC0OxpPM0RLHCDG5iSvIkPbu1tUj9rbxRx45JM6xgpTP1C9kEFSm5w5MoQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-ui": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-38.1.1.tgz",
+      "integrity": "sha512-lTqOaciupH66Zz7BSRGOm5DyjLURJwmFfZyCYCKD6+ZbTsxcP1asdiUm8y3bOx2maRCZTrHMhuAANp3qFWXoLQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "color-convert": "2.0.1",
+        "color-parse": "1.4.2",
+        "lodash-es": "^4.17.15",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "@ckeditor/ckeditor5-undo": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-38.1.1.tgz",
+      "integrity": "sha512-21XCRb4XKYrK2bAkNTbOUb3Cmbu4FB11cqG3ncIg2rWSHSJJOijMdvZpZBvNpXVEsvJgA2Ol7bCiSXgdVUR/yQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-upload": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-38.1.1.tgz",
+      "integrity": "sha512-c7zau/N4cGJKpNPoRj0QEAQKOiIQzrSK2UCG0JsPtfF9jzTWa5fIJ/6hSHquwjtnhkB7zAL0PKXwcTNpdlyibA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1"
+      }
+    },
+    "@ckeditor/ckeditor5-utils": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-38.1.1.tgz",
+      "integrity": "sha512-+dSCchr8sseqWSfCuuOk5uajCo2Tr71IXmn3EGalEHE6Fc1GjWElO90GAA4Pbezrt1zG1tDqhh+bZHULAcK8wQ==",
+      "requires": {
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-vue": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-5.1.0.tgz",
+      "integrity": "sha512-KEx4Tj2Irr4ZbLG8LnaKpb0Dgd8qmLmKFWeiKkQwM3RAAeYRYOCcBVB2Y168I9KA8wRosPxgOO9jbQ92yopYHA=="
+    },
+    "@ckeditor/ckeditor5-watchdog": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-38.1.1.tgz",
+      "integrity": "sha512-NijdWJsl+vnzdtyhI0u0Ln2TEVaSLa2VEHyB7J1r57cUN9Bq5tqRH4/BhvvqGKGc9lkpbvcSFduH2c6StHm0rw==",
+      "requires": {
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-widget": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-38.1.1.tgz",
+      "integrity": "sha512-WAQhYBRfpu5jhV7Subc8pVkHYFCgXyJ65bQg5Jn8Em86lySejXQEi/GowjKwkwzlSrceqDrELEJV9jcCaUZlaA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-enter": "38.1.1",
+        "@ckeditor/ckeditor5-typing": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "lodash-es": "^4.17.15"
+      }
     },
     "@esbuild/linux-loong64": {
       "version": "0.14.54",
@@ -5351,9 +6316,9 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
-      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.0.tgz",
+      "integrity": "sha512-zJmuCWj2VLBt4c25CfBIbMZLGLyhkvs7LznyVX5HfpzeocThgIj5XQK4L+g3U36mMcx8bPMhGyPpwCATamC4jQ==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -5374,9 +6339,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
-      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
+      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
       "dev": true
     },
     "@firebase/analytics": {
@@ -5650,18 +6615,18 @@
       "integrity": "sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A=="
     },
     "@grpc/grpc-js": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.2.tgz",
-      "integrity": "sha512-Lf2pUhNTaviEdEaGgjU+29qw3arX7Qd/45q66F3z1EV5hroE6wM9xSHPvjB8EY+b1RmKZgwnLWXQorC6fZ9g5g==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.4.tgz",
+      "integrity": "sha512-oEnzYiDuEsBydZBtP84BkpduLsE1nSAO4KrhTLHRzNrIQE647fhchmosTQsJdCo8X9zBBt+l5+fNk+m/yCFJ/Q==",
       "requires": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       },
       "dependencies": {
         "@grpc/proto-loader": {
-          "version": "0.7.9",
-          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.9.tgz",
-          "integrity": "sha512-YJsOehVXzgurc+lLAxYnlSMc1p/Gu6VAvnfx0ATi2nzvr0YZcjhmZDeY8SeAKv1M7zE3aEJH0Xo9mK1iZ8GYoQ==",
+          "version": "0.7.10",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+          "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
           "requires": {
             "lodash.camelcase": "^4.3.0",
             "long": "^5.0.0",
@@ -5760,7 +6725,9 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "file:../jac-kit/src/packages",
+      "version": "3.0.37",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/3.0.37/2a23e8c56240dc8f0258a260899adc53c3631144",
+      "integrity": "sha512-VF2BGDMz1U72Y/Adasct5a83I8xhAZSpQsEtZegPwdmXZijxGuDitKv8FtW6hKl2+9lJeom+sFrrz7PTztd72A==",
       "requires": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",
@@ -5888,87 +6855,87 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.66.0.tgz",
-      "integrity": "sha512-3vCgC2hC3T45pn53yTDVcRpHoJTBxelDPPZVsipAbZnoOVPkj7n6dNfDhj3I3kwWCBPahPkXmE+R4xViR8VqJg==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.72.0.tgz",
+      "integrity": "sha512-DToryaRSHk9R5RLgN4ktYEXZjQdqncOAWPqyyIurji8lIobXFRfmLtGL1wjoCK6sQNgWsjhSM9kXxwGnva1DNw==",
       "requires": {
-        "@sentry/core": "7.66.0",
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0",
+        "@sentry/core": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/browser": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.66.0.tgz",
-      "integrity": "sha512-rW037rf8jkhyykG38+HUdwkRCKHJEMM5NkCqPIO5zuuxfLKukKdI2rbvgJ93s3/9UfsTuDFcKFL1u43mCn6sDw==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.72.0.tgz",
+      "integrity": "sha512-fcFDTzqhPd3VZAmmYW3KvBTBaEfrKjPmRhlAsfhkGWYLCHqVkNtzsFER4cmUNRGNxjyt9tcG3WlTTqgLRucycQ==",
       "requires": {
-        "@sentry-internal/tracing": "7.66.0",
-        "@sentry/core": "7.66.0",
-        "@sentry/replay": "7.66.0",
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0",
+        "@sentry-internal/tracing": "7.72.0",
+        "@sentry/core": "7.72.0",
+        "@sentry/replay": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.66.0.tgz",
-      "integrity": "sha512-WMAEPN86NeCJ1IT48Lqiz4MS5gdDjBwP4M63XP4msZn9aujSf2Qb6My5uT87AJr9zBtgk8MyJsuHr35F0P3q1w==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.72.0.tgz",
+      "integrity": "sha512-G03JdQ5ZsFNRjcNNi+QvCjqOuBvYqU92Gs1T2iK3GE8dSBTu2khThydMpG4xrKZQLIpHOyiIhlFZiuPtZ66W8w==",
       "requires": {
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/replay": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.66.0.tgz",
-      "integrity": "sha512-5Y2SlVTOFTo3uIycv0mRneBakQtLgWkOnsJaC5LB0Ip0TqVKiMCbQ578vvXp+yvRj4LcS1gNd98xTTNojBoQNg==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.72.0.tgz",
+      "integrity": "sha512-dHH/mYCFBwJ/kYmL9L5KihjwQKcefiuvcH0otHSwKSpbbeEoM/BV+SHQoYGd6OMSYnL9fq1dHfF7Zo26p5Yu0Q==",
       "requires": {
-        "@sentry/core": "7.66.0",
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0"
+        "@sentry/core": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0"
       }
     },
     "@sentry/tracing": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.66.0.tgz",
-      "integrity": "sha512-9bnz2EcOwjeMZAuYJnrwcRrImu9c10p7A0iDB8b2HLcp7gpuCkJbJyGoC1xeKD7reVD0BPq3VIbeHSwCcQufoQ==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.72.0.tgz",
+      "integrity": "sha512-DOMlyviMLNwWgN4gJw/TrHaAdBcZWvm8xLbgwMwrihRn/m84kmH2Ui1FUYpL30o/mH+mQS+53IHZukrgQjHkZA==",
       "requires": {
-        "@sentry-internal/tracing": "7.66.0"
+        "@sentry-internal/tracing": "7.72.0"
       }
     },
     "@sentry/types": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.66.0.tgz",
-      "integrity": "sha512-uUMSoSiar6JhuD8p7ON/Ddp4JYvrVd2RpwXJRPH1A4H4Bd4DVt1mKJy1OLG6HdeQv39XyhB1lPZckKJg4tATPw=="
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.72.0.tgz",
+      "integrity": "sha512-g6u0mk62yGshx02rfFADIfyR/S9VXcf3RG2qQPuvykrWtOfN/BOTrZypF7I+MiqKwRW76r3Pcu2C/AB+6z9XQA=="
     },
     "@sentry/utils": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.66.0.tgz",
-      "integrity": "sha512-9GYUVgXjK66uXXcLXVMXVzlptqMtq1eJENCuDeezQiEFrNA71KkLDg00wESp+LL+bl3wpVTBApArpbF6UEG5hQ==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.72.0.tgz",
+      "integrity": "sha512-o/MtqI7WJXuswidH0bSgBP40KN2lrnyQEIx5uoyJUJi/QEaboIsqbxU62vaFJpde8SYrbA+rTnP3J3ujF2gUag==",
       "requires": {
-        "@sentry/types": "7.66.0",
+        "@sentry/types": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/vue": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.66.0.tgz",
-      "integrity": "sha512-yuqS8w8pILm8r686ldAnWTlxCtyAomZdEemUIbnkYvvBbURnpYwVakJPyhFOwpuLgBAJ0FALyPV0ULDd5OAzrQ==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.72.0.tgz",
+      "integrity": "sha512-XTJK7C8WH370jBhXzKwPS3TgG5w5tT+qW25IQ+ypyBv4vclcaKeeGMlIehuH2n3hVI9ut/f4Wjj1EwCrQE4ORw==",
       "requires": {
-        "@sentry/browser": "7.66.0",
-        "@sentry/core": "7.66.0",
-        "@sentry/types": "7.66.0",
-        "@sentry/utils": "7.66.0",
+        "@sentry/browser": "7.72.0",
+        "@sentry/core": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@types/eslint": {
-      "version": "8.44.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
-      "integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
+      "version": "8.44.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.3.tgz",
+      "integrity": "sha512-iM/WfkwAhwmPff3wZuPLYiHX18HI24jU8k1ZSH7P8FHwxTjZ2P6CoX2wnF43oprR+YXJM6UUxATkNvyv/JHd+g==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -5976,14 +6943,14 @@
       }
     },
     "@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
     },
     "@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
     },
     "@types/json5": {
@@ -5998,9 +6965,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
-      "version": "20.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
+      "version": "20.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
+      "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg=="
     },
     "@vitejs/plugin-vue": {
       "version": "1.10.2",
@@ -6155,6 +7122,11 @@
       "dev": true,
       "requires": {}
     },
+    "adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -6207,15 +7179,15 @@
       }
     },
     "array-includes": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "is-string": "^1.0.7"
       }
     },
@@ -6233,38 +7205,39 @@
       }
     },
     "array.prototype.flat": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
-      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0"
       }
     },
     "arraybuffer.prototype.slice": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
-      "integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+      "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
       "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "get-intrinsic": "^1.2.1",
         "is-array-buffer": "^3.0.2",
         "is-shared-array-buffer": "^1.0.2"
@@ -6276,13 +7249,13 @@
       "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
     },
     "autoprefixer": {
-      "version": "10.4.15",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
-      "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
       "requires": {
         "browserslist": "^4.21.10",
-        "caniuse-lite": "^1.0.30001520",
-        "fraction.js": "^4.2.0",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -6337,14 +7310,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.0.tgz",
+      "integrity": "sha512-v+Jcv64L2LbfTC6OnRcaxtqJNJuQAVhZKSJfR/6hn7lhnChUXl4amwVviqN1k411BB+3rRoKMitELRn1CojeRA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
+        "caniuse-lite": "^1.0.30001539",
+        "electron-to-chromium": "^1.4.530",
         "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "buffer": {
@@ -6382,9 +7355,18 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001525",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
-      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q=="
+      "version": "1.0.30001541",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+      "integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw=="
+    },
+    "cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "requires": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -6431,6 +7413,26 @@
         }
       }
     },
+    "ckeditor5": {
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-38.1.1.tgz",
+      "integrity": "sha512-KE6H2WGLlhlI4F//AZn+fv52DhbwAeVv+ZeSIsa5gC81/3ZCzuYc3+IMur/70IBE9Gze8gKwFP9elh/TIaQ5Hw==",
+      "requires": {
+        "@ckeditor/ckeditor5-clipboard": "38.1.1",
+        "@ckeditor/ckeditor5-core": "38.1.1",
+        "@ckeditor/ckeditor5-engine": "38.1.1",
+        "@ckeditor/ckeditor5-enter": "38.1.1",
+        "@ckeditor/ckeditor5-paragraph": "38.1.1",
+        "@ckeditor/ckeditor5-select-all": "38.1.1",
+        "@ckeditor/ckeditor5-typing": "38.1.1",
+        "@ckeditor/ckeditor5-ui": "38.1.1",
+        "@ckeditor/ckeditor5-undo": "38.1.1",
+        "@ckeditor/ckeditor5-upload": "38.1.1",
+        "@ckeditor/ckeditor5-utils": "38.1.1",
+        "@ckeditor/ckeditor5-watchdog": "38.1.1",
+        "@ckeditor/ckeditor5-widget": "38.1.1"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -6460,6 +7462,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "color-parse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
+      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
     "colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -6475,6 +7485,16 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
       "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -6513,12 +7533,24 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+    "define-data-property": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
+      "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
       "dev": true,
       "requires": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "requires": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
@@ -6553,9 +7585,9 @@
       "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg=="
     },
     "electron-to-chromium": {
-      "version": "1.4.508",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
-      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg=="
+      "version": "1.4.532",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.532.tgz",
+      "integrity": "sha512-piIR0QFdIGKmOJTSNg5AwxZRNWQSXlRYycqDB9Srstx4lip8KpcmRxVP6zuFWExWziHYZpJ0acX7TxqX95KBpg=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -6563,18 +7595,18 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "es-abstract": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
-      "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
+      "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
       "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.2",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.5",
+        "function.prototype.name": "^1.1.6",
         "get-intrinsic": "^1.2.1",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
@@ -6590,23 +7622,23 @@
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.10",
+        "is-typed-array": "^1.1.12",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.0",
-        "safe-array-concat": "^1.0.0",
+        "regexp.prototype.flags": "^1.5.1",
+        "safe-array-concat": "^1.0.1",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.7",
-        "string.prototype.trimend": "^1.0.6",
-        "string.prototype.trimstart": "^1.0.6",
+        "string.prototype.trim": "^1.2.8",
+        "string.prototype.trimend": "^1.0.7",
+        "string.prototype.trimstart": "^1.0.7",
         "typed-array-buffer": "^1.0.0",
         "typed-array-byte-length": "^1.0.0",
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.10"
+        "which-typed-array": "^1.1.11"
       }
     },
     "es-set-tostringtag": {
@@ -6800,16 +7832,16 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
-      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
+      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.48.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/js": "8.50.0",
+        "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.12.4",
@@ -7244,9 +8276,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
     "flatten-vertex-data": {
@@ -7267,9 +8299,9 @@
       }
     },
     "fraction.js": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.5.tgz",
-      "integrity": "sha512-58DncB2bO/8ZvTHapG7U2KEbeFFyUbbrFFkHakecpdUSqJrQnEuBeTUPEggIVkx5cnugZJ4IVzk2Nbb32MOxBg=="
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -7357,9 +8389,9 @@
       }
     },
     "globals": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "version": "13.22.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
+      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -7464,6 +8496,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "immutable": {
       "version": "4.3.4",
@@ -7740,6 +8777,51 @@
         "minimist": "^1.2.0"
       }
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -7759,6 +8841,14 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7772,6 +8862,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -8208,6 +9303,11 @@
         "p-limit": "^3.0.2"
       }
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8292,6 +9392,11 @@
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "promise-polyfill": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
@@ -8349,14 +9454,14 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+      "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
-        "functions-have-names": "^1.2.3"
+        "set-function-name": "^2.0.0"
       }
     },
     "regexpp": {
@@ -8371,9 +9476,9 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
     "resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
+      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
       "requires": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -8425,13 +9530,13 @@
       }
     },
     "safe-array-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
-      "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
+        "get-intrinsic": "^1.2.1",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       }
@@ -8453,9 +9558,9 @@
       }
     },
     "sass": {
-      "version": "1.66.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
-      "integrity": "sha512-50c+zTsZOJVgFfTgwwEzkjA3/QACgdNsKueWPyAR0mRINIvLAStVQBbPg14iuqEQ74NPDbXzJARJ/O4SI1zftA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.68.0.tgz",
+      "integrity": "sha512-Lmj9lM/fef0nQswm1J2HJcEsBUba4wgNx2fea6yJHODREoMFnwRpZydBnX/RjyXw2REIwdkbqE4hrTo4qfDBUA==",
       "devOptional": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -8476,11 +9581,32 @@
         "write": "^1.0.0"
       }
     },
+    "sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+    },
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
+    },
+    "set-function-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "dev": true,
+      "requires": {
+        "define-data-property": "^1.0.1",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.0"
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -8565,36 +9691,36 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
-      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       }
     },
     "strip-ansi": {
@@ -8760,9 +9886,9 @@
       }
     },
     "update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -8791,6 +9917,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "vanilla-colorful": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
+      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg=="
+    },
     "vite": {
       "version": "2.9.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
@@ -8804,9 +9935,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "8.4.29",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
-          "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
+          "version": "8.4.30",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
+          "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
           "requires": {
             "nanoid": "^3.3.6",
             "picocolors": "^1.0.0",
@@ -8904,9 +10035,9 @@
       "requires": {}
     },
     "vue-router": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.4.tgz",
-      "integrity": "sha512-9PISkmaCO02OzPVOMq2w82ilty6+xJmQrarYZDkjZBfl4RvYAlt4PKnEX21oW4KTtWfa9OuO/b3qk1Od3AEdCQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.5.tgz",
+      "integrity": "sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==",
       "requires": {
         "@vue/devtools-api": "^6.5.0"
       }
@@ -9018,6 +10149,17 @@
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "xlsx-populate": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/xlsx-populate/-/xlsx-populate-1.21.0.tgz",
+      "integrity": "sha512-8v2Gm8BehXo6LU7KT802QoXTPkYY1SKk5V8g/UuYZnNB3JzXqud/P99Pxr2yXeKyt+sKlCatmidz6jQNie1hRw==",
+      "requires": {
+        "cfb": "^1.1.3",
+        "jszip": "^3.2.2",
+        "lodash": "^4.17.15",
+        "sax": "^1.2.4"
       }
     },
     "xmlhttprequest": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "3.0.30",
+    "@jac-uk/jac-kit": "3.0.37",
     "@ministryofjustice/frontend": "0.2.4",
     "@rollup/plugin-inject": "^5.0.3",
     "@sentry/tracing": "^7.61.1",


### PR DESCRIPTION
## What's included?
This fix relies on the jac-kit v3.0.37.
The problem was that the scrollIntoView was somehow causing the page content to shift to the left. It's difficult to say exactly why.
The fix involved changing the element being scrolled into view.

Closes #2120 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- Go to the following page: https://jac-admin-develop--pr2152-hotfix-hotfix-2120-m-6ctuhch9.web.app/exercise/q3r80nVrmVFhB2ML03qq/details/timeline/edit
- Remove one of the dates
- Scroll to the bottom of the page and press the 'Save and Continue' button

The page should scroll back up to display the error summary and the left side of the page should NOT have the display bug as shown in the image below.

<img width="543" alt="Screenshot 2023-09-28 at 14 16 11" src="https://github.com/jac-uk/admin/assets/115651787/52a79561-00b6-4b23-9fda-5f60589d5741">

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
