### PR TITLE
Remove the required condition for the authorised field

### DIFF
--- a/src/views/Exercise/Details/Eligibility/Edit.vue
+++ b/src/views/Exercise/Details/Eligibility/Edit.vue
@@ -92,7 +92,6 @@
           v-model="formData.authorisations"
           label="Authorisations"
           hint="Select all that apply."
-          required
         >
           <CheckboxItem
             value="s9-1"


### PR DESCRIPTION
## What's included?
A user requested that the authorisations should not be a required field, ie they should not have to specify s9(1) nor Class 1 Ticket.

Closes jac-uk/ticketing-system#288

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1) Open a draft exercise
2) Click on the 'Eligibility Information' link in the left sidebar
3) Ensure neither of the Authorisations check boxes are checked
4) Submit the form

Repeat above checking one and both of the checkboxes can be checked and the form submitted.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
<img width="1725" alt="Screenshot 2024-04-22 at 14 14 16" src="https://github.com/jac-uk/admin/assets/115651787/a7025cc0-389f-4569-99b1-c03f6bbdfb0d">

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
