### PR TITLE
Feature/2276 Make candidate responses to bespoke question on Ex.187 visible

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -94,7 +94,8 @@ export {
   getStagePassingStatuses,
   getStageWithdrawalStatus,
   isApplicationVersionGreaterThan,
-  isApplicationVersionLessThan
+  isApplicationVersionLessThan,
+  isJAC00187
 };
 
 // const EXERCISE_STATES = ['draft', 'ready', 'approved', 'shortlisting', 'selection', 'recommendation', 'handover', 'archived'];
@@ -1291,4 +1292,10 @@ function isApplicationVersionGreaterThan(exercise, version) {
 }
 function isApplicationVersionLessThan(exercise, version) {
   return exercise?._applicationVersion < version;
+}
+
+function isJAC00187(referenceNumber) {
+  if (!referenceNumber) { return false; }
+  // [develop, staging, prod]
+  return ['JAC00696', 'JAC00695', 'JAC00187'].includes(referenceNumber);
 }

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -1294,8 +1294,9 @@ function isApplicationVersionLessThan(exercise, version) {
   return exercise?._applicationVersion < version;
 }
 
-function isJAC00187(referenceNumber) {
-  if (!referenceNumber) { return false; }
-  // [develop, staging, prod]
-  return ['JAC00696', 'JAC00695', 'JAC00187'].includes(referenceNumber);
+function isJAC00187(env, referenceNumber) {
+  if (!env || !referenceNumber) { return false; }
+  return (env === 'DEVELOP' && referenceNumber === 'JAC00696') ||
+    (env === 'STAGING' && referenceNumber === 'JAC00695') ||
+    (env === 'PRODUCTION' && referenceNumber === 'JAC00187');
 }

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -273,6 +273,13 @@
               :editable="editable"
               @update-application="changeApplication"
             />
+            <ResignationFromDWPSummary
+              v-if="isJAC00187"
+              :application="application"
+              :exercise="exercise"
+              :editable="editable"
+              @update-application="changeApplication"
+            />
           </div>
         </div>
 
@@ -326,6 +333,7 @@ import ExperienceSummary from '@/views/InformationReview/ExperienceSummary.vue';
 import AssessmentsSummary from '@/views/InformationReview/AssessmentsSummary.vue';
 import AssessorsSummary from '@/views/InformationReview/AssessorsSummary.vue';
 import CommissionerConflictsSummary from '@/views/InformationReview/CommissionerConflictsSummary.vue';
+import ResignationFromDWPSummary from '@/views/InformationReview/ResignationFromDWPSummary.vue';
 import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer.vue';
 import PageNotFound from '@/views/Errors/PageNotFound.vue';
 import { splitFullName } from '@jac-uk/jac-kit/helpers/splitFullName';
@@ -337,7 +345,8 @@ import {
   hasStatementOfSuitability,
   hasIndependentAssessments,
   isApplicationPartAsked,
-  isCharacterChecksAsked
+  isCharacterChecksAsked,
+  isJAC00187
 } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
 
@@ -363,6 +372,7 @@ export default {
     AssessmentsSummary,
     AssessorsSummary,
     CommissionerConflictsSummary,
+    ResignationFromDWPSummary,
   },
   mixins: [permissionMixin],
   data() {
@@ -514,6 +524,9 @@ export default {
     },
     isCharacterChecksAsked() {
       return this.application && isCharacterChecksAsked(this.application);
+    },
+    isJAC00187() {
+      return isJAC00187(this.application.exerciseRef);
     },
   },
   watch: {

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -526,7 +526,8 @@ export default {
       return this.application && isCharacterChecksAsked(this.application);
     },
     isJAC00187() {
-      return isJAC00187(this.application.exerciseRef);
+      const env = this.$store.getters.appEnvironment;
+      return isJAC00187(env, this.application.exerciseRef);
     },
   },
   watch: {

--- a/src/views/InformationReview/ResignationFromDWPSummary.vue
+++ b/src/views/InformationReview/ResignationFromDWPSummary.vue
@@ -22,6 +22,25 @@
             />
           </dd>
         </div>
+        <div
+          v-if="workingAtDWP"
+          class="govuk-summary-list__row"
+        >
+          <dt class="govuk-summary-list__key widerColumn">
+            Please note, if you work for the DWP and are recommended for appointment as a Fee-paid Medical Member, you will be required to resign from your post in order to take up appointment. Please tick to confirm that you have read this.
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <InformationReviewRenderer
+              :edit="editable"
+              :options="[true, false]"
+              type="selection"
+              :data="isConfirmed"
+              field="resignationFromDWP"
+              extension="isConfirmed"
+              @change-field="changeInfo"
+            />
+          </dd>
+        </div>
       </dl>
     </div>
   </div>
@@ -57,6 +76,9 @@ export default {
     },
     workingAtDWP() {
       return this.resignationFromDWP?.workingAtDWP;
+    },
+    isConfirmed() {
+      return this.resignationFromDWP?.isConfirmed;
     },
   },
   methods: {

--- a/src/views/InformationReview/ResignationFromDWPSummary.vue
+++ b/src/views/InformationReview/ResignationFromDWPSummary.vue
@@ -15,7 +15,7 @@
               :edit="editable"
               :options="[true, false]"
               type="selection"
-              :data="resignationFromDWP.workingAtDWP"
+              :data="workingAtDWP"
               field="resignationFromDWP"
               extension="workingAtDWP"
               @change-field="changeInfo"
@@ -54,6 +54,9 @@ export default {
     },
     resignationFromDWP() {
       return this.application.resignationFromDWP;
+    },
+    workingAtDWP() {
+      return this.resignationFromDWP?.workingAtDWP;
     },
   },
   methods: {

--- a/src/views/InformationReview/ResignationFromDWPSummary.vue
+++ b/src/views/InformationReview/ResignationFromDWPSummary.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <div class="govuk-!-margin-top-9">
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-4">
+        Resignation from the Department for Work and Pensions (DWP)
+      </h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key widerColumn">
+            Do you currently work at the Department for Work and Pensions (DWP)?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <InformationReviewRenderer
+              :edit="editable"
+              :options="[true, false]"
+              type="selection"
+              :data="resignationFromDWP.workingAtDWP"
+              field="resignationFromDWP"
+              extension="workingAtDWP"
+              @change-field="changeInfo"
+            />
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</template>
+
+<script>
+import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer.vue';
+
+export default {
+  name: 'ResignationFromDWPSummary',
+  components: {
+    InformationReviewRenderer,
+  },
+  props: {
+    application: {
+      type: Object,
+      required: true,
+      default: () => {},
+    },
+    editable: {
+      type: [Boolean, Function, Promise],
+      required: true,
+      default: false,
+    },
+  },
+  emits: ['updateApplication'],
+  computed: {
+    exercise() {
+      return this.$store.state.exerciseDocument.record;
+    },
+    resignationFromDWP() {
+      return this.application.resignationFromDWP;
+    },
+  },
+  methods: {
+    changeInfo(obj) {
+      const changedObj = this.application[obj.field] || {};
+      if (obj.hasOwnProperty('change') && obj.hasOwnProperty('extension')) {
+        changedObj[obj.extension] = obj.change;
+        const updatedApplication = {
+          ...this.application,
+          [obj.field]: changedObj,
+        };
+        this.$emit('updateApplication', updatedApplication);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+  .widerColumn {
+    width: 70%;
+  }
+</style>


### PR DESCRIPTION
## What's included?
Closes #2276 

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example application: https://jac-admin-develop--pr2277-feature-2276-candida-ed5kqmxt.web.app/exercise/09zuw8tcILdrH2DJZA2g/applications/draft/application/aYWsPP6QjSVD9mmhGYtR

1. Go to the application.
2. Check if "Resignation from the Department for Work and Pensions (DWP)" section appears.
3. Check if you are able to edit the answers under "Resignation from the Department for Work and Pensions (DWP)" section.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

- apply site
  ![image](https://github.com/jac-uk/admin/assets/79906532/4e879eb3-e613-4fde-9ec7-33ff63b659e9)

- admin site
  ![image](https://github.com/jac-uk/admin/assets/79906532/c5b35c61-2108-4942-848b-588aafd23e62)


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
