### PR TITLE
#2261 Bugfix: Staff user dropdowns are not populated in Contacts section

### DIFF
--- a/src/store/users.js
+++ b/src/store/users.js
@@ -107,8 +107,8 @@ export default {
           return true;
         })
         .sort((a, b) => {
-          a = a.displayName.toLowerCase();
-          b = b.displayName.toLowerCase();
+          a = a.displayName ? a.displayName.toLowerCase() : a.email;
+          b = b.displayName ? b.displayName.toLowerCase() : b.email;
           if (a < b) return -1;
           if (a > b) return 1;
           return 0;


### PR DESCRIPTION
## What's included?
Further amendment to the staff dropdowns to account for users not having a `displayName`

Closes #2261

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Check that the dropdowns work on the following preview URL:
https://jac-apply-admin-production--pr2267-bugfix-2261-2-r28c9x89.web.app/

- You can use any exercise which is in draft.
- Navigate to the Exercise > Contacts > Update exercise contacts form
- Check that the dropdowns have content

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:PRODUCTION
_can be OFF, DEVELOP or STAGING_
