### PR TITLE
#2261 Bugfix: Staff user dropdowns are not populated in Contacts section

### DIFF
--- a/src/components/RepeatableFields/SelectionExerciseManager.vue
+++ b/src/components/RepeatableFields/SelectionExerciseManager.vue
@@ -12,7 +12,7 @@
         :key="user.uid"
         :value="user.email"
       >
-        {{ user.email }}
+        {{ user.displayName }} ({{ user.email }})
       </option>
     </Select>
     <slot name="removeButton" />
@@ -39,7 +39,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      users: 'users/enabledMicrosoftUsers',
+      users: 'users/enabledJACUsers',
     }),
   },
 };

--- a/src/components/RepeatableFields/SelectionExerciseOfficer.vue
+++ b/src/components/RepeatableFields/SelectionExerciseOfficer.vue
@@ -12,7 +12,7 @@
         :key="user.uid"
         :value="user.email"
       >
-        {{ user.email }}
+        {{ user.displayName }} ({{ user.email }})
       </option>
     </Select>
     <slot name="removeButton" />
@@ -40,7 +40,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      users: 'users/enabledMicrosoftUsers',
+      users: 'users/enabledJACUsers',
     }),
   },
 };

--- a/src/components/RepeatableFields/SeniorSelectionExerciseManager.vue
+++ b/src/components/RepeatableFields/SeniorSelectionExerciseManager.vue
@@ -12,7 +12,7 @@
         :key="user.uid"
         :value="user.email"
       >
-        {{ user.email }}
+        {{ user.displayName }} ({{ user.email }})
       </option>
     </Select>
     <slot name="removeButton" />
@@ -40,7 +40,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      users: 'users/enabledMicrosoftUsers',
+      users: 'users/enabledJACUsers',
     }),
   },
 };

--- a/src/store/users.js
+++ b/src/store/users.js
@@ -97,18 +97,21 @@ export default {
     users: [],
   },
   getters: {
-    enabledMicrosoftUsers: (state) => {
+    enabledJACUsers: (state) => {
       if (!Array.isArray(state.records)) return [];
       return state.records
         .filter(user => {
-          if (user.disabled) return false;
-          let isMicrosoft = false;
-          user.providerData.forEach(item => {
-            if (item.providerId === 'microsoft.com') {
-              isMicrosoft = true;
-            }
-          });
-          return isMicrosoft;
+          if (user.disabled) return false;  // user account has been disabled
+          if (!(user.role && user.role.id)) return false;  // user doesn't have a role
+          if (!(user.email && user.email.split('@')[1].toLowerCase() === 'judicialappointments.gov.uk')) return false;  // user isn't using @judicialappointments.gov.uk email address
+          return true;
+        })
+        .sort((a, b) => {
+          a = a.displayName.toLowerCase();
+          b = b.displayName.toLowerCase();
+          if (a < b) return -1;
+          if (a > b) return 1;
+          return 0;
         });
     },
   },


### PR DESCRIPTION
## What's included?
Fixes #2261 

## Who should test?
✅ Product owner
✅ Developers

## How to test?

Using the preview URL:
https://jac-admin-develop--pr2263-bugfix-2261-d69tpw4d.web.app/

- Go to the following exercise:
  - JAC00693, Pre selection day test exercise 7
- Navigate to Exercise > Contacts > Update exercise contacts
- Check that the following dropdowns are populated:
  - Senior selection exercise manager
  - Selection exercise manager
  - Selection exercise officers
- Observe that the dropdown options are only for active JAC staff
- Observe that the dropdown options include Name and email (e.g. `Jim Bob (jim.bob@judicialappointments.gov.uk)`)
- Observe that the dropdown options are ordered alphabetically

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
