### PR TITLE
Change EMP tie-breaker entry status to be 'Only SCC to reconsider app…

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -476,7 +476,7 @@ function previousTaskType(exercise, type) {
 function taskEntryStatus(exercise, type) {
   let status = '';
   if (!exercise) return status;
-  if (type === TASK_TYPE.EMP_TIEBREAKER) return APPLICATION_STATUS.SECOND_STAGE_INVITED;  // TODO: remove this eventually: override entry status for EMP tie-breakers
+  if (type === TASK_TYPE.EMP_TIEBREAKER) return APPLICATION_STATUS.SCC_TO_RECONSIDER;  // TODO: remove this eventually: override entry status for EMP tie-breakers
   const prevTaskType = previousTaskType(exercise, type);
   if (prevTaskType) {
     status = `${prevTaskType}Passed`;


### PR DESCRIPTION
## What's included?
Change EMP tie-breaker entry status to be 'Only SCC to reconsider applications will be included'.

Closes #2271 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Note that the links below can only be clicked on once.

https://jac-admin-develop--pr2304-bugfix-2271-emp-tie-mclrz6vv.web.app/exercise/BEUMP8bn7RCwo7v0BHsY/tasks/all/empTiebreaker/new
https://jac-admin-develop--pr2304-bugfix-2271-emp-tie-mclrz6vv.web.app/exercise/X2tDg5AKt18xvzBRJFYW/tasks/all/empTiebreaker/new
https://jac-admin-develop--pr2304-bugfix-2271-emp-tie-mclrz6vv.web.app/exercise/aDxEqK36807d0Nhpugo3/tasks/all/empTiebreaker/new
https://jac-admin-develop--pr2304-bugfix-2271-emp-tie-mclrz6vv.web.app/exercise/5MC34wbOTnI8BuOIsGUR/tasks/all/empTiebreaker/new

1) Click on one of the links above
2) You will see the following on the screen. Note the second checkbox should say 'Only 'SCC to reconsider' applications will be included'.

<img width="885" alt="Screenshot 2024-02-06 at 11 47 06" src="https://github.com/jac-uk/admin/assets/115651787/6afb4f0b-6a25-4662-9abc-282eef7b210a">

3) Check both of the checkboxes and press the 'Continue' button
4) When the following page loads you should see the following:

<img width="898" alt="Screenshot 2024-02-06 at 11 49 01" src="https://github.com/jac-uk/admin/assets/115651787/0b0343de-35e8-4c4a-a65d-440856844664">

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_