### PR TITLE
Bugfix/TS 247 Update Assessor Info

### DIFF
--- a/src/store/assessment.js
+++ b/src/store/assessment.js
@@ -1,4 +1,4 @@
-import { query, where, getDocs, collection, doc, updateDoc, setDoc, serverTimestamp } from '@firebase/firestore';
+import { query, where, getDocs, getDoc, collection, doc, updateDoc, setDoc, serverTimestamp } from '@firebase/firestore';
 import { firestore } from '@/firebase';
 import { firestoreAction } from '@/helpers/vuexfireJAC';
 import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
@@ -64,7 +64,7 @@ export default {
       }
 
       const ref = doc(collectionRef, `${id}-${AssessorNr}`);
-      const docSnapshot = await ref.get();
+      const docSnapshot = await getDoc(ref);
       if (docSnapshot.exists) {
          await setDoc(ref, returnData, { merge: true });
       }

--- a/src/views/InformationReview/AssessmentsSummary.vue
+++ b/src/views/InformationReview/AssessmentsSummary.vue
@@ -151,11 +151,13 @@
                 :key="i"
                 style="white-space: pre-line;"
               >
-                <strong>
+                <strong v-if="section.question">
                   {{ `${i + 1}. ${section.question}` }}
                 </strong>
                 <br>
-                {{ application.uploadedSelfAssessmentContent[i] || '' }}
+                <p v-if="application.uploadedSelfAssessmentContent && application.uploadedSelfAssessmentContent[i]">
+                  {{ application.uploadedSelfAssessmentContent[i] }}
+                </p>
                 <hr v-if="i !== selfAssessmentSections.length - 1">
               </div>
             </div>


### PR DESCRIPTION
## What's included?
Issue: [User Raised Issue BR_000058 #247](https://github.com/jac-uk/ticketing-system/issues/247)

- Fix Firebase syntax in the store `assessment.js`.
- Check the assessment question before accessing it.

Note: The PR required the changes in [digital-platform: Bugfix/TS 247 Update Assessor Info #1054](https://github.com/jac-uk/digital-platform/pull/1054).

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example exercise: https://jac-admin-develop--pr2355-bugfix-ts-247-update-qejdbf0q.web.app/exercise/ONqUjAzhDS7rjh6dFJLB/tasks/all/independent-assessments
Example application: https://jac-admin-develop--pr2355-bugfix-ts-247-update-qejdbf0q.web.app/exercise/ONqUjAzhDS7rjh6dFJLB/applications/applied/application/X5ToXRooJbu9h6AVRtuA

1. Go to the application and update the information (type, full name, email) of the first/second assessor.
2. Go to "Independent Assessments" and check if the information of the assessor has been updated. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
