### PR TITLE
#2225 Update Handover report in line with application form improvements - Make Judicial Experience to be multi-line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "admin",
       "version": "1.18.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "3.0.46",
+        "@jac-uk/jac-kit": "3.0.47",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.61.1",
         "@sentry/vue": "^7.61.1",
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "3.0.46",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/3.0.46/29b710148391780615d8bec6031cd86fb174d2ee",
-      "integrity": "sha512-0dKm6XHO2ejkT6Wbby8zBX0Ay8igL5j8s0XsKdTJXD0kWnZJnE7WEumqIDZrdGpuQ+3I47en3lKS3ub1udD4KA==",
+      "version": "3.0.47",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/3.0.47/397216b0c2fd21ce09ea259448d54e34ed6689f1",
+      "integrity": "sha512-c633lPDJymd60heEL1Yg1BP6XMLqIlu/6YksY1PT27ZPvDoBD2FJVpCiRYRROZMEQY3fOrZlDZqzrEalr+KQtQ==",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "3.0.46",
+    "@jac-uk/jac-kit": "3.0.47",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.61.1",
     "@sentry/vue": "^7.61.1",

--- a/src/views/Exercise/Reports/Handover.vue
+++ b/src/views/Exercise/Reports/Handover.vue
@@ -190,6 +190,18 @@ export default {
     async exportData() {
       const title = 'Handover Report';
       const data = this.gatherReportData();
+      /**
+       * Make the 'Judicial experience' (column S) can display multiple lines.
+       * 
+       * @link: https://github.com/dtjohnson/xlsx-populate?tab=readme-ov-file#styles-1
+       */
+      const styles = {
+        column: {
+          'S': {
+            wrapText: true,
+          },
+        },
+      };
 
       downloadXLSX(
         data,
@@ -197,7 +209,8 @@ export default {
           title: `${this.exercise.referenceNumber} ${title}`,
           sheetName: title,
           fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
-        }
+        },
+        styles
       );
     },
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,8 @@ const path = require('path');
 // Vite does not automatically polyfill Node.js modules
 import rollupNodePolyFill from 'rollup-plugin-node-polyfills';
 
+const nodeModuleDir = path.resolve(__dirname, './node_modules');
+
 export default defineConfig({
   define: {
     'import.meta.env.PACKAGE_VERSION': JSON.stringify(process.env.npm_package_version),
@@ -13,11 +15,11 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-      stream: 'stream-browserify',
-      process: 'process/browser',
-      buffer: 'buffer',
-      events: 'rollup-plugin-node-polyfills/polyfills/events',
-      util: 'rollup-plugin-node-polyfills/polyfills/util',
+      stream: `${nodeModuleDir}/stream-browserify`,
+      process: `${nodeModuleDir}/process/browser`,
+      buffer: `${nodeModuleDir}/buffer`,
+      events: `${nodeModuleDir}/rollup-plugin-node-polyfills/polyfills/events`,
+      util: `${nodeModuleDir}/rollup-plugin-node-polyfills/polyfills/util`,
     },
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],  // Remove this eventually
   },


### PR DESCRIPTION
## What's included?
Closes #2225 
- Make the Judicial Experience field can be multi-line

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://jac-admin-develop--pr2269-fix-2225-update-hand-id9x8gal.web.app/exercise/6LHFYxCon9P6u96QLvwe/reports/handover
- Hit 'Refresh' button to generate report data
- Hit 'Export data' button to download the file
- Check the file, the Judicial Experience field should be multi-line
![image](https://github.com/jac-uk/admin/assets/79906532/10fc4bab-cce1-4a6a-84a0-04e10efb5ab4)



## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
