### PR TITLE
Bugfix/2238 Ensure commissioners are populated before exercise is published

### DIFF
--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -75,7 +75,7 @@ export default {
     save: async ({ state }, data) => {
       await collection.doc(state.record.id).update(getExerciseSaveData(state.record, data));
     },
-    updateApprovalProcess: async ({ state, getters }, { userId, userName, decision, rejectionReason, rejectionResponse }) => {
+    updateApprovalProcess: async ({ state, getters, rootGetters }, { userId, userName, decision, rejectionReason, rejectionResponse }) => {
       const data = {};
       const user = {
         id: userId,
@@ -85,6 +85,8 @@ export default {
       data[`_approval.${decision}`] = {};
       data[`_approval.${decision}.date`] = firebase.firestore.FieldValue.serverTimestamp();
       data[`_approval.${decision}.user`] = user;
+      data.commissioners = rootGetters['services/getCommissioners'] || [];
+
       switch (decision) {
         case 'approved':
           data['_approval.rejected'] = null;
@@ -111,14 +113,6 @@ export default {
       // Update record
       const id = state.record.id;
       const ref = collection.doc(id);
-      await ref.update(data);
-    },
-    updateCommissioners: async ({ state, rootGetters }) => {
-      const id = state.record.id;
-      const ref = collection.doc(id);
-      const data = {
-        commissioners: rootGetters['services/getCommissioners'],
-      };
       await ref.update(data);
     },
     isReadyForTest: async ({ state }) => {
@@ -154,10 +148,11 @@ export default {
       };
       await ref.update(data);
     },
-    publish: async ({ state }) => {
+    publish: async ({ state, rootGetters }) => {
       const id = state.record.id;
       const ref = collection.doc(id);
       const data = {
+        commissioners: rootGetters['services/getCommissioners'] || [],
         published: true,
       };
       await ref.update(data);

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -371,7 +371,6 @@ export default {
         decision: 'requested',
         rejectionResponse: note ? note : null,
       });
-      await this.$store.dispatch('exerciseDocument/updateCommissioners');
       this.closeApprovalModal();
     },
     async confirmDelete() {
@@ -380,7 +379,6 @@ export default {
       this.$router.push({ name: 'exercises' });
     },
     async publish() {
-      await this.$store.dispatch('exerciseDocument/updateCommissioners');
       await this.$store.dispatch('exerciseDocument/publish');
       logEvent('info', 'Exercise published', {
         exerciseId: this.exerciseId,

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -380,6 +380,7 @@ export default {
       this.$router.push({ name: 'exercises' });
     },
     async publish() {
+      await this.$store.dispatch('exerciseDocument/updateCommissioners');
       await this.$store.dispatch('exerciseDocument/publish');
       logEvent('info', 'Exercise published', {
         exerciseId: this.exerciseId,

--- a/src/views/Exercise/Details/Overview/ApproveReject.vue
+++ b/src/views/Exercise/Details/Overview/ApproveReject.vue
@@ -118,7 +118,7 @@ export default {
   mounted() {
     this.$store.dispatch('vacancy/bind', this.exerciseId).then(() => {
       // Below only compares fields that exist in the first object
-      this.changes = deepKeysDiff(this.vacancy, this.exercise, ['state']);
+      this.changes = deepKeysDiff(this.vacancy, this.exercise, ['state', 'commissioners']);
     });
   },
   methods: {


### PR DESCRIPTION
## What's included?
Closes #2238 

- Update the commissioner data in the exercise document once the exercise is submitted for approval or published.
- Ignore the difference in the commissioner data between the exercise and vacancy document.

## Who should test?
✅ Developers

## How to test?
Preview URL: https://jac-admin-develop--pr2239-bugfix-2238-ensure-c-kfld18wu.web.app

1. Created an exercise with "Commissioner conflicts" in the application process.
2. Submit and publish the exercise.
3. Go to Firetore and check if "commissioners" are populated into the exercise document.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
