### PR TITLE
Bugfix/New user missing uid

### DIFF
--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -58,6 +58,7 @@ const module = {
               id: userInvitation.roleId || '',
               isChanged: false,
             },
+            uid: user.uid || '',
           };
           userDoc = await dispatch('users/create', { id: user.uid, data: newUser }, { root: true });
           // set user role in custom claims


### PR DESCRIPTION
## What's included?
Fix the missing uid when creating a new user document in Firestore.

## Who should test?
✅ Developers

## How to test?

1. Create a new user invitation with an email address.
2. Sign in with the email address and check if you can.
3. Go to Firestore and check if the field `uid` exists in the user document.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
