### PR TITLE
#2159 Disallow archiving until exercise unpublished from website

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -117,7 +117,7 @@
 
     <main
       id="main-content"
-      class="govuk-width-container govuk-main-wrapper govuk-main-wrapper--auto-spacing"
+      class="govuk-width-container govuk-main-wrapper govuk-main-wrapper--auto-spacing govuk-!-padding-left-4 govuk-!-padding-right-4"
       role="main"
     >
       <RouterView />

--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -176,6 +176,8 @@ export default {
       const id = state.record.id;
       const ref = collection.doc(id);
       const data = {
+          published: false,   // Unpublish!
+          testingState: null,
           state: 'archived',
           stateBeforeArchive: state.record.state,
         };

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -103,9 +103,9 @@
 
       <Modal ref="archiveModal">
         <ModalInner
-          title="Archive exercise"
+          :title="archiveTitle"
           :message="archiveMessage"
-          button-text="Accept - archive this exercise"
+          :button-text="archiveButtonText"
           @close="closeArchiveModal"
           @confirmed="archive"
         />
@@ -203,11 +203,27 @@ export default {
     isProduction() {
       return this.$store.getters['isProduction'];
     },
+    archiveTitle() {
+      if (this.isArchived) {
+        return 'Unarchive exercise';
+      } else {
+        return 'Archive exercise';
+      }
+    },
     archiveMessage() {
-      if (this.isPublished) {
+      if (this.isArchived) {
+        return 'By clicking accept you authorise the exercise to be unarchived';
+      } else if (this.isPublished) {
         return 'This exercise is Live on Apply; by clicking accept, you authorise the exercise to be removed from Apply and archived';
       } else {
         return 'By clicking accept you authorise the exercise to be archived';
+      }
+    },
+    archiveButtonText() {
+      if (this.isArchived) {
+        return 'Accept - unarchive this exercise';
+      } else {
+        return 'Accept - archive this exercise';
       }
     },
     hasOpened() {

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -103,6 +103,9 @@
 
       <Modal ref="archiveModal">
         <ModalInner
+          title="Archive exercise"
+          :message="archiveMessage"
+          button-text="Accept - archive this exercise"
           @close="closeArchiveModal"
           @confirmed="archive"
         />
@@ -199,6 +202,13 @@ export default {
     },
     isProduction() {
       return this.$store.getters['isProduction'];
+    },
+    archiveMessage() {
+      if (this.isPublished) {
+        return 'This exercise is Live on Apply; by clicking accept, you authorise the exercise to be removed from Apply and archived';
+      } else {
+        return 'By clicking accept you authorise the exercise to be archived';
+      }
     },
     hasOpened() {
       if (this.exercise && this.exercise.applicationOpenDate <= new Date()) {

--- a/src/views/Exercise/Details/Overview/ApprovalProcess.vue
+++ b/src/views/Exercise/Details/Overview/ApprovalProcess.vue
@@ -1,16 +1,17 @@
 <template>
   <div class="govuk-!-margin-right-3 govuk-!-margin-left-3">
     <Banner
-      v-if="notPublishedDuringApplicationWindow"
-      message="This exercise is currently within the application window and is not published on the website."
-      status="warning"
-    />
-
-    <Banner
       v-if="isApproved && !isPublished && !isArchived && (canUpdateExercises && canPublishExercises)"
       message="This exercise has been approved. Now you can publish it to the website."
       status="success"
     />
+
+    <Banner
+      v-else-if="notPublishedDuringApplicationWindow"
+      message="This exercise is currently within the application window and is not published on the website."
+      status="warning"
+    />
+
     <template v-if="isReadyForApproval">
       <RejectionForm
         v-if="canApproveExercise && showRejectionForm"

--- a/src/views/Exercise/Details/Summary/View.vue
+++ b/src/views/Exercise/Details/Summary/View.vue
@@ -145,7 +145,7 @@
 
 <script>
 import { logEvent } from '@/helpers/logEvent';
-import { isEditable } from '@/helpers/exerciseHelper';
+import { isEditable, isArchived } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
 import ChangeExerciseAdvertType from '@/components/ModalViews/ChangeExerciseAdvertType.vue';
@@ -178,8 +178,11 @@ export default {
     isPublished() {
       return this.exercise.published;
     },
+    isArchived() {
+      return isArchived(this.exercise);
+    },
     canPublish() {
-      return this.exercise.progress && this.exercise.progress.vacancySummary;
+      return this.exercise.progress && this.exercise.progress.vacancySummary && !this.isArchived;
     },
   },
   methods: {

--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -162,8 +162,6 @@ import { mapState } from 'vuex';
 import Table from '@jac-uk/jac-kit/components/Table/Table.vue';
 import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
 import permissionMixin from '@/permissionMixin';
-import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
-import ModalInner from '@jac-uk/jac-kit/components/Modal/ModalInner.vue';
 import _upperFirst from 'lodash/upperFirst';
 import _get from 'lodash/get';
 export default {
@@ -171,8 +169,6 @@ export default {
   components: {
     Table,
     TableCell,
-    Modal,
-    ModalInner,
   },
   mixins: [permissionMixin],
   data() {

--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -1,8 +1,28 @@
 <template>
   <div>
-    <div class="govuk-grid-row print-none">
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <div class="text-right">
+        <div class="float-left">
+          <h1
+            v-if="isFavourites"
+            class="govuk-heading-xl govuk-!-margin-bottom-4"
+          >
+            Favourite exercises
+          </h1>
+          <h1
+            v-else-if="isArchived"
+            class="govuk-heading-xl govuk-!-margin-bottom-4"
+          >
+            Archived exercises
+          </h1>
+          <h1
+            v-else
+            class="govuk-heading-xl govuk-!-margin-bottom-4"
+          >
+            Live exercises
+          </h1>
+        </div>
+        <div class="text-right print-none">
           <button
             v-if="isFavourites"
             class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-0"
@@ -44,24 +64,6 @@
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h1
-          v-if="isFavourites"
-          class="govuk-heading-xl"
-        >
-          Favourite exercises
-        </h1>
-        <h1
-          v-else-if="isArchived"
-          class="govuk-heading-xl"
-        >
-          Archived exercises
-        </h1>
-        <h1
-          v-else
-          class="govuk-heading-xl"
-        >
-          Live exercises
-        </h1>
         <form
           class="exercises-table"
           @submit.prevent="checkForm"
@@ -104,24 +106,6 @@
                 :disabled="isButtonDisabled"
               >
                 Export data
-              </button>
-              <button
-                v-if="(hasPermissions([PERMISSIONS.exercises.permissions.canUpdateExercises.value]))"
-                class="govuk-button moj-button-menu__item moj-page-header-actions__action govuk-!-margin-right-2 govuk-!-margin-bottom-3"
-                :disabled="isButtonDisabled"
-                type="button"
-                @click="openArchiveModal"
-              >
-                {{ isArchived ? 'Unarchive' : 'Archive' }}
-              </button>
-              <button
-                v-if="(hasPermissions([PERMISSIONS.exercises.permissions.canDeleteExercises.value]))"
-                class="govuk-button moj-button-menu__item moj-page-header-actions__action govuk-!-margin-right-2 govuk-!-margin-bottom-3"
-                :disabled="isButtonDisabled"
-                type="button"
-                @click="openDeleteModal"
-              >
-                Delete
               </button>
             </template>
             <template #row="{row}">
@@ -170,24 +154,6 @@
         </form>
       </div>
     </div>
-    <Modal
-      ref="archiveModal"
-    >
-      <ModalInner
-        :title="archiveModalTitle"
-        :message="archiveModalMessage"
-        @close="closeArchiveModal"
-        @confirmed="toggleArchive"
-      />
-    </Modal>
-    <Modal ref="deleteModal">
-      <ModalInner
-        title="Delete Exercises"
-        :message="deleteModalMessage"
-        @close="closeDeleteModal"
-        @confirmed="deleteExercises"
-      />
-    </Modal>
   </div>
 </template>
 
@@ -252,19 +218,6 @@ export default {
         return data;
       });
     },
-    archiveModalTitle() {
-      const archiveVerb = (this.isArchived) ? 'Unarchive' : 'Archive';
-      return `${archiveVerb} Exercises`;
-    },
-    archiveModalMessage() {
-      const archiveVerb = (this.isArchived) ? 'unarchive' : 'archive';
-      const pluralText = this.selectedItems.length === 1 ? 'exercise' : 'exercises';
-      return `Are you sure you want to ${archiveVerb} ${this.selectedItems.length} ${pluralText}?`;
-    },
-    deleteModalMessage() {
-      const pluralText = this.selectedItems.length === 1 ? 'exercise' : 'exercises';
-      return `Are you sure you want to delete ${this.selectedItems.length} ${pluralText}?`;
-    },
   },
   watch: {
     isFavourites() {
@@ -316,31 +269,6 @@ export default {
     },
     getExerciseApprovalStatus(exercise) {
       return _upperFirst(_get(exercise, '_approval.status', ''));
-    },
-    toggleArchive() {
-      if (this.isArchived) {
-        this.$store.dispatch('exerciseCollection/unarchive');
-      } else {
-        this.$store.dispatch('exerciseCollection/archive');
-      }
-      this.$refs.archiveModal.closeModal();
-    },
-    openArchiveModal() {
-      this.$refs.archiveModal.openModal();
-    },
-    closeArchiveModal() {
-      this.$refs.archiveModal.closeModal();
-    },
-    deleteExercises() {
-      this.$store.dispatch('exerciseCollection/delete');
-      this.$refs.deleteModal.closeModal();
-      this.$refs['exercisesTable'].reload(); // reload table
-    },
-    openDeleteModal() {
-      this.$refs.deleteModal.openModal();
-    },
-    closeDeleteModal() {
-      this.$refs.deleteModal.closeModal();
     },
   },
 };


### PR DESCRIPTION
## What's included?
Disallow archiving until exercise is unpublished from website.
Here I'm actually un-publishing at the same time as archiving!

Closes #2159 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Goto the following url (it may prompt you to login first): https://jac-admin-develop--pr2215-feature-2159-disallo-5vj3g8aa.web.app/exercise/VG7qW7osx4eWUSIxFcT5/details/overview
- find an exercise that has been published and ensure the vacancy appears in the apply site
- archive the exercise and ensure a message appears saying 'This application is currently within the application window and is not published on the website' AND it no longer appears as a vacancy 
- unarchive the exercise and check that a message appears saying 'This exercise has been approved. Now you can publish it on the website' AND ensure it reappears as a vacancy.

See video attached below:

https://github.com/jac-uk/admin/assets/115651787/353c7b8c-80e3-45f6-8b36-251758b9d54c

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
