### PR TITLE
#2248 Use global commissioners not exercise-specific

### DIFF
--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -113,14 +113,6 @@ export default {
       const ref = collection.doc(id);
       await ref.update(data);
     },
-    updateCommissioners: async ({ state, rootGetters }) => {
-      const id = state.record.id;
-      const ref = collection.doc(id);
-      const data = {
-        commissioners: rootGetters['services/getCommissioners'],
-      };
-      await ref.update(data);
-    },
     isReadyForTest: async ({ state }) => {
       const id = state.record.id;
       const ref = collection.doc(id);

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -370,7 +370,6 @@ export default {
         decision: 'requested',
         rejectionResponse: note ? note : null,
       });
-      await this.$store.dispatch('exerciseDocument/updateCommissioners');
       this.closeApprovalModal();
     },
     async confirmDelete() {

--- a/src/views/InformationReview/CommissionerConflictsSummary.vue
+++ b/src/views/InformationReview/CommissionerConflictsSummary.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      v-if="exercise.commissioners"
+      v-if="commissioners"
       class="govuk-!-margin-top-9"
     >
       <h2 class="govuk-heading-l govuk-!-margin-bottom-4">
@@ -79,8 +79,11 @@ export default {
     exercise() {
       return this.$store.state.exerciseDocument.record;
     },
+    commissioners() {
+      return this.$store.getters['services/getCommissioners'];
+    },
     commissionerConflicts() {
-      return Array.isArray(this.exercise.commissioners) && this.exercise.commissioners.map((commissioner) => {
+      return Array.isArray(this.commissioners) && this.commissioners.map((commissioner) => {
         const match = this.application?.additionalInfo?.commissionerConflicts.find((commissionerConflict) => {
           return commissionerConflict.name === commissioner.name;
         });


### PR DESCRIPTION

## What's included?
Modifications to commissioner conflicts to use global commissioners list rather than an exercise-specific copy.

Closes #2248 

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Check that commissioner conflicts feature works as expected.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
