### PR TITLE
Feature/2272 Add role filter to user list

### DIFF
--- a/src/store/users.js
+++ b/src/store/users.js
@@ -9,7 +9,11 @@ export default {
   namespaced: true,
   actions: {
     bind: firestoreAction(async ({ bindFirestoreRef, state, commit }, params) => {
-      const firestoreRef = await tableQuery(state.records, collection, params);
+      let firestoreRef = collection;
+      if (params.roleId) {
+        firestoreRef = firestoreRef.where('role.id', '==', params.roleId);
+      }
+      firestoreRef = await tableQuery(state.records, firestoreRef, params);
       if (firestoreRef) {
         return bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
       } else {

--- a/src/views/Users/Users.vue
+++ b/src/views/Users/Users.vue
@@ -14,6 +14,21 @@
     >
       <h2>List of admin users</h2>
 
+      <div class="govuk-!-margin-bottom-7">
+        <select
+          v-model="filteredRole"
+          class="govuk-select"
+        >
+          <option
+            v-for="(option, index) in roleFilterOptions"
+            :key="index"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+      </div>
+
       <Table
         ref="usersTable"
         data-key="id"
@@ -150,6 +165,7 @@ export default {
         { title: 'Role' },
         { title: 'Action' },
       ],
+      filteredRole: null,
       selectedUser: null,
     };
   },
@@ -179,6 +195,24 @@ export default {
     roles() {
       return this.$store.state.roles.records;
     },
+    roleFilterOptions() {
+      let options = [
+        {
+          value: null,
+          label: 'All',
+        },
+      ];
+      options = options.concat(this.roles.map((role) => ({
+        value: role.id,
+        label: role.roleName,
+      })));
+      return options;
+    },
+  },
+  watch: {
+    filteredRole() {
+      this.reloadTable();
+    },
   },
   mounted() {
     this.$store.dispatch('roles/bind', {
@@ -188,7 +222,15 @@ export default {
   },
   methods: {
     getTableData(params) {
+      if (this.filteredRole) {
+        params.roleId = this.filteredRole;
+      }
       this.$store.dispatch('users/bind', params);
+    },
+    reloadTable() {
+      if (this.$refs['usersTable']) {
+        this.$refs['usersTable'].reload();
+      }
     },
     handleRoleChange(event, user) {
       const roleId = event.target.value;


### PR DESCRIPTION
## What's included?
Closes #2272 

Note: Required the changes of Firestore indexes in [digital-platform: Feature/admin#2272 Users indexes](https://github.com/jac-uk/digital-platform/pull/994).

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Go to the user list under "User Management" and check if the role filter works properly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
