### PR TITLE
Ticketing System #194 - BugFix Commissioner Conflicts Summary When No Commissioner Conflicts

### DIFF
--- a/src/views/InformationReview/CommissionerConflictsSummary.vue
+++ b/src/views/InformationReview/CommissionerConflictsSummary.vue
@@ -9,7 +9,7 @@
       </h2>
 
       <dl
-        v-if="commissionerConflicts || editable"
+        v-if="commissionerConflicts.length || editable"
         class="govuk-summary-list"
       >
         <div
@@ -83,16 +83,19 @@ export default {
       return this.$store.getters['services/getCommissioners']();
     },
     commissionerConflicts() {
-      return Array.isArray(this.commissioners) && this.commissioners.map((commissioner) => {
-        const match = this.application?.additionalInfo?.commissionerConflicts.find((commissionerConflict) => {
-          return commissionerConflict.name === commissioner.name;
+      if (Array.isArray(this.commissioners)) {
+        return this.commissioners.map((commissioner) => {
+          const match = this.application?.additionalInfo?.commissionerConflicts?.find?.((commissionerConflict) => {
+            return commissionerConflict.name === commissioner.name;
+          });
+          return match ? match : {
+            name: commissioner.name,
+            hasRelationship: null,
+            details: null,
+          };
         });
-        return match ? match : {
-          name: commissioner.name,
-          hasRelationship: null,
-          details: null,
-        };
-      });
+      }
+      return [];
     },
   },
   methods: {


### PR DESCRIPTION
## What's included?
Added the optional chaining operator on the attribute and find method so that it works when no commissionerConflicts in additionalInfo in the application record.

Closes jac-uk/ticketing-system#194

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

**Test 1**

- Go to the following url: https://jac-admin-develop--pr2316-bugfix-ts-194-commis-zs8iqa2a.web.app/exercise/ONqUjAzhDS7rjh6dFJLB/applications/applied/application/LinokWzjBmo6uNykztEa
- Scroll to the bottom of the screen
- Ensure there are some commissioner conflicts set to 'no', see screenshot below:

<img width="696" alt="Screenshot 2024-02-14 at 15 16 37" src="https://github.com/jac-uk/admin/assets/115651787/179fdcd2-3736-46b7-81dc-e3ffeea067cd">

**Test 2**

- Go to the following url: https://jac-admin-develop--pr2316-bugfix-ts-194-commis-zs8iqa2a.web.app/exercise/wdpALbyICL7ZxxN5AQt8/applications/applied/application/XJ9oRckhw2Kf0hQAHOpM
- Scroll to the bottom of the screen
- Ensure all of the commissioner conflicts set to 'No information (not asked)', see screenshot below:

<img width="736" alt="Screenshot 2024-02-14 at 15 19 49" src="https://github.com/jac-uk/admin/assets/115651787/cd2a71d7-a0b5-4372-ad78-69134f817dbc">

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
