### PR TITLE
Bugfix/TS 305 Shortlisting Other Statuses

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -228,6 +228,9 @@ const lookup = (value) => {
   lookup[APPLICATION_STATUS.SIFT_PASSED] = 'Sift Passed';
   lookup[APPLICATION_STATUS.WITHDRAWN] = 'Withdrew';
 
+  lookup[APPLICATION_STATUS.OTHER_PASSED] = 'Other Passed';
+  lookup[APPLICATION_STATUS.OTHER_FAILED] = 'Other Failed';
+
   lookup[`${TASK_TYPE.CRITICAL_ANALYSIS}`] = 'Critical Analysis Test';
   lookup[`${TASK_TYPE.CRITICAL_ANALYSIS}Passed`] = 'Critical Analysis Test Passed';
   lookup[`${TASK_TYPE.CRITICAL_ANALYSIS}Failed`] = 'Critical Analysis Test Failed';

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -83,6 +83,10 @@ const APPLICATION_STATUS = {
   APPROVED_FUTURE: 'approvedFuture',
   WITHDRAWN: 'withdrawn',
 
+  // shortlisting other
+  OTHER_PASSED: 'otherPassed',
+  OTHER_FAILED: 'otherFailed',
+
   // v1 REVIEW
   PASSED_SIFT: 'passedSift',
   FAILED_SIFT: 'failedSift',

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -1259,8 +1259,7 @@ function shortlistingStatuses(exercise) {
     // sift
     if (
       exercise.shortlistingMethods.indexOf(SHORTLISTING.NAME_BLIND_PAPER_SIFT) >= 0 ||
-      exercise.shortlistingMethods.indexOf(SHORTLISTING.PAPER_SIFT) >= 0 ||
-      exercise.shortlistingMethods.indexOf(SHORTLISTING.OTHER) >= 0
+      exercise.shortlistingMethods.indexOf(SHORTLISTING.PAPER_SIFT) >= 0
     ) {
       if (exercise._processingVersion >= 2) {
         statuses.push(APPLICATION_STATUS.SIFT_PASSED);
@@ -1280,7 +1279,11 @@ function shortlistingStatuses(exercise) {
         statuses.push(APPLICATION_STATUS.PASSED_TELEPHONE_ASSESSMENT);
       }
     }
-    // TODO other
+    // other
+    if (exercise.shortlistingMethods.indexOf(SHORTLISTING.OTHER) >= 0) {
+      statuses.push(APPLICATION_STATUS.OTHER_PASSED);
+      statuses.push(APPLICATION_STATUS.OTHER_FAILED);
+    }
   }
   return statuses;
 }

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -1259,7 +1259,8 @@ function shortlistingStatuses(exercise) {
     // sift
     if (
       exercise.shortlistingMethods.indexOf(SHORTLISTING.NAME_BLIND_PAPER_SIFT) >= 0 ||
-      exercise.shortlistingMethods.indexOf(SHORTLISTING.PAPER_SIFT) >= 0
+      exercise.shortlistingMethods.indexOf(SHORTLISTING.PAPER_SIFT) >= 0 ||
+      exercise.shortlistingMethods.indexOf(SHORTLISTING.OTHER) >= 0
     ) {
       if (exercise._processingVersion >= 2) {
         statuses.push(APPLICATION_STATUS.SIFT_PASSED);


### PR DESCRIPTION
## What's included?
Closes [User Raised Issue BR_ADMIN_PR_000108 #305](https://github.com/jac-uk/ticketing-system/issues/305)

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example exercise: https://jac-admin-develop--pr2394-bugfix-ts-305-shortl-xpjwkr7r.web.app/exercise/oNX74wd8yTHohVauj9UW/stages/review

1. Select candidates and then set status.
2. Check if `Other Passed` and `Other Failed` are available under New status.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/de60929d-07d0-499a-b30a-983d4950c14a

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
