### PR TITLE
Feature/2143 capture commissioner conflicts

### DIFF
--- a/src/components/RepeatableFields/AssignedCommissioner.vue
+++ b/src/components/RepeatableFields/AssignedCommissioner.vue
@@ -39,9 +39,9 @@ export default {
   },
   computed: {
     emails() {
-      const originalEmails = this.$store.getters['services/getEmails']('commissioners');
+      const commissioners = this.$store.getters['services/getCommissioners'];
       // make a copy of the array so we don't mutate the original
-      const emails = [...originalEmails];
+      const emails = commissioners.map(commissioner => commissioner.email);
       // sort emails alphabetically
       emails.sort((a, b) => {
         a = a.toLowerCase();

--- a/src/filters.js
+++ b/src/filters.js
@@ -34,6 +34,7 @@ const lookup = (value) => {
     statementOfEligibility: 'Statement of eligibility',
     selfAssessmentCompetencies: 'Self assessment with competencies',
     additionalInfo: 'Additional Information',
+    commissionerConflicts: 'Commissioner conflicts',
 
     // exercise states
     draft: 'Draft',

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -134,6 +134,7 @@ const APPLICATION_PARTS = [
   'statementOfEligibility',
   'selfAssessmentCompetencies',
   'additionalInfo',
+  'commissionerConflicts',
 ];
 
 const CAPABILITIES = ['L&J', 'PQ', 'L', 'EJ', 'PBK', 'ACI', 'WCO', 'MWE', 'OVERALL'];
@@ -647,6 +648,7 @@ function exerciseApplicationParts(data, newValues) {
   if (hasSelfAssessment(exercise)) {
     applicationParts.push('selfAssessmentCompetencies');
   }
+  applicationParts.push('commissionerConflicts');
   applicationParts.push('additionalInfo');
   return applicationParts;
 }

--- a/src/router.js
+++ b/src/router.js
@@ -73,6 +73,7 @@ import ExerciseReportsPanelsView from '@/views/Exercise/Reports/PanelsView.vue';
 import ExerciseReportsSift from '@/views/Exercise/Reports/Sift.vue';
 import ExerciseReportsSelectionDays from '@/views/Exercise/Reports/SelectionDays.vue';
 import ExerciseReportsScenario from '@/views/Exercise/Reports/Scenario.vue';
+import ExerciseReportsCommissionerConflicts from '@/views/Exercise/Reports/CommissionerConflicts.vue';
 
 // Merit list
 import ExerciseReportsMeritList from '@/views/Exercise/Reports/MeritList.vue';
@@ -1089,6 +1090,15 @@ const routes = [
                 },
               },
             ],
+          },
+          {
+            name: 'commissioner-conflicts',
+            path: 'commissioner-conflicts',
+            component: ExerciseReportsCommissionerConflicts,
+            meta: {
+              requiresAuth: true,
+              title: 'Commissioner Conflicts | Exercise Reports',
+            },
           },
         ],
       },

--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -113,6 +113,14 @@ export default {
       const ref = collection.doc(id);
       await ref.update(data);
     },
+    updateCommissioners: async ({ state, rootGetters }) => {
+      const id = state.record.id;
+      const ref = collection.doc(id);
+      const data = {
+        commissioners: rootGetters['services/getCommissioners'],
+      };
+      await ref.update(data);
+    },
     isReadyForTest: async ({ state }) => {
       const id = state.record.id;
       const ref = collection.doc(id);

--- a/src/store/services.js
+++ b/src/store/services.js
@@ -45,5 +45,8 @@ export default {
       }
       return null;
     },
+    getCommissioners: (state) => {
+      return state.record && state.record.commissioners;
+    },
   },
 };

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -267,6 +267,12 @@
               :authorised-to-perform-action="editable"
               @update-application="changeApplication"
             />
+            <CommissionerConflictsSummary
+              :application="application"
+              :exercise="exercise"
+              :editable="editable"
+              @update-application="changeApplication"
+            />
           </div>
         </div>
 
@@ -319,6 +325,7 @@ import QualificationsAndMembershipsSummary from '@/views/InformationReview/Quali
 import ExperienceSummary from '@/views/InformationReview/ExperienceSummary.vue';
 import AssessmentsSummary from '@/views/InformationReview/AssessmentsSummary.vue';
 import AssessorsSummary from '@/views/InformationReview/AssessorsSummary.vue';
+import CommissionerConflictsSummary from '@/views/InformationReview/CommissionerConflictsSummary.vue';
 import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer.vue';
 import PageNotFound from '@/views/Errors/PageNotFound.vue';
 import { splitFullName } from '@jac-uk/jac-kit/helpers/splitFullName';
