### PR TITLE
Feature/2275 Update reports which include stage status

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -185,9 +185,9 @@ const lookup = (value) => {
 
   // v2 exercise stages
   lookup[EXERCISE_STAGE.SHORTLISTING] = 'Shortlisting';
-  lookup[EXERCISE_STAGE.SELECTION] = 'Selection';
+  lookup[EXERCISE_STAGE.SELECTION] = 'Selection Days';
   lookup[EXERCISE_STAGE.SCC] = 'SCC';
-  lookup[EXERCISE_STAGE.RECOMMENDATION] = 'Recommendation';
+  lookup[EXERCISE_STAGE.RECOMMENDATION] = 'Recommendations';
 
   lookup[EXERCISE_STAGE.REVIEW] = 'Review';
   lookup[EXERCISE_STAGE.APPLIED] = 'Applied';
@@ -244,7 +244,7 @@ const lookup = (value) => {
   lookup[`${TASK_TYPE.SHORTLISTING_OUTCOME}Passed`] = 'Shortlisting Passed';
   lookup[`${TASK_TYPE.SHORTLISTING_OUTCOME}Failed`] = 'Shortlisting Failed';
   // lookup[TASK_TYPE.WELSH_ASSESSMENT] = 'Welsh Assessment';
-  lookup[TASK_TYPE.PRE_SELECTION_DAY_QUESTIONNAIRE] = 'Pre Selection Day Questionnaire';  
+  lookup[TASK_TYPE.PRE_SELECTION_DAY_QUESTIONNAIRE] = 'Pre Selection Day Questionnaire';
   lookup[TASK_TYPE.SELECTION_DAY] = 'Selection Day';
   lookup[`${TASK_TYPE.SELECTION_DAY}Passed`] = 'Selection Day Passed';
   lookup[`${TASK_TYPE.SELECTION_DAY}Failed`] = 'Selection Day Failed';

--- a/src/reports.js
+++ b/src/reports.js
@@ -1,32 +1,9 @@
 
 import { lookup } from '@/filters';
 import _cloneDeep from 'lodash/cloneDeep';
-import { EXERCISE_STAGE } from '@/helpers/constants';
 
 const REPORTS = {
   ApplicationStageDiversity: {
-    labels: [
-      {
-        key: EXERCISE_STAGE.APPLIED,
-        title: lookup(EXERCISE_STAGE.APPLIED),
-      },
-      {
-        key: EXERCISE_STAGE.SHORTLISTED,
-        title: lookup(EXERCISE_STAGE.SHORTLISTED),
-      },
-      {
-        key: EXERCISE_STAGE.SELECTED,
-        title: lookup(EXERCISE_STAGE.SELECTED),
-      },
-      {
-        key: EXERCISE_STAGE.RECOMMENDED,
-        title: lookup(EXERCISE_STAGE.RECOMMENDED),
-      },
-      {
-        key: EXERCISE_STAGE.HANDOVER,
-        title: lookup(EXERCISE_STAGE.HANDOVER),
-      },
-    ],
     legend: {
       gender: [
         {
@@ -158,21 +135,9 @@ const post04012023SocialMobility = {
   title: `${lookup('parentsNotAttendedUniversity')}`,
 };
 
-const getReports = (applicationOpenDate, exerciseRef, processingVersion) => {
+const getReports = (applicationOpenDate, exerciseRef) => {
   const usesPre01042023Questions = ['JAC00130', 'JAC00123', 'JAC00164'].includes(exerciseRef);
   const mergedReports = _cloneDeep(REPORTS);
-
-  if (processingVersion >= 2) {
-    mergedReports.ApplicationStageDiversity.labels = REPORTS.ApplicationStageDiversity.labels.map(item => {
-      if (item.key === EXERCISE_STAGE.SELECTED) {
-        return {
-          key: EXERCISE_STAGE.SELECTABLE,
-          title: lookup(EXERCISE_STAGE.SELECTABLE),
-        };
-      }
-      return item;
-    });
-  }
 
   if (applicationOpenDate > new Date('2023-04-01') && !usesPre01042023Questions) {
     mergedReports.ApplicationStageDiversity.legend.parentsNotAttendedUniversity = [];

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -73,12 +73,16 @@
             v-if="canEditExerciseConfiguration"
             class="govuk-link govuk-!-margin-right-4 print-none"
             :to="{name: 'exercise-configuration-application-version'}"
-          >Application form v{{ exercise._applicationVersion || 1 }}</router-link>
+          >
+            Application form v{{ exercise._applicationVersion || 1 }}
+          </router-link>
           <router-link
             v-if="canEditExerciseConfiguration"
             class="govuk-link print-none"
             :to="{name: 'exercise-configuration-processing-version'}"
-          >Processing v{{ exercise._processingVersion || 1 }}</router-link>
+          >
+            Processing v{{ exercise._processingVersion || 1 }}
+          </router-link>
           <div
             v-if="!isProduction"
             class="govuk-!-margin-top-4"

--- a/src/views/Exercise/Dashboard/Dashboard.vue
+++ b/src/views/Exercise/Dashboard/Dashboard.vue
@@ -60,7 +60,7 @@
     </div>
 
     <div
-      v-if="report"
+      v-if="report && showTabs"
       class="govuk-grid-column-full"
     >
       <Select
@@ -113,6 +113,14 @@
       </Table>
       <p class="govuk-caption-s color-middle">
         <span class="">Diversity Report Last Updated: {{ $filters.formatDate(reportCreatedAt, 'datetime') }}</span>
+      </p>
+    </div>
+    <div
+      v-else
+      class="govuk-grid-column-full"
+    >
+      <p class="govuk-body">
+        Please refresh the report.
       </p>
     </div>
   </div>
@@ -224,6 +232,9 @@ export default {
       }
       types.push('emp');
       return types;
+    },
+    showTabs() {
+      return this.report && this.availableStages?.length && this.report?.[this.availableStages[0]];  // check if report data is available
     },
     tabs() {
       return _map(this.labels, item => {

--- a/src/views/Exercise/Reports/Diversity.vue
+++ b/src/views/Exercise/Reports/Diversity.vue
@@ -563,7 +563,7 @@ import Stat from '@/components/Report/Stat.vue';
 import permissionMixin from '@/permissionMixin';
 import { mapGetters } from 'vuex';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
-import { EXERCISE_STAGE } from '@/helpers/constants';
+import { availableStages } from '@/helpers/exerciseHelper';
 
 export default {
   name: 'Diversity',
@@ -577,7 +577,7 @@ export default {
     return {
       diversity: null,
       unsubscribe: null,
-      activeTab: EXERCISE_STAGE.APPLIED,
+      activeTab: '',
     };
   },
   computed: {
@@ -587,39 +587,16 @@ export default {
     exercise() {
       return this.$store.state.exerciseDocument.record;
     },
+    availableStages() {
+      return availableStages(this.exercise);
+    },
     tabs() {
-      const tabs = [
-        {
-          ref: EXERCISE_STAGE.APPLIED,
-          title: this.$filters.lookup(EXERCISE_STAGE.APPLIED),
-        },
-        {
-          ref: EXERCISE_STAGE.SHORTLISTED,
-          title: this.$filters.lookup(EXERCISE_STAGE.SHORTLISTED),
-        },
-      ];
-
-      if (this.exercise?._processingVersion >= 2) {
-        tabs.push({
-          ref: EXERCISE_STAGE.SELECTABLE,
-          title: this.$filters.lookup(EXERCISE_STAGE.SELECTABLE),
-        });
-      } else {
-        tabs.push({
-          ref: EXERCISE_STAGE.SELECTED,
-          title: this.$filters.lookup(EXERCISE_STAGE.SELECTED),
-        });
-      }
+      const tabs = this.availableStages.map((stage) => ({
+        ref: stage,
+        title: this.$filters.lookup(stage),
+      }));
 
       tabs.push(
-        {
-          ref: EXERCISE_STAGE.RECOMMENDED,
-          title: this.$filters.lookup(EXERCISE_STAGE.RECOMMENDED),
-        },
-        {
-          ref: EXERCISE_STAGE.HANDOVER,
-          title: this.$filters.lookup(EXERCISE_STAGE.HANDOVER),
-        },
         {
           ref: 'summary',
           title: 'Summary',
@@ -628,7 +605,7 @@ export default {
       return tabs;
     },
     showTabs() {
-      return this.diversity && this.diversity.shortlisted;  // .shortlisted indicates we have stages reports
+      return this.diversity && this.availableStages?.length && this.diversity?.[this.availableStages[0]];  // check if diversity data is available
     },
     activeTabTitle() {
       for (let i = 0, len = this.tabs.length; i < len; ++i) {
@@ -639,7 +616,21 @@ export default {
       return '';
     },
   },
+  watch: {
+    availableStages: {
+      immediate: true,
+      handler() {
+        if (this.availableStages.length && !this.activeTab && this.activeTab !== this.availableStages[0]) {
+          this.activeTab = this.availableStages[0];
+        }
+      },
+    },
+  },
   created() {
+    if (this.$route.hash && this.$route.hash.slice(1)) {
+      this.activeTab = this.$route.hash.slice(1);
+    }
+
     this.unsubscribe = onSnapshot(
       doc(firestore, `exercises/${this.exercise.id}/reports/diversity`),
       (snap) => {
@@ -663,13 +654,7 @@ export default {
     },
     gatherReportData(stage) {
       const data = [];
-      let stages = [
-        EXERCISE_STAGE.APPLIED,
-        EXERCISE_STAGE.SHORTLISTED,
-        this.exercise?._processingVersion >= 2 ? EXERCISE_STAGE.SELECTABLE : EXERCISE_STAGE.SELECTED,
-        EXERCISE_STAGE.RECOMMENDED,
-        EXERCISE_STAGE.HANDOVER,
-      ];
+      let stages = this.availableStages;
       if (stage) {
         stages = [stage];
       }

--- a/src/views/Exercise/Reports/Diversity.vue
+++ b/src/views/Exercise/Reports/Diversity.vue
@@ -52,7 +52,7 @@
       </div>
 
       <div
-        v-if="diversity"
+        v-if="diversity && showTabs"
         class="govuk-grid-row"
       >
         <div class="govuk-grid-column-one-half">
@@ -74,15 +74,19 @@
           </div>
         </div>
       </div>
+      <div v-else>
+        <p class="govuk-body">
+          Please refresh the report.
+        </p>
+      </div>
     </div>
 
     <!-- results -->
     <div
-      v-if="diversity"
+      v-if="diversity && showTabs"
       class="govuk-grid-column-full"
     >
       <TabsList
-        v-if="showTabs"
         v-model:active-tab="activeTab"
         :tabs="tabs"
         class="print-none"
@@ -605,7 +609,7 @@ export default {
       return tabs;
     },
     showTabs() {
-      return this.diversity && this.availableStages?.length && this.diversity?.[this.availableStages[0]];  // check if diversity data is available
+      return this.diversity && this.availableStages?.length && this.diversity?.[this.availableStages[0]];  // check if report data is available
     },
     activeTabTitle() {
       for (let i = 0, len = this.tabs.length; i < len; ++i) {

--- a/src/views/Exercise/Reports/Outreach.vue
+++ b/src/views/Exercise/Reports/Outreach.vue
@@ -348,8 +348,7 @@ import TabsList from '@jac-uk/jac-kit/draftComponents/TabsList.vue';
 import Stat from '@/components/Report/Stat.vue';
 import permissionMixin from '@/permissionMixin';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
-import { isLegal } from '@/helpers/exerciseHelper';
-import { EXERCISE_STAGE } from '@/helpers/constants';
+import { isLegal, availableStages } from '@/helpers/exerciseHelper';
 
 export default {
   name: 'Outreach',
@@ -363,7 +362,7 @@ export default {
     return {
       report: null,
       unsubscribe: null,
-      activeTab: EXERCISE_STAGE.APPLIED,
+      activeTab: '',
       reportKeys: [
         'jac-website',
         'professional-body-website-or-email',
@@ -381,39 +380,16 @@ export default {
     exercise() {
       return this.$store.state.exerciseDocument.record;
     },
+    availableStages() {
+      return availableStages(this.exercise);
+    },
     tabs() {
-      const tabs = [
-        {
-          ref: EXERCISE_STAGE.APPLIED,
-          title: this.$filters.lookup(EXERCISE_STAGE.APPLIED),
-        },
-        {
-          ref: EXERCISE_STAGE.SHORTLISTED,
-          title: this.$filters.lookup(EXERCISE_STAGE.SHORTLISTED),
-        },
-      ];
-
-      if (this.exercise?._processingVersion >= 2) {
-        tabs.push({
-          ref: EXERCISE_STAGE.SELECTABLE,
-          title: this.$filters.lookup(EXERCISE_STAGE.SELECTABLE),
-        });
-      } else {
-        tabs.push({
-          ref: EXERCISE_STAGE.SELECTED,
-          title: this.$filters.lookup(EXERCISE_STAGE.SELECTED),
-        });
-      }
+      const tabs = this.availableStages.map((stage) => ({
+        ref: stage,
+        title: this.$filters.lookup(stage),
+      }));
 
       tabs.push(
-        {
-          ref: EXERCISE_STAGE.RECOMMENDED,
-          title: this.$filters.lookup(EXERCISE_STAGE.RECOMMENDED),
-        },
-        {
-          ref: EXERCISE_STAGE.HANDOVER,
-          title: this.$filters.lookup(EXERCISE_STAGE.HANDOVER),
-        },
         {
           ref: 'summary',
           title: 'Summary',
@@ -422,7 +398,7 @@ export default {
       return tabs;
     },
     showTabs() {
-      return this.report && this.report.shortlisted;  // .shortlisted indicates we have stages reports
+      return this.report && this.availableStages?.length && this.report?.[this.availableStages[0]];  // check if diversity data is available
     },
     activeTabTitle() {
       for (let i = 0, len = this.tabs.length; i < len; ++i) {
@@ -436,7 +412,21 @@ export default {
       return isLegal(this.exercise);
     },
   },
+  watch: {
+    availableStages: {
+      immediate: true,
+      handler() {
+        if (this.availableStages.length && !this.activeTab && this.activeTab !== this.availableStages[0]) {
+          this.activeTab = this.availableStages[0];
+        }
+      },
+    },
+  },
   created() {
+    if (this.$route.hash && this.$route.hash.slice(1)) {
+      this.activeTab = this.$route.hash.slice(1);
+    }
+
     this.unsubscribe = onSnapshot(
       doc(firestore, `exercises/${this.exercise.id}/reports/outreach`),
       (snap) => {
@@ -460,13 +450,7 @@ export default {
     },
     gatherReportData(stage) {
       const data = [];
-      let stages = [
-        EXERCISE_STAGE.APPLIED,
-        EXERCISE_STAGE.SHORTLISTED,
-        this.exercise?._processingVersion >= 2 ? EXERCISE_STAGE.SELECTABLE : EXERCISE_STAGE.SELECTED,
-        EXERCISE_STAGE.RECOMMENDED,
-        EXERCISE_STAGE.HANDOVER,
-      ];
+      let stages = this.availableStages;
       if (stage) {
         stages = [stage];
       }

--- a/src/views/Exercise/Reports/Outreach.vue
+++ b/src/views/Exercise/Reports/Outreach.vue
@@ -52,7 +52,7 @@
       </div>
 
       <div
-        v-if="report"
+        v-if="report && showTabs"
         class="govuk-grid-row"
       >
         <div class="govuk-grid-column-one-half">
@@ -74,15 +74,19 @@
           </div>
         </div>
       </div>
+      <div v-else>
+        <p class="govuk-body">
+          Please refresh the report.
+        </p>
+      </div>
     </div>
 
     <!-- results -->
     <div
-      v-if="report"
+      v-if="report && showTabs"
       class="govuk-grid-column-full"
     >
       <TabsList
-        v-if="showTabs"
         v-model:active-tab="activeTab"
         :tabs="tabs"
         class="print-none"
@@ -398,7 +402,7 @@ export default {
       return tabs;
     },
     showTabs() {
-      return this.report && this.availableStages?.length && this.report?.[this.availableStages[0]];  // check if diversity data is available
+      return this.report && this.availableStages?.length && this.report?.[this.availableStages[0]];  // check if report data is available
     },
     activeTabTitle() {
       for (let i = 0, len = this.tabs.length; i < len; ++i) {


### PR DESCRIPTION
## What's included?
Related Issue: #2275.

- Fix the diversity report when switching different processing versions.
- Fix the outreach report when switching different processing versions.

Note: This PR needs the changes in [digital-platform: Feature/admin 2275 Update reports which include stage status](https://github.com/jac-uk/digital-platform/pull/1047).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example exercise: https://jac-admin-develop--pr2350-feature-2275-update-plb1q8v0.web.app/exercise/Oy4hPcHarUc0CMQau7Hh/details/overview

1. Go to an exercise and change the processing version.
2. Go to "Diversity" report and hit the "Refresh" button. Check if the stages show correctly.
3. Go to "Outreach" report and hit the "Refresh" button. Check if the stages show correctly.


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/e7597f68-d85b-4595-a4f7-b8140dcdc3f2


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
