### PR TITLE
Bugfix/2361 Ensure SA upload can handle 6 questions

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -231,6 +231,7 @@ const SELF_ASSESSMENT_COMPETENCIES_QUESTIONS = [
   'Legal and judicial skills',
   'Personal qualities',
   'Working Effectively',
+  'Career Highlights',
 ];
 
 const WORKING_BASIS = {


### PR DESCRIPTION
## What's included?
Closes #2361 

- Add `Career Highlights` to the dropdown of Self Assessment with competencies.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example exercise: https://jac-admin-develop--pr2362-bugfix-2361-sa-uploa-826z1cyu.web.app/exercise/kGW2SkyaMb7M68OAN5fR/details/assessments

1. Go to "Assessment options" of an exercise.
2. Update the assessment options.
3. Tick "Self Assessment with competencies" and check if "Career Highlights" appears in the dropdown.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

Screenshot:

<img width="1221" alt="Screenshot 2024-04-03 at 15 49 27" src="https://github.com/jac-uk/admin/assets/79906532/d763349d-fe07-4cb6-b743-01d5e7416813">


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
