### PR TITLE
Feature/2326 Address candidate naming inconsistencies

### DIFF
--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -642,10 +642,6 @@ export default {
       return objChanged;
     },
     changePersonalDetails(objChanged) {
-      if (objChanged.firstName || objChanged.lastName) {
-        objChanged = this.makeFullName(objChanged);
-      }
-
       const myPersonalDetails = { ...this.application.personalDetails, ...objChanged };
       this.changeApplication({ personalDetails: myPersonalDetails });
       this.$store.dispatch('candidates/savePersonalDetails', { data: objChanged, id: this.application.userId });


### PR DESCRIPTION
## What's included?
#2326 

- Avoid calculating `fullName` twice.

## Who should test?
✅ Product owner
✅ Developers

## How to test?

Example application:  https://jac-admin-develop--pr2354-feature-2326-address-0lntfdbu.web.app/exercise/b96p6e9GTAkVUhbggHom/applications/applied/application/KbaGWWL5C6oTiOHa64Sg

- Amend first name or last name.
- Check if the full name shows correctly in the application list: https://jac-admin-develop--pr2354-feature-2326-address-0lntfdbu.web.app/exercise/b96p6e9GTAkVUhbggHom/applications/applied
- Check if the full name shows correctly in the stage list: https://jac-admin-develop--pr2354-feature-2326-address-0lntfdbu.web.app/exercise/b96p6e9GTAkVUhbggHom/stages/selected


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
