### PR TITLE
Disable user feedback link for staging

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -134,7 +134,7 @@
     </main>
 
     <UserFeedbackLink
-      v-show="isSignedIn && isMounted"
+      v-show="isSignedIn && isMounted && !isStagingEnvironment"
       :style="{ 'bottom': linkBottom }"
       @open-feedback-modal="openFeedbackModal()"
     />
@@ -280,6 +280,9 @@ export default {
   computed: {
     isDevelopmentEnvironment() {
       return this.$store.getters.isDevelop;
+    },
+    isStagingEnvironment() {
+      return this.$store.getters.isStaging;
     },
     isSignedIn() {
       return this.$store.getters['auth/isSignedIn'];

--- a/src/store.js
+++ b/src/store.js
@@ -123,6 +123,9 @@ const store = createStore({
     isDevelop: (state, getters) => {
       return getters.appEnvironment === 'DEVELOP';
     },
+    isStaging: (state, getters) => {
+      return getters.appEnvironment === 'STAGING';
+    },
   },
 });
 


### PR DESCRIPTION
## What's included?
Ensure the user feedback link is not displayed on the staging environment (until the env is made compatible with staging).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Ensure the 'Report An Issue' button does not appear on any pages.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
