### PR TITLE
Feature/2260 Create Deployment Report

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -70,6 +70,7 @@ import ExerciseReportsEligibilityIssues from '@/views/Exercise/Reports/Eligibili
 import ExerciseReportsReasonableAdjustments from '@/views/Exercise/Reports/ReasonableAdjustments.vue';
 import ExerciseReportsAgency from '@/views/Exercise/Reports/Agency.vue';
 import ExerciseReportsHandover from '@/views/Exercise/Reports/Handover.vue';
+import ExerciseReportsDeployment from '@/views/Exercise/Reports/Deployment.vue';
 import ExerciseReportsStatutoryConsultation from '@/views/Exercise/Reports/StatutoryConsultation.vue';
 import ExerciseReportsPanels from '@/views/Exercise/Reports/Panels.vue';
 import ExerciseReportsPanelsNew from '@/views/Exercise/Reports/PanelsNew.vue';
@@ -1009,6 +1010,15 @@ const routes = [
             meta: {
               requiresAuth: true,
               title: 'Handover | Exercise Reports',
+            },
+          },
+          {
+            name: 'deployment',
+            path: 'deployment',
+            component: ExerciseReportsDeployment,
+            meta: {
+              requiresAuth: true,
+              title: 'Deployment | Exercise Reports',
             },
           },
           {

--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -56,6 +56,10 @@ export default {
           name: 'handover',
         },
         {
+          title: 'Deployment',
+          name: 'deployment',
+        },
+        {
           title: 'Statutory Consultation',
           name: 'statutory-consultation',
         },

--- a/src/views/Exercise/Reports/Deployment.vue
+++ b/src/views/Exercise/Reports/Deployment.vue
@@ -1,0 +1,211 @@
+<template>
+  <div class="govuk-grid-column-full">
+    <div class="moj-page-header-actions">
+      <div class="moj-page-header-actions__title">
+        <h2 class="govuk-heading-l">
+          Deployment
+        </h2>
+      </div>
+
+      <div
+        class="moj-page-header-actions__actions float-right"
+      >
+        <div class="moj-button-menu">
+          <div class="moj-button-menu__wrapper">
+            <button
+              class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
+              data-module="govuk-button"
+              :disabled="!hasReportData"
+              @click="exportData()"
+            >
+              Export data
+            </button>
+
+            <ActionButton
+              v-if="hasPermissions([
+                PERMISSIONS.exercises.permissions.canReadExercises.value,
+                PERMISSIONS.applicationRecords.permissions.canReadApplicationRecords.value,
+                PERMISSIONS.applications.permissions.canReadApplications.value
+              ])"
+              type="primary"
+              :action="refreshReport"
+            >
+              Refresh
+            </ActionButton>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <div class="panel govuk-!-margin-bottom-9">
+          <span class="govuk-caption-m">
+            Approved for immediate appointment
+          </span>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+            {{ $filters.formatNumber(totalApplicationRecords) }}
+          </h2>
+        </div>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <div class="panel govuk-!-margin-bottom-9">
+          <span class="govuk-caption-m">Type of exercise</span>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+            {{ $filters.lookup(exerciseType) }}
+          </h2>
+        </div>
+      </div>
+    </div>
+
+    <Table
+      v-if="report != null"
+      data-key="id"
+      :data="report.rows"
+      :columns="tableColumns"
+      :page-size="1000"
+      local-data
+      @change="getTableData"
+    >
+      <template #row="{row}">
+        <TableCell :title="tableColumns[0].title">
+          <RouterLink
+            :to="{ name: 'exercise-application', params: { applicationId: row.applicationId } }"
+          >
+            {{ row.referenceNumber }}
+          </RouterLink>
+        </TableCell>
+        <TableCell :title="tableColumns[1].title">
+          <RouterLink
+            :to="{ name: 'candidates-view', params: { id: row.candidateId } }"
+          >
+            {{ row.fullName }}
+          </RouterLink>
+        </TableCell>
+      </template>
+    </Table>
+  </div>
+</template>
+
+<script>
+import { httpsCallable } from '@firebase/functions';
+import { onSnapshot, doc } from '@firebase/firestore';
+import { mapState } from 'vuex';
+import { firestore, functions } from '@/firebase';
+import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
+import { downloadXLSX } from '@jac-uk/jac-kit/helpers/export';
+import Table from '@jac-uk/jac-kit/components/Table/Table.vue';
+import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
+import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
+import { APPLICATION_STATUS } from '@jac-uk/jac-kit/helpers/constants';
+import permissionMixin from '@/permissionMixin';
+
+export default {
+  name: 'DeploymentReport',
+  components: {
+    Table,
+    TableCell,
+    ActionButton,
+  },
+  mixins: [permissionMixin],
+  data() {
+    return {
+      report: null,
+      tableColumns: [
+        {
+          title: 'Reference number',
+          class: ['govuk-!-width-one-third'],
+        },
+        { title: 'Name', sort: 'candidate.fullName', default: true },
+      ],
+    };
+  },
+  computed: {
+    ...mapState({
+      exercise: state => state.exerciseDocument.record,
+    }),
+    exerciseType() {
+      return this.exercise.typeOfExercise;
+    },
+    totalApplicationRecords() {
+      return this.report ? this.report.totalApplications : 0;
+    },
+    hasReportData() {
+      return this.report && this.report.headers;
+    },
+  },
+  created() {
+    this.unsubscribe = onSnapshot(
+      doc(firestore, `exercises/${this.exercise.id}/reports/deployment`),
+      (snap) => {
+        if (snap.exists) {
+          this.report = vuexfireSerialize(snap);
+        }
+      });
+  },
+  unmounted() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+    }
+  },
+  methods: {
+    getTableData(params) {
+      this.$store.dispatch(
+        'stageHandover/bind',
+        {
+          exerciseId: this.exercise.id,
+          status: APPLICATION_STATUS.APPROVED_FOR_IMMEDIATE_APPOINTMENT,
+          ...params,
+        }
+      );
+    },
+    async refreshReport() {
+      try {
+        await httpsCallable(functions, 'generateDeploymentReport')({ exerciseId: this.exercise.id });
+        return true;
+      } catch (error) {
+        return;
+      }
+    },
+    gatherReportData() {
+      const reportData = [];
+
+      // get headers
+      reportData.push(this.report.headers.map(header => header.title));
+
+      // get rows
+      this.report.rows.forEach((row) => {
+        reportData.push(this.report.headers.map(header => row[header.ref]));
+      });
+
+      return reportData;
+    },
+    async exportData() {
+      const title = 'Deployment Report';
+      const data = this.gatherReportData();
+      /**
+       * Make the 'Judicial experience' (column S) can display multiple lines.
+       *
+       * @link: https://github.com/dtjohnson/xlsx-populate?tab=readme-ov-file#styles-1
+       */
+      const styles = {
+        column: {
+          'S': {
+            wrapText: true,
+          },
+        },
+      };
+
+      downloadXLSX(
+        data,
+        {
+          title: `${this.exercise.referenceNumber} ${title}`,
+          sheetName: title,
+          fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
+        },
+        styles
+      );
+    },
+  },
+};
+</script>

