### PR TITLE
Add test-ci command back into pull request github workflow

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Lint
         run: npm run lint-ci
       - name: Test
-        run: echo "tests disabled" #npm run test-ci
+        run: npm run test-ci
       - name: Create env file
         run: |
           touch .env.${{ env.environment }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Lint
         run: npm run lint-ci
       - name: Test
-        run: echo "tests disabled" #npm run test-ci
+        run: npm run test-ci
 
   deploy_to_develop:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         run: npm run lint-ci
       - name: Test
-        run: echo "tests disabled" #npm run test-ci
+        run: npm run test-ci
 
   check_preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What's included?
test-ci command was commented out of the pull request workflow when the vue3 upgrade was happening. Here i'm putting it back in.

## Who should test?
✅ Developers

## How to test?
Ensure the test-ci command runs when a pull request is made

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

