### PR TITLE
TS 285 IA Table Not Sorting Nor Paginating Properly

### DIFF
--- a/src/views/Exercise/Tasks/IndependentAssessments.vue
+++ b/src/views/Exercise/Tasks/IndependentAssessments.vue
@@ -383,13 +383,6 @@ export default {
     TabsList,
   },
   mixins: [permissionMixin],
-  beforeRouteUpdate (to, from, next) {
-    this.$store.dispatch('assessments/bind', {
-      exerciseId: this.exercise.id,
-      status: this.getStatus(),
-    });
-    next();
-  },
   data() {
     const tabs = [
       {


### PR DESCRIPTION
## What's included?
The IA table was being rendered twice when the Requested tab was pressed and also when pressing the pagination links.
This second render was without the params so any sorting was lost.
The fix entailed removing the beforeRouteUpdate lifecycle hook from the component.

Closes jac-uk/ticketing-system#285

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to an exercise which has content in its Independent Assessments table (found under the Tasks tab).
Ensure you can reorder the table by pressing the sort links at the top of each column then, while sorted, press the pagination links at the bottom of the page to ensure the sorting is maintained as you navigate through the records.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
