### PR TITLE
#2226 Configure Candidate Availability

### DIFF
--- a/src/store/candidateForms/document.js
+++ b/src/store/candidateForms/document.js
@@ -16,16 +16,24 @@ export default {
     unbind: firestoreAction(({ unbindFirestoreRef }) => {
       return unbindFirestoreRef('record');
     }),
-    create: async (context, data) => {
-      const ref = collection.doc();
-      data.created = firebase.firestore.FieldValue.serverTimestamp();
-      data.lastUpdated = firebase.firestore.FieldValue.serverTimestamp();
-      await ref.set(data, { merge: true });
+    close: async (context, formId) => {
+      const ref = collection.doc(formId);
+      const saveData = {};
+      saveData.status = 'closed';
+      saveData['statusLog.closed'] = firebase.firestore.FieldValue.serverTimestamp();
+      saveData.lastUpdated = firebase.firestore.FieldValue.serverTimestamp();
+      await ref.set(saveData, { merge: true });
     },
-    update: async (context, { data, id }) => {
-      const ref = collection.doc(id);
-      data.lastUpdated = firebase.firestore.FieldValue.serverTimestamp();
-      await ref.update(data);
+    update: async (context, { saveData, formId }) => {
+      const ref = formId ? collection.doc(formId) : collection.doc();
+      saveData.lastUpdated = firebase.firestore.FieldValue.serverTimestamp();
+      if (formId) {
+        await ref.update(saveData);
+      } else {
+        saveData.status = 'created';
+        saveData.statusLog = { created: firebase.firestore.FieldValue.serverTimestamp() };
+        await ref.set(saveData, { merge: true });  
+      }
     },
     delete: async (context, id) => {
       await collection.doc(id).delete();

--- a/src/store/candidateForms/document.js
+++ b/src/store/candidateForms/document.js
@@ -16,24 +16,22 @@ export default {
     unbind: firestoreAction(({ unbindFirestoreRef }) => {
       return unbindFirestoreRef('record');
     }),
+    open: async (context, formId) => {
+      const saveData = {};
+      saveData.status = 'open';
+      saveData['statusLog.open'] = firebase.firestore.FieldValue.serverTimestamp();
+      await context.dispatch('update', { saveData, formId });
+    },
     close: async (context, formId) => {
-      const ref = collection.doc(formId);
       const saveData = {};
       saveData.status = 'closed';
       saveData['statusLog.closed'] = firebase.firestore.FieldValue.serverTimestamp();
-      saveData.lastUpdated = firebase.firestore.FieldValue.serverTimestamp();
-      await ref.set(saveData, { merge: true });
+      await context.dispatch('update', { saveData, formId });      
     },
     update: async (context, { saveData, formId }) => {
-      const ref = formId ? collection.doc(formId) : collection.doc();
+      const ref = collection.doc(formId);
       saveData.lastUpdated = firebase.firestore.FieldValue.serverTimestamp();
-      if (formId) {
-        await ref.update(saveData);
-      } else {
-        saveData.status = 'created';
-        saveData.statusLog = { created: firebase.firestore.FieldValue.serverTimestamp() };
-        await ref.set(saveData, { merge: true });  
-      }
+      await ref.update(saveData);
     },
     delete: async (context, id) => {
       await collection.doc(id).delete();

--- a/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
+++ b/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
@@ -13,7 +13,9 @@
 
     <ProgressBar :steps="taskSteps" />
 
-    <form @submit.prevent="validateAndSave">
+    <form
+      @submit.prevent="validateAndSave"
+    >
       <ErrorSummary
         :errors="errors"
       />
@@ -31,6 +33,18 @@
           :label="$filters.lookup(part)"
         />
       </CheckboxGroup>
+
+      <div v-if="formData.parts.indexOf('candidateAvailability') >= 0">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+          Which dates would you like to check for candidate availability?
+        </h2>
+        <RepeatableFields
+          v-model="formData.candidateAvailabilityDates"
+          :component="repeatableFields.LocationDate"
+          :allow-empty="false"
+          required
+        />
+      </div>
 
       <CheckboxGroup
         v-if="formData.parts.indexOf('panelConflicts') >= 0"
@@ -65,6 +79,9 @@ import ProgressBar from '@/components/Page/ProgressBar.vue';
 import CheckboxGroup from '@jac-uk/jac-kit/draftComponents/Form/CheckboxGroup.vue';
 import CheckboxItem from '@jac-uk/jac-kit/draftComponents/Form/CheckboxItem.vue';
 import { functions } from '@/firebase';
+import RepeatableFields from '@jac-uk/jac-kit/draftComponents/RepeatableFields.vue';
+import LocationDate from './LocationDate.vue';
+import { shallowRef } from 'vue';
 
 export default {
   components: {
@@ -73,6 +90,7 @@ export default {
     CheckboxItem,
     FullScreenButton,
     ProgressBar,
+    RepeatableFields,
   },
   extends: Form,
   beforeRouteEnter: beforeRouteEnter,
@@ -84,15 +102,17 @@ export default {
   },
   data() {
     const exercise = this.$store.state.exerciseDocument.record;
-    const openDate = exercise.preSelectionDayQuestionnaireSendDate;
-    const closeDate = exercise.preSelectionDayQuestionnaireReturnDate;
     return {
       formData: {
-        openDate: openDate,
-        closeDate: closeDate,
+        openDate: exercise.preSelectionDayQuestionnaireSendDate,
+        closeDate: exercise.preSelectionDayQuestionnaireReturnDate,
         parts: [],
         panellists: [],
+        candidateAvailabilityDates: null,
       },
+      repeatableFields: shallowRef({
+        LocationDate,
+      }),
       CandidateFormParts: [
         APPLICATION_FORM_PARTS.CANDIDATE_AVAILABILITY,
         APPLICATION_FORM_PARTS.PANEL_CONFLICTS,
@@ -119,8 +139,15 @@ export default {
       return this.$store.state.panellists.records.map(item => ({ id: item.id, fullName: item.fullName }));
     },
   },
-  created() {
+  async created() {
     this.$store.dispatch('panellists/bind', {});
+    await this.$store.dispatch('candidateForm/bind', this.task.formId);
+    const candidateForm = this.$store.getters['candidateForm/data']();
+    this.formData.openDate = candidateForm.openDate;
+    this.formData.closeDate = candidateForm.closeDate;
+    this.formData.parts = candidateForm.parts;
+    this.formData.panellists = candidateForm.panellists;
+    this.formData.candidateAvailabilityDates = candidateForm.candidateAvailabilityDates;
   },
   methods: {
     btnNext,
@@ -134,7 +161,7 @@ export default {
         },
         ...this.formData,
       };
-      await this.$store.dispatch('candidateForm/create', saveData);
+      await this.$store.dispatch('candidateForm/update', { saveData, formId: this.task.formId });
       await this.btnContinue();
     },
     async btnContinue() {

--- a/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
+++ b/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
@@ -101,11 +101,10 @@ export default {
     },
   },
   data() {
-    const exercise = this.$store.state.exerciseDocument.record;
     return {
       formData: {
-        openDate: exercise.preSelectionDayQuestionnaireSendDate,
-        closeDate: exercise.preSelectionDayQuestionnaireReturnDate,
+        openDate: null,
+        closeDate: null,
         parts: [],
         panellists: [],
         candidateAvailabilityDates: null,

--- a/src/views/Exercise/Tasks/Task/CandidateForm/LocationDate.vue
+++ b/src/views/Exercise/Tasks/Task/CandidateForm/LocationDate.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="location-date-form">
+    <DateInput
+      :id="`date_${index}`"
+      v-model="row.date"
+      class="inline-block"
+      required
+    />
+    <TextField
+      :id="`location_${index}`"
+      v-model="row.location"
+      input-class="govuk-input--width-20"
+      label="Location"
+      class="location"
+      required
+    />
+    <slot name="removeButton" />
+  </div>
+</template>
+
+<script>
+import DateInput from '@jac-uk/jac-kit/draftComponents/Form/DateInput.vue';
+import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField.vue';
+
+export default {
+  name: 'LocationDate',
+  components: {
+    DateInput,
+    TextField,
+  },
+  props: {
+    row: {
+      required: true,
+      type: Object,
+    },
+    index: {
+      required: true,
+      type: Number,
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.location-date-form {
+  .jac-add-another__remove-button {
+    position: relative !important;
+    vertical-align: bottom !important;
+    margin-bottom: 32px !important;
+    margin-left: 20px !important;
+  }
+  .govuk-form-group {
+    display: inline-block;
+  }
+  .location > label {
+    font-size: 19px;
+    margin-bottom: 5px !important;
+    font-weight: normal;  
+  }
+}
+</style>


### PR DESCRIPTION
## What's included?
If the Pre Selection Day Questionnaire has been configured to ask for Candidate Availability we now enable dates and locations to be configured. It is these dates and locations which will be presented to the candidate in order to check their availability.

Closes #2226

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Example exercise: JAC00684 Exercise with Pre Selection Day Questionnaire

- Configure the Pre Selection Day Questionnaire to request Candidate Availability.
- Notice that an additional question appears requesting "Which dates would you like to check for candidate availability?"
- Try to add, edit and remove dates
- Check that at least one date must be configured before you're able to 'Save and continue' successfully

Example set of dates & locations
<img width="687" alt="image" src="https://github.com/jac-uk/admin/assets/8524401/5e1e632f-9e65-4f1e-acf8-40684f0632ff">


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