@@ -355,6 +362,7 @@ export default {
     ExperienceSummary,
     AssessmentsSummary,
     AssessorsSummary,
+    CommissionerConflictsSummary,
   },
   mixins: [permissionMixin],
   data() {

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -371,6 +371,7 @@ export default {
         decision: 'requested',
         rejectionResponse: note ? note : null,
       });
+      await this.$store.dispatch('exerciseDocument/updateCommissioners');
       this.closeApprovalModal();
     },
     async confirmDelete() {

--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -94,6 +94,14 @@ export default {
           }
         );
       }
+      if (exercise?._applicationContent?.registration?.commissionerConflicts) {
+        sideNavigation.push(
+          {
+            title: 'Commissioner conflicts',
+            path: `${path}/commissioner-conflicts`,
+          }
+        );
+      }
 
       return sideNavigation;
     },

--- a/src/views/Exercise/Reports/CommissionerConflicts.vue
+++ b/src/views/Exercise/Reports/CommissionerConflicts.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        Commissioner Conflicts
+      </h1>
+    </div>
+    <div class="govuk-grid-column-one-third text-right govuk-!-padding-bottom-7">
+      <ActionButton
+        v-if="hasPermissions([
+          PERMISSIONS.exercises.permissions.canReadExercises.value,
+          PERMISSIONS.applications.permissions.canReadApplications.value
+        ])"
+        class="govuk-!-margin-right-2"
+        :action="exportData"
+      >
+        Export to Word
+      </ActionButton>
+    </div>
+
+    <div class="govuk-grid-column-full">
+      <Table
+        data-key="id"
+        :data="applications"
+        :columns="tableColumns"
+        :search-map="$searchMap.applications"
+        :page-size="50"
+        @change="getTableData"
+      >
+        <template #row="{row}">
+          <TableCell :title="tableColumns[0].title">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds">
+                <div class="candidate-name govuk-heading-m govuk-!-margin-bottom-0">
+                  {{ row.personalDetails.fullName }}
+                </div>
+              </div>
+              <div class="govuk-grid-column-one-third text-right">
+                <RouterLink
+                  :to="{name: 'exercise-application', params: { applicationId: row.id, tab: 'issues' }}"
+                  class="govuk-link print-none"
+                >
+                  View application
+                </RouterLink>
+              </div>
+              <div
+                v-if="row.additionalInfo && row.additionalInfo.commissionerConflicts"
+                class="govuk-grid-column-full"
+              >
+                <div
+                  v-for="(commissionerConflict, index) in getCommissionerConflicts(row)"
+                  :key="index"
+                  class="govuk-grid-row govuk-!-margin-0 govuk-!-margin-bottom-4 govuk-!-margin-left-3"
+                >
+                  <hr
+                    v-if="index"
+                    class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-2"
+                  >
+                  <div v-if="commissionerConflict.hasRelationship">
+                    <p><b>Commissioner:</b> {{ commissionerConflict.name }}</p>
+                    <p><b>Details:</b> {{ commissionerConflict.detail }}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </TableCell>
+        </template>
+      </Table>
+    </div>
+  </div>
+</template>
+
+<script>
+import Table from '@jac-uk/jac-kit/components/Table/Table.vue';
+import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
+import permissionMixin from '@/permissionMixin';
+import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
+
+export default {
+  name: 'CommissionerConflicts',
+  components: {
+    Table,
+    TableCell,
+    ActionButton,
+  },
+  mixins: [permissionMixin],
+  data () {
+    return {
+      unsubscribe: null,
+      tableColumns: [
+        { title: 'Candidate', sort: '_sort.fullNameUC', default: true },
+      ],
+    };
+  },
+  computed: {
+    exercise() {
+      return this.$store.state.exerciseDocument.record;
+    },
+    applications() {
+      return this.$store.state.applications.records;
+    },
+  },
+  unmounted() {
+    this.$store.dispatch('applications/unbind');
+  },
+  methods: {
+    getTableData(params) {
+      this.$store.dispatch(
+        'applications/bind',
+        {
+          exerciseId: this.exercise.id,
+          status: 'applied',
+          ...params,
+        }
+      );
+    },
+    getCommissionerConflicts(application) {
+      if (application.additionalInfo && application.additionalInfo.commissionerConflicts) {
+        return application.additionalInfo.commissionerConflicts.filter(conflict => conflict.hasRelationship);
+      }
+      return [];
+    },
+    async exportData() {
+      // TODO:
+    },
+  },
+};
+</script>

--- a/src/views/Exercise/Reports/CommissionerConflicts.vue
+++ b/src/views/Exercise/Reports/CommissionerConflicts.vue
@@ -12,7 +12,7 @@
           PERMISSIONS.applications.permissions.canReadApplications.value
         ])"
         class="govuk-!-margin-right-2"
-        :action="exportData"
+        :action="exportToGoogleDoc"
       >
         Export to Word
       </ActionButton>
