### PR TITLE
Allow users can edit external exercise if having update permission

### DIFF
--- a/src/views/Exercise/Externals/View.vue
+++ b/src/views/Exercise/Externals/View.vue
@@ -437,7 +437,7 @@
 
     <button
       v-if="!isPublished && hasPermissions([
-        PERMISSIONS.exercises.permissions.canPublishExercise.value
+        PERMISSIONS.exercises.permissions.canUpdateExercises.value
       ])"
       :disabled="!canPublish"
       class="govuk-button govuk-button--secondary"
@@ -447,7 +447,7 @@
     </button>
     <button
       v-if="isPublished && hasPermissions([
-        PERMISSIONS.exercises.permissions.canPublishExercise.value
+        PERMISSIONS.exercises.permissions.canUpdateExercises.value
       ])"
       class="govuk-button govuk-button--secondary"
       @click="unPublish"


### PR DESCRIPTION
## What's included?
closes #2254 

The problem here is that we don't want all users to be able to publish all exercises; we want Ops senior managers (but not Ops team members) to be able to publish all exercises, but we want 2/3 users to be able to publish only external exercises without having to gain approval.
we would only want Adela and Gemma (Operations  Team Member) plus Ops Senior Leaders to publish external exercises.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## Related permissions
Test as user in `Operations  Team Member` group, without `Can publish an exercise as live` permission, but has following permissions:
- Can read exercises
- Can create exercises
- Can update exercises

## How to test?
- Change the user role  of log-in account to `Operations  Team Member` which should be `without` `Can publish an exercise as live` permission.
- Go to external exercises of the preview link: https://jac-admin-develop--pr2370-feat-2254-remove-ext-rkhkcll3.web.app/exercise/h5NnKG22oWc6qT12D2VC/externals, it should appear `Publish on website` or `Remove From Apply Site button`, and the actions of these buttons should reflect  on the apply site: https://apply-develop.judicialappointments.digital/vacancies .
- Go to internal exercises of the preview link: https://jac-admin-develop--pr2370-feat-2254-remove-ext-rkhkcll3.web.app/exercise/77MKqzFIG5imN8ttB6Vl/details/overview, it shouldn't appear publish button.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
