### PR TITLE
The uploadBytes function no longer returns the state in its response …

### DIFF
--- a/src/components/Micro/CaptureScreenshot.vue
+++ b/src/components/Micro/CaptureScreenshot.vue
@@ -87,18 +87,12 @@ export default {
         const blob = this.dataURLtoBlob(this.thumbnail);
 
         // Upload the blob to file storage
-        const fileUploaded = await uploadBytes(uploadRef, blob);
-
-        if (fileUploaded && fileUploaded.state === 'success') {
-          const downloadUrl = await getDownloadURL(uploadRef);
-          return {
-            downloadUrl: downloadUrl,
-            filePath: this.filePath,
-          };
-        } else {
-          this.setError('File upload failed, please try again. If the problem persist please remove the screenshot and report the problem.');
-          return false;
-        }
+        await uploadBytes(uploadRef, blob);
+        const downloadUrl = await getDownloadURL(uploadRef);
+        return {
+          downloadUrl: downloadUrl,
+          filePath: this.filePath,
+        };
       } catch (e) {
         this.setError('File upload failed, please try again. If the problem persist please remove the screenshot and report the problem.');
         return false;


### PR DESCRIPTION
## What's included?
When an issue was being reported an error was being displayed when a screenshot was being taken.
This was because the firebase api had changed and no longer passed back the 'state' in the response for the The uploadBytes function call.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- Click the 'Report An Issue' button
- Take a screenshot and fiil in the rest of the form and submit it
- You should see no errors about the screenshot upload

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