@@ -71,6 +71,7 @@
 </template>
 
 <script>
+import { functions } from '@/firebase';
 import Table from '@jac-uk/jac-kit/components/Table/Table.vue';
 import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
 import permissionMixin from '@/permissionMixin';
@@ -86,7 +87,6 @@ export default {
   mixins: [permissionMixin],
   data () {
     return {
-      unsubscribe: null,
       tableColumns: [
         { title: 'Candidate', sort: '_sort.fullNameUC', default: true },
       ],
@@ -120,8 +120,14 @@ export default {
       }
       return [];
     },
-    async exportData() {
-      // TODO:
+    async exportToGoogleDoc() {
+      if (!this.exercise) return;
+      try {
+        await functions.httpsCallable('exportApplicationCommissionerConflicts')({ exerciseId: this.exercise.id, format: 'googledoc' });
+        return true;
+      } catch (error) {
+        return;
+      }
     },
   },
 };

--- a/src/views/Exercise/Reports/CommissionerConflicts.vue
+++ b/src/views/Exercise/Reports/CommissionerConflicts.vue
@@ -58,7 +58,7 @@
                   >
                   <div v-if="commissionerConflict.hasRelationship">
                     <p><b>Commissioner:</b> {{ commissionerConflict.name }}</p>
-                    <p><b>Details:</b> {{ commissionerConflict.detail }}</p>
+                    <p><b>Details:</b> {{ commissionerConflict.details }}</p>
                   </div>
                 </div>
               </div>

--- a/src/views/Exercise/Reports/CommissionerConflicts.vue
+++ b/src/views/Exercise/Reports/CommissionerConflicts.vue
@@ -123,11 +123,38 @@ export default {
     async exportToGoogleDoc() {
       if (!this.exercise) return;
       try {
-        await functions.httpsCallable('exportApplicationCommissionerConflicts')({ exerciseId: this.exercise.id, format: 'googledoc' });
-        return true;
+        const res = await functions.httpsCallable('exportApplicationCommissionerConflicts')({ exerciseId: this.exercise.id, format: 'googledoc' });
+        if (res.data.sourceContent) {
+          this.export2Word(res.data.sourceContent, `${this.exercise.referenceNumber} ${this.exercise.name} - Commissioner Conflicts Report`);
+          return true;
+        }
+        return;
       } catch (error) {
         return;
       }
+    },
+    export2Word(html, filename = '') {
+      const blob = new Blob(['\ufeff', html], {
+        type: 'application/msword',
+      });
+    
+      // specify link url
+      const url = `data:application/vnd.ms-word;charset=utf-8,${encodeURIComponent(html)}`;
+      // specify file name
+      filename = filename ? `${filename}.doc` : 'Commissioner Conflicts Report.doc';
+      // create download link element
+      const downloadLink = document.createElement('a');
+      document.body.appendChild(downloadLink);
+    
+      if (navigator.msSaveOrOpenBlob ){
+        navigator.msSaveOrOpenBlob(blob, filename);
+      } else {
+        downloadLink.href = url;
+        downloadLink.download = filename;
+        downloadLink.click();
+      }
+    
+      document.body.removeChild(downloadLink);
     },
   },
 };

--- a/src/views/Exercise/Reports/CommissionerConflicts.vue
+++ b/src/views/Exercise/Reports/CommissionerConflicts.vue
@@ -37,7 +37,7 @@
               </div>
               <div class="govuk-grid-column-one-third text-right">
                 <RouterLink
-                  :to="{name: 'exercise-application', params: { applicationId: row.id, tab: 'issues' }}"
+                  :to="{name: 'exercise-application', params: { applicationId: row.id }}"
                   class="govuk-link print-none"
                 >
                   View application

--- a/src/views/InformationReview/CommissionerConflictsSummary.vue
+++ b/src/views/InformationReview/CommissionerConflictsSummary.vue
@@ -40,7 +40,7 @@
               <InformationReviewRenderer
                 v-if="commissionerConflict.hasRelationship"
                 :data="commissionerConflict.details"
-                field="detail"
+                field="details"
                 :edit="editable"
                 :is-asked="isApplicationPartAsked('commissionerConflicts')"
                 @change-field="(obj) => changeCommissionerConflict(obj, index)"
@@ -87,7 +87,7 @@ export default {
         return match ? match : {
           name: commissioner.name,
           hasRelationship: null,
-          detail: null,
+          details: null,
         };
       });
     },

--- a/src/views/InformationReview/CommissionerConflictsSummary.vue
+++ b/src/views/InformationReview/CommissionerConflictsSummary.vue
@@ -39,7 +39,7 @@
               </dt>
               <InformationReviewRenderer
                 v-if="commissionerConflict.hasRelationship"
-                :data="commissionerConflict.detail"
+                :data="commissionerConflict.details"
                 field="detail"
                 :edit="editable"
                 :is-asked="isApplicationPartAsked('commissionerConflicts')"