--- a/src/views/Exercise/Reports/Deployment.vue
+++ b/src/views/Exercise/Reports/Deployment.vue
@@ -5,6 +5,12 @@
         <h2 class="govuk-heading-l">
           Deployment
         </h2>
+        <span
+          v-if="report"
+          class="govuk-body govuk-!-font-size-14"
+        >
+          {{ $filters.formatDate(report.createdAt, 'longdatetime') }}
+        </span>
       </div>
 
       <div


### PR DESCRIPTION
## What's included?
Closes #2260 

Note: This PR needs changes in [digital-platform: Feature/admin 2260 Create Deployment Report](https://github.com/jac-uk/digital-platform/pull/1032).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example exercises:
- Working preferences with ranked choice: https://jac-admin-develop--pr2348-feature-2260-create-k8ed2wp8.web.app/exercise/9JP3KOJHxrKyj2VLDiTG/reports/deployment
- Working preferences with multiple choice: https://jac-admin-develop--pr2348-feature-2260-create-k8ed2wp8.web.app/exercise/NebJYlQl4fxnUXWmrWOa/reports/deployment
- Working preferences with single choice: https://jac-admin-develop--pr2348-feature-2260-create-k8ed2wp8.web.app/exercise/vzReRrA5LPZ3sGvZKWvM/reports/deployment

1. Go to the report page and check if there is a new link "Deployment" under "Handover" in the reports menu.
2. Go to the "Deployment" report page.
3. Check if the "Refresh" button works correctly.
4. Check if the "Export data" button works correctly.
5. Open the report and check if the information is present correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/b5b06451-196e-4a7f-9970-c5194fe06721

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
