### PR TITLE
Bugfix/TS 237 Exercise Location in Welsh

### DIFF
--- a/src/views/Exercise/Details/Vacancy/Edit.vue
+++ b/src/views/Exercise/Details/Vacancy/Edit.vue
@@ -344,6 +344,13 @@
           rows="2"
         />
 
+        <TextareaInput
+          id="location-welsh"
+          v-model="formData.locationWelsh"
+          label="Location (Welsh)"
+          rows="2"
+        />
+
         <RadioGroup
           id="welsh-requirement"
           v-model="formData.welshRequirement"
@@ -481,6 +488,7 @@ export default {
       immediateStart: null,
       futureStart: null,
       location: null,
+      locationWelsh: null,
       jurisdiction: null,
       otherJurisdiction: null,
       statutoryConsultationWaived: null,

--- a/src/views/Exercise/Details/Vacancy/View.vue
+++ b/src/views/Exercise/Details/Vacancy/View.vue
@@ -124,6 +124,14 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          Location (Welsh)
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ exercise.locationWelsh }}
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
           Welsh requirement
         </dt>
         <dd class="govuk-summary-list__value">


### PR DESCRIPTION
## What's included?
Issue: [User Raised Issue BR_000047](https://github.com/jac-uk/ticketing-system/issues/237)

- Add `Location (Welsh)` to the exercise.

![image](https://github.com/jac-uk/admin/assets/79906532/3ee845cf-aa77-4253-bc68-55170372f4d5)

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example exercise: https://jac-admin-develop--pr2349-bugfix-ts-237-exerci-r9gcy8w6.web.app/exercise/cGgGaguvcdSVb7SsTD7Y/details/vacancy

1. Go to the "Vacancy information" of an exercise.
2. Edit the field "Location (Welsh)".
3. Check if "Location (Welsh)" is saved correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