--- a/src/views/InformationReview/CommissionerConflictsSummary.vue
+++ b/src/views/InformationReview/CommissionerConflictsSummary.vue
@@ -1,0 +1,124 @@
+<template>
+  <div>
+    <div
+      v-if="exercise.commissioner"
+      class="govuk-!-margin-top-9"
+    >
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-4">
+        Commissioner conflicts
+      </h2>
+
+      <dl
+        v-if="commissionerConflicts || editable"
+        class="govuk-summary-list"
+      >
+        <div
+          v-for="(commissionerConflict, index) in commissionerConflicts"
+          :key="index"
+          class="govuk-summary-list__row"
+        >
+          <dt class="govuk-summary-list__key widerColumn">
+            {{ commissionerConflict.name }}
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <InformationReviewRenderer
+              :data="commissionerConflict.hasRelationship"
+              field="hasRelationship"
+              :edit="editable"
+              type="selection"
+              :options="[true, false]"
+              :is-asked="isApplicationPartAsked('commissionerConflicts')"
+              @change-field="(obj) => changeCommissionerConflict(obj, index)"
+            />
+            <div
+              v-if="commissionerConflict.hasRelationship"
+              class="govuk-body"
+            >
+              <dt class="govuk-summary-list__key">
+                Details
+              </dt>
+              <InformationReviewRenderer
+                v-if="commissionerConflict.hasRelationship"
+                :data="commissionerConflict.detail"
+                field="detail"
+                :edit="editable"
+                :is-asked="isApplicationPartAsked('commissionerConflicts')"
+                @change-field="(obj) => changeCommissionerConflict(obj, index)"
+              />
+            </div>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</template>
+
+<script>
+import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer.vue';
+import { isApplicationPartAsked } from '@/helpers/exerciseHelper';
+
+export default {
+  name: 'CommissionerConflictsSummary',
+  components: {
+    InformationReviewRenderer,
+  },
+  props: {
+    application: {
+      type: Object,
+      required: true,
+      default: () => {},
+    },
+    editable: {
+      type: [Boolean, Function, Promise],
+      required: true,
+      default: false,
+    },
+  },
+  emits: ['updateApplication'],
+  computed: {
+    exercise() {
+      return this.$store.state.exerciseDocument.record;
+    },
+    commissionerConflicts() {
+      return Array.isArray(this.exercise.commissioners) && this.exercise.commissioners.map((commissioner) => {
+        const match = this.application?.additionalInfo?.commissionerConflicts.find((commissionerConflict) => {
+          return commissionerConflict.name === commissioner.name;
+        });
+        return match ? match : {
+          name: commissioner.name,
+          hasRelationship: null,
+          detail: null,
+        };
+      });
+    },
+  },
+  methods: {
+    getCommissionerConflicts(name) {
+      return this.commissionerConflicts.find((commissionerConflict) => {
+        return commissionerConflict.name === name;
+      });
+    },
+    isApplicationPartAsked(part) {
+      return isApplicationPartAsked(this.exercise, part);
+    },
+    changeCommissionerConflict(obj, index) {
+      const commissionerConflicts = this.commissionerConflicts.map((commissionerConflict, i) => {
+        return i === index ? { ...commissionerConflict, ...obj } : commissionerConflict;
+      });
+      const data = {
+        additionalInfo: {
+          ...this.application.additionalInfo,
+          commissionerConflicts,
+        },
+      };
+      this.$emit('updateApplication', data);
+    },
+  },
+};
+</script>
+
+<style scoped>
+  .widerColumn {
+    width: 70%;
+  }
+</style>

--- a/src/views/InformationReview/CommissionerConflictsSummary.vue
+++ b/src/views/InformationReview/CommissionerConflictsSummary.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      v-if="exercise.commissioner"
+      v-if="exercise.commissioners"
       class="govuk-!-margin-top-9"
     >
       <h2 class="govuk-heading-l govuk-!-margin-bottom-4">


### PR DESCRIPTION
## What's included?
Closes #2143 

Note: This PR is related to [digital-platform: Feature/Export commissioner conflicts](https://github.com/jac-uk/digital-platform/pull/957).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Example exercise: https://jac-admin-develop--pr2179-feature-2143-capture-f3nlqymg.web.app/exercise/ONqUjAzhDS7rjh6dFJLB/reports/commissioner-conflicts

1. Go to "Commissioner Conflicts" report.
2. Check if the details of the commissioner conflicts are shown in the table.
3. Click "Export to Word" and check if the report is exported to Google Drive (https://drive.google.com/drive/u/0/folders/1RjUXKqkn1tJUvarj2mmvV6W1vvyAlk3v).

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/4e2353d4-c291-4f47-a573-ea1f99b2a981

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
