### PR TITLE
Make last release of each repo visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "autoprefixer": "^10.4.14",
         "buffer": "^6.0.3",
         "chart.js": "^4.2.1",
+        "dayjs": "^1.11.11",
         "detect-browser": "^5.3.0",
         "firebaseui": "^4.8.0",
         "govuk-frontend": "^3.12.0",
@@ -3333,6 +3334,11 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "autoprefixer": "^10.4.14",
     "buffer": "^6.0.3",
     "chart.js": "^4.2.1",
+    "dayjs": "^1.11.11",
     "detect-browser": "^5.3.0",
     "firebaseui": "^4.8.0",
     "govuk-frontend": "^3.12.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@
           </a>
 
           <RouterLink
-            v-if="hasPermissions([PERMISSIONS.logs.permissions.canReadReleases.value])"
+            v-if="hasPermissions([PERMISSIONS.releases.permissions.canReadReleases.value])"
             :to="{ name: 'releases' }"
             class="govuk-body-xs govuk-!-padding-left-2 govuk-!-font-weight-bold"
           >

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,19 @@
           >
             JAC Digital Platform
           </a>
-          <span class="govuk-body-xs govuk-!-padding-left-2">{{ $store.getters.appEnvironment }} {{ $store.getters.appVersion }}</span>
+
+          <RouterLink
+            v-if="hasPermissions([PERMISSIONS.logs.permissions.canReadReleases.value])"
+            :to="{ name: 'releases' }"
+            class="govuk-body-xs govuk-!-padding-left-2 govuk-!-font-weight-bold"
+          >
+            {{ $store.getters.appEnvironment }} {{ $store.getters.appVersion }}
+          </RouterLink>
+
+          <span
+            v-else
+            class="govuk-body-xs govuk-!-padding-left-2"
+          >{{ $store.getters.appEnvironment }} {{ $store.getters.appVersion }}</span>
 
           <nav
             v-if="isSignedIn"

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -156,7 +156,7 @@ const PERMISSIONS = {
         value: 'pa1',
       },
     },
-  },  
+  },
   panels: {
     label: 'Panels',
     permissions: {
@@ -374,7 +374,16 @@ const PERMISSIONS = {
         value: 'cf4',
       },
     },
-  },  
+  },
+  releases: {
+    label: 'Releases',
+    permissions: {
+      canReadReleases: {
+        label: 'Can read releases',
+        value: 'r1',
+      },
+    },
+  },
 };
 
 export default PERMISSIONS;

--- a/src/router.js
+++ b/src/router.js
@@ -144,6 +144,9 @@ import Sandbox from '@/views/Sandbox.vue';
 // Users
 import Users from '@/views/Users/Users.vue';
 
