### PR TITLE
#2163 Search Not Working For Panel Packs

### DIFF
--- a/src/components/PanelPacks/PanelPacks.vue
+++ b/src/components/PanelPacks/PanelPacks.vue
@@ -195,6 +195,9 @@ export default {
       return !isDisabled;
     },
   },
+  created() {
+    console.log('Testing1');
+  },
   methods: {
     getTableData(params) {
       this.$store.dispatch(

--- a/src/components/PanelPacks/PanelPacks.vue
+++ b/src/components/PanelPacks/PanelPacks.vue
@@ -38,7 +38,7 @@
     <!-- // END PANELS -->
     <!-- CANDIDATES -->
     <div v-show="activeTab == 'candidates'">
-      <Table
+      <!-- <Table
         v-model:selection="selectedItems"
         data-key="id"
         :data="candidatesList"
@@ -50,6 +50,16 @@
           handler: candidateSearch,
           field: 'candidate.id',
         }"
+        @change="getTableDataCandidates"
+      > -->
+      <Table
+        v-model:selection="selectedItems"
+        data-key="id"
+        :data="candidatesList"
+        :columns="tableColumnsCandidates"
+        multi-select
+        :page-size="50"
+        search-map="_search"
         @change="getTableDataCandidates"
       >
         <template #actions>
@@ -194,9 +204,6 @@ export default {
       const isDisabled = this.selectedItems && this.selectedItems.length;
       return !isDisabled;
     },
-  },
-  created() {
-    console.log('Testing1');
   },
   methods: {
     getTableData(params) {

--- a/src/components/PanelPacks/PanelPacks.vue
+++ b/src/components/PanelPacks/PanelPacks.vue
@@ -38,20 +38,6 @@
     <!-- // END PANELS -->
     <!-- CANDIDATES -->
     <div v-show="activeTab == 'candidates'">
-      <!-- <Table
-        v-model:selection="selectedItems"
-        data-key="id"
-        :data="candidatesList"
-        :columns="tableColumnsCandidates"
-        multi-select
-        :page-size="50"
-        :custom-search="{
-          placeholder: 'Search candidate names',
-          handler: candidateSearch,
-          field: 'candidate.id',
-        }"
-        @change="getTableDataCandidates"
-      > -->
       <Table
         v-model:selection="selectedItems"
         data-key="id"


### PR DESCRIPTION
## What's included?
Fixed search for panel packs.

Closes #2163 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the panel packs search. Ensure you can search by the following fields:

- candidate national insurance number
- candidate email
- candidate full name
- application reference number

So, for example you can use this test link: https://jac-admin-develop--pr2164-hotfix-2163-search-n-ue7wk0py.web.app/exercise/mgiIdf4ccm3z7Q3jsZKb/reports/selection#candidates

And one of the candidates has the following details:

Fullname: Yesim Sharp
NI: (has the following characters in it: 359)
Email: (has the user's name in it)
Application ID: JAC00545-kun0002

See video below:

https://github.com/jac-uk/admin/assets/115651787/3aad84e7-be8a-4e3a-93d5-c8b8972938e5

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
