### PR TITLE
Feature/2161 Changing Live Exercises page to display exercise status and stage

### DIFF
--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -140,12 +140,9 @@
               <TableCell :title="tableColumns[4].title">
                 {{ getExerciseStatus(row) }}
               </TableCell>
-              <TableCell :title="tableColumns[5].title">
-                {{ getExerciseStage(row) }}
-              </TableCell>
               <TableCell
                 class="govuk-table__cell--numeric"
-                :title="tableColumns[6].title"
+                :title="tableColumns[5].title"
               >
                 {{ $filters.formatNumber(row.applicationsCount) }}
               </TableCell>
@@ -180,7 +177,6 @@ export default {
         { title: 'Open date', sort: 'applicationOpenDate' },
         { title: 'Close date', sort: 'applicationCloseDate' },
         { title: 'Status' },
-        { title: 'Stage' },
         {
           title: 'Submitted Applications',
           sort: '_applications.applied',
@@ -260,11 +256,11 @@ export default {
       } else if (exercise.state === 'draft') {
         status += 'Draft';
       } else {
-        status += 'Live';
+        status += this.getExerciseTimelineStage(exercise);
       }
       return status;
     },
-    getExerciseStage(exercise) {
+    getExerciseTimelineStage(exercise) {
       let timeItemToShow = 0;
       const timeline = createTimeline(exerciseTimeline(exercise));
       if (timeline) {

--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -141,7 +141,7 @@
                 {{ getExerciseStatus(row) }}
               </TableCell>
               <TableCell :title="tableColumns[5].title">
-                {{ getExerciseApprovalStatus(row) }}
+                {{ getExerciseStage(row) }}
               </TableCell>
               <TableCell
                 class="govuk-table__cell--numeric"
@@ -162,8 +162,9 @@ import { mapState } from 'vuex';
 import Table from '@jac-uk/jac-kit/components/Table/Table.vue';
 import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
 import permissionMixin from '@/permissionMixin';
-import _upperFirst from 'lodash/upperFirst';
-import _get from 'lodash/get';
+import createTimeline from '@jac-uk/jac-kit/helpers/Timeline/createTimeline';
+import exerciseTimeline from '@jac-uk/jac-kit/helpers/Timeline/exerciseTimeline';
+
 export default {
   name: 'Exercises',
   components: {
@@ -179,7 +180,7 @@ export default {
         { title: 'Open date', sort: 'applicationOpenDate' },
         { title: 'Close date', sort: 'applicationCloseDate' },
         { title: 'Status' },
-        { title: 'Approval' },
+        { title: 'Stage' },
         {
           title: 'Submitted Applications',
           sort: '_applications.applied',
@@ -263,8 +264,17 @@ export default {
       }
       return status;
     },
-    getExerciseApprovalStatus(exercise) {
-      return _upperFirst(_get(exercise, '_approval.status', ''));
+    getExerciseStage(exercise) {
+      let timeItemToShow = 0;
+      const timeline = createTimeline(exerciseTimeline(exercise));
+      if (timeline) {
+        timeline.forEach((time, index) => {
+          if (time.date <= Date.now()) {
+            timeItemToShow = index;
+          }
+        });
+      }
+      return timeline[timeItemToShow]?.entry || '';
     },
   },
 };


### PR DESCRIPTION
## What's included?
Closes #2161 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to Live Exercises page.
2. Check if the "Status" column (it will reflect the timeline stage) displays correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Screehshot:

![image](https://github.com/jac-uk/admin/assets/79906532/bdc58f6b-ed52-4e57-8d88-c1728c96d061)


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
