### PR TITLE
#2173 Independent Assessments

### DIFF
--- a/src/components/ModalViews/IndependentAssessmentsRequests.vue
+++ b/src/components/ModalViews/IndependentAssessmentsRequests.vue
@@ -21,7 +21,7 @@
             class="govuk-!-margin-bottom-5"
           >
             <span class="govuk-body-m">Before proceeding, please confirm that you wish to send a {{ typeOfEmail }} to </span>
-            <span class="govuk-body-m govuk-!-font-weight-bold">{{ numberOfCandidates }} candidate(s) </span>
+            <span class="govuk-body-m govuk-!-font-weight-bold">{{ numberOfCandidates }} assessor(s) </span>
             <span class="govuk-body-m">and the email template contains all required information</span>
           </div>
 


### PR DESCRIPTION
## What's included?
Closes #2173

Note: This PR needs changes on Digital Platform [#2173 Admin Independent Assessments](https://github.com/jac-uk/digital-platform/pull/981)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to preview link: https://jac-admin-develop--pr2244-feature-2173-indepen-wskxjm6y.web.app/exercise/ONqUjAzhDS7rjh6dFJLB/tasks/all/independent-assessments#notrequested

2. Go to "Not Requested" tab
- Select one assessment
- Click "Send Request" button
- It should appear a pop-up with related information (changed to X assessor(s)): 
![image](https://github.com/jac-uk/admin/assets/79906532/168c7c60-167a-43ee-b99b-e1f88139cdb0)

3. Go to "Requested" tab
- Select one assessment
- Click "Send reminders" button
- It should appear a pop-up with related information (changed to X assessor(s)): 
![image](https://github.com/jac-uk/admin/assets/79906532/1dfaf88a-0655-4279-8c83-a514ae887cd1)

4. Go to preview link: https://jac-admin-develop--pr2244-feature-2173-indepen-wskxjm6y.web.app/exercise/ONqUjAzhDS7rjh6dFJLB/details/contacts
- Click "Update exercise contacts"
- Change the "Exercise mailbox" to your email like "xxxxx@judicialappointments.digital"
- Enter the "Email signature name" like "Tester", then Save.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
