### PR TITLE
Feature/2283 Add MS Word guidance to Self-assessment Exercise Downloads

### DIFF
--- a/src/components/ModalViews/UploadFiles.vue
+++ b/src/components/ModalViews/UploadFiles.vue
@@ -4,6 +4,20 @@
       {{ $attrs.title }}
     </div>
     <div class="modal__content govuk-!-padding-4">
+      <div
+        v-if="$attrs.id === 'candidateAssessementForms'"
+        class="govuk-form-group"
+      >
+        <p class="modal__message govuk-body-l">
+          <a
+            href="https://firebasestorage.googleapis.com/v0/b/platform-production-9207d.appspot.com/o/Preparing%20SA%20template%20for%20upload.pdf?alt=media&token=353fad1f-fa08-4d67-a0a7-85323baed3d3"
+            target="_blank"
+            title="Guidance"
+          >
+            Preparing SA template for upload
+          </a>
+        </p>
+      </div>
       <p class="modal__message govuk-body-l">
         <TextField
           :id="`${$attrs.name}-file-title`"


### PR DESCRIPTION
## What's included?
Closes #2283 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example exercise: https://jac-admin-develop--pr2288-feature-2283-add-wor-4r8po8y6.web.app/exercise/qxj0UCVXoDGbdNuj4qRi/details/downloads

1. Go to "Exercise downloads" and click "update downloads".
2. Click the "Add" of "Candidate Assessment Form".
3. The pop-up of "Candidate Assessment Form" will appear and check if there is a guidance link "Preparing SA template for upload".
4. Check if you can access the file.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

![image](https://github.com/jac-uk/admin/assets/79906532/3019cabb-9f7e-4b65-b7af-eda02d2ecd21)


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
