### PR TITLE
Limit format of SA template uploads to .docx

### DIFF
--- a/src/components/ModalViews/UploadFiles.vue
+++ b/src/components/ModalViews/UploadFiles.vue
@@ -32,7 +32,7 @@
           :path="buildFileFolder"
           :file-path="$attrs.filePath"
           label=""
-          :types="$attrs.types"
+          :types="'.docx'"
           required
           @update:model-value="changeFileName"
         />


### PR DESCRIPTION
## What's included?
closes #2391 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://jac-admin-develop--pr2402-feat-admin-2391-limi-kdfniodr.web.app/exercise/S9V9R15MGRjCDHdcRQRZ/details/downloads/edit
- Upload the `Candidate Assessment Form` (self assessment template), is should only accept .docx.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
