### PR TITLE
#2170 Update Downloads in line with Application Form updates

### DIFF
--- a/src/views/Exercise/Reports/PanelsView.vue
+++ b/src/views/Exercise/Reports/PanelsView.vue
@@ -436,6 +436,7 @@ export default {
         'statusLog.approved': firebase.firestore.FieldValue.serverTimestamp(),
       };
       await this.$store.dispatch('panels/updatePanel', { id: this.panelId, data: data });
+      return true;
     },
   },
 };


### PR DESCRIPTION
## What's included?
Closes #2170 

Update post-qualification experience in the following downloads:
- Panel packs

Note: This work is related to [digital-platform: Feature/Admin#2170 Update Downloads in line with Application Form updates](https://github.com/jac-uk/digital-platform/pull/968).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example exercise: https://jac-admin-develop--pr2220-feature-2170-update-151wfhz5.web.app/exercise/6LHFYxCon9P6u96QLvwe/reports/selection

1. Go to a panel of an exercise.
2. Click "Export to google drive" and wait until the status changes to "created".
3. Go to Google Drive (https://drive.google.com/drive/folders/1dOhgREFvqG6gk20-dwRj1y4jHWjCfJrB).
4. Go to the "application-0002 Jac JAC00683-vay0002" folder in the latest "00683 Test" folder.
5. Open the doc "Application Data".
6. Check if the following fields are exported in the doc:
    - Is this a judicial or quasi-judicial post?
    - How many sitting days have you accumulated in this post?
    - Is a legal qualification a requisite for appointment?
    - Powers, procedures and main responsibilities
    - Details of how you have acquired the necessary skills

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/51295e42-07fd-4ec1-977c-46dd325e9d28

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