+// Latest Releases
+import ReleasesList from '@/views/ReleasesList.vue';
+
 const routes = [
   {
     path: '/:pathMatch(.*)*',
@@ -166,6 +169,15 @@ const routes = [
     meta: {
       requiresAuth: true,
       title: 'Events',
+    },
+  },
+  {
+    path: '/latest-releases',
+    name: 'releases',
+    component: ReleasesList,
+    meta: {
+      requiresAuth: true,
+      title: 'Latest Releases',
     },
   },
   {
@@ -303,7 +315,7 @@ const routes = [
               requiresAuth: true,
               title: 'Processing Version | Exercise Configuration',
             },
-          },          
+          },
         ],
       },
       {

--- a/src/store.js
+++ b/src/store.js
@@ -47,6 +47,8 @@ import vacancy from '@/store/vacancy';
 import bugReports from '@/store/bugReports/collection';
 import bugReport from '@/store/bugReports/document';
 
+import releases from '@/store/releases';
+
 //const store = new Vuex.Store({
 const store = createStore({
   // Don't use strict mode in production for performance reasons (https://vuex.vuejs.org/guide/strict.html)
@@ -81,6 +83,7 @@ const store = createStore({
     panellist,
     panellists,
     panels,
+    releases,
     roles,
     services,
     task,

--- a/src/store/releases.js
+++ b/src/store/releases.js
@@ -1,0 +1,31 @@
+import { httpsCallable } from '@firebase/functions';
+import { functions } from '@/firebase';
+
+const module = {
+  namespaced: true,
+  state: {
+    records: [],
+    lastFetched: null,
+  },
+  mutations: {
+    setRecords(state, value) {
+      state.records = value;
+    },
+    setLastFetched(state, value) {
+      state.lastFetched = value;
+    },
+  },
+  actions: {
+    async getLatestReleases({ commit }) {
+
+      console.log('releases::getLatestReleases');
+
+      const records = await httpsCallable(functions, 'getLatestReleases')();
+      console.log(records.data);
+
+      commit('setRecords', records.data);
+    },
+  },
+};
+
+export default module;

--- a/src/store/releases.js
+++ b/src/store/releases.js
@@ -17,12 +17,7 @@ const module = {
   },
   actions: {
     async getLatestReleases({ commit }) {
-
-      console.log('releases::getLatestReleases');
-
       const records = await httpsCallable(functions, 'getLatestReleases')();
-      console.log(records.data);
-
       commit('setRecords', records.data);
     },
   },

--- a/src/views/ReleasesList.vue
+++ b/src/views/ReleasesList.vue
@@ -5,51 +5,43 @@
     >
       Latest Releases
     </h1>
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th
-            v-for="item in releasesColumns"
-            :key="item.title"
-            scope="col"
-            class="govuk-table__header"
-          >
-            {{ item.title }}
-          </th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <tr
-          v-for="item in releasesData"
-          :key="item.id"
-          class="govuk-table__row"
-        >
-          <th
-            scope="row"
-            class="govuk-table__header"
-          >
-            {{ item.title }}
-          </th>
-          <td class="govuk-table__cell">
-            {{ item.tag_name }}
-          </td>
-          <td class="govuk-table__cell">
-            {{ item.author }}
-          </td>
-          <td class="govuk-table__cell">
-            {{ formatDate(item.published_at) }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <Table
+      data-key="id"
+      :data="releasesData"
+      :page-size="50"
+      :columns="releasesColumns"
+      @change="getReleasesData"
+    >
+      <template #row="{row}">
+        <TableCell :title="releasesColumns[0].title">
+          {{ row.title }}
+        </TableCell>
+        <TableCell :title="releasesColumns[1].title">
+          {{ row.tag_name }}
+        </TableCell>
+        <TableCell :title="releasesColumns[2].title">
+          {{ row.author }}
+        </TableCell>
+        <TableCell :title="releasesColumns[3].title">
+          {{ row.published_at ? formatDate(row.published_at) : '' }}
+        </TableCell>
+      </template>
+    </Table>
   </div>
 </template>
 
 <script>
 import permissionMixin from '@/permissionMixin';
 import dayjs from 'dayjs';
+import Table from '@jac-uk/jac-kit/components/Table/Table.vue';
+import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
 
 export default {
+  name: 'ReleasesList',
+  components: {
+    Table,
+    TableCell,
+  },
   mixins: [permissionMixin],
   data() {
     return {

--- a/src/views/ReleasesList.vue
+++ b/src/views/ReleasesList.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <h1
+      class="govuk-heading-xl govuk-!-margin-bottom-6"
+    >
+      Latest Releases
+    </h1>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th
+            v-for="item in releasesColumns"
+            :key="item.title"
+            scope="col"
+            class="govuk-table__header"
+          >
+            {{ item.title }}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr
+          v-for="item in releasesData"
+          :key="item.id"
+          class="govuk-table__row"
+        >
+          <th
+            scope="row"
+            class="govuk-table__header"
+          >
+            {{ item.title }}
+          </th>
+          <td class="govuk-table__cell">
+            {{ item.tag_name }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ item.author }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ formatDate(item.published_at) }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import permissionMixin from '@/permissionMixin';
+import dayjs from 'dayjs';
+
+export default {
+  mixins: [permissionMixin],
+  data() {
+    return {
+      releasesColumns: [
+        { title: 'Repository' },
+        { title: 'Tag Name' },
+        { title: 'Author' },
+        { title: 'Published At' },
+      ],
+    };
+  },
+  computed: {
+    releasesData() {
+      return this.$store.state.releases.records;
+    },
+  },
+  created() {
+    this.$store.dispatch('releases/getLatestReleases');
+  },
+  methods: {
+    formatDate(dateStr) {
+      return dateStr ? dayjs(dateStr).format('DD/MM/YYYY HH:mm:ss') : '';
+    },
+    getReleasesData(params) {
+      this.$store.dispatch('releases/getLatestReleases', params);
+    },
+  },
+};
+</script>

--- a/src/views/ReleasesList.vue
+++ b/src/views/ReleasesList.vue
@@ -7,22 +7,22 @@
     </h1>
     <Table
       data-key="id"
-      :data="releasesData"
+      :data="tableData"
       :page-size="50"
-      :columns="releasesColumns"
-      @change="getReleasesData"
+      :columns="tableColumns"
+      @change="getTableData"
     >
       <template #row="{row}">
-        <TableCell :title="releasesColumns[0].title">
+        <TableCell :title="tableColumns[0].title">
           {{ row.title }}
         </TableCell>
-        <TableCell :title="releasesColumns[1].title">
+        <TableCell :title="tableColumns[1].title">
           {{ row.tag_name }}
         </TableCell>
-        <TableCell :title="releasesColumns[2].title">
+        <TableCell :title="tableColumns[2].title">
           {{ row.author }}
         </TableCell>
-        <TableCell :title="releasesColumns[3].title">
+        <TableCell :title="tableColumns[3].title">
           {{ row.published_at ? formatDate(row.published_at) : '' }}
         </TableCell>
       </template>
@@ -45,8 +45,8 @@ export default {
   mixins: [permissionMixin],
   data() {
     return {
-      releasesColumns: [
-        { title: 'Repository' },
+      tableColumns: [
+        { title: 'Repository', sort: 'title', direction: 'desc', default: true },
         { title: 'Tag Name' },
         { title: 'Author' },
         { title: 'Published At' },
@@ -54,7 +54,7 @@ export default {
     };
   },
   computed: {
-    releasesData() {
+    tableData() {
       return this.$store.state.releases.records;
     },
   },
@@ -65,7 +65,7 @@ export default {
     formatDate(dateStr) {
       return dateStr ? dayjs(dateStr).format('DD/MM/YYYY HH:mm:ss') : '';
     },
-    getReleasesData(params) {
+    getTableData(params) {
       this.$store.dispatch('releases/getLatestReleases', params);
     },
   },


### PR DESCRIPTION
## What's included?
Added new page and route for displaying the latest releases.
Added dedicated permission to view releases.
Optionally showing link to releases page if permission applies.

**This PR relies on the following PR being deployed on the Digital Platform: https://github.com/jac-uk/digital-platform/pull/1093**

Closes #2398 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Go to: https://jac-admin-develop--pr2405-feature-2398-display-bdzye2m7.web.app/

**Test 1**
- Login as a Digital Super User
- Go to the Exercises page
- Click on the releases link at the top of the page (see Figure 1 below)
- The Latest Releases page should open (see Figure 2 below)

**Test 1**
- Login as a user who is NOT a Digital Super User
- Go to the Exercises page
- If you click on the releases link at the top of the page nothing should happen (see Figure 1 below)

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

**Figure 1**

<img width="1242" alt="Screenshot 2024-05-22 at 12 35 42" src="https://github.com/jac-uk/admin/assets/115651787/6b2b73ad-52a9-4f3c-9242-e579a247aa2a">


**Figure 2**

<img width="1727" alt="Screenshot 2024-05-22 at 12 31 39" src="https://github.com/jac-uk/admin/assets/115651787/2aed5b4a-e8b9-4ce2-9180-aa15af5c91c6">


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
