### PR TITLE
Statuses for withdrawn candidates

### DIFF
--- a/src/store/application.js
+++ b/src/store/application.js
@@ -1,8 +1,9 @@
-import { collection, doc, updateDoc, setDoc, addDoc, serverTimestamp, runTransaction } from '@firebase/firestore';
+import { collection, doc, updateDoc, setDoc, getDoc, addDoc, serverTimestamp, runTransaction } from '@firebase/firestore';
 import { firestore } from '@/firebase';
 import { firestoreAction } from '@/helpers/vuexfireJAC';
 import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
-import { STATUS } from '@jac-uk/jac-kit/helpers/constants';
+// import { STATUS } from '@jac-uk/jac-kit/helpers/constants';
+import { getStageWithdrawalStatus } from '../helpers/exerciseHelper';
 import clone from 'clone';
 
 const collectionName = 'applications';
@@ -83,7 +84,7 @@ export default {
     withdraw: async (context, data ) => {
       const applicationId = data.applicationId;
 
-      await context.dispatch('update', { data: { status: STATUS.WITHDRAWN }, id: applicationId });
+      await context.dispatch('update', { data: { status: getStageWithdrawalStatus(context.rootState.exerciseDocument.record) }, id: applicationId });
 
       //  If IAs has started ensure relevant assessments documents are removed (soft deleted)
       context.dispatch('assessment/delete', { id: applicationId }, { root: true });
@@ -127,6 +128,11 @@ export default {
   getters: {
     data: (state) => () => {
       return clone(state.record);
+    },
+    exists: () => async (id) => {
+      const applicationRef = doc(firestore, 'applicationRecords', id);
+      const applicationDoc = await getDoc(applicationRef);
+      return applicationDoc.exists();
     },
   },
 };

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -652,14 +652,14 @@ export default {
         exerciseRef: this.exercise.referenceNumber,
       });
     },
-    // openModal(modalRef){
-    //   this.$refs[modalRef].openModal();
-    // },
-    // closeModal(modalRef) {
-    //   this.$refs[modalRef].closeModal();
-    // },
     async confirmWithdraw() {
-      await this.$store.dispatch('application/withdraw', { applicationId: this.applicationId }, { root: true });
+      const applicationExists = await this.$store.getters['application/exists'](this.applicationId);
+      if (applicationExists) {
+        this.$store.dispatch('applicationRecords/storeItems', { items: [this.applicationId] });
+        await this.$store.dispatch('applicationRecords/updateStatus', { status: 'withdrawn' });
+      } else {
+        await this.$store.dispatch('application/withdraw', { applicationId: this.applicationId }, { root: true });
+      }
       this.$refs.modalRefWithdrawApplication.closeModal();
     },
     changeApplication(obj) {

--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -83,6 +83,12 @@
           <span v-if="row._processing && row._processing.status">
             {{ $filters.lookup(row._processing.status) }}
           </span>
+          <span v-else-if="row.status">
+            {{ $filters.lookup(row.status) }}
+          </span>
+          <span v-else>
+            Error: No status
+          </span>
         </TableCell>
       </template>
     </Table>

--- a/src/views/Exercise/Stages/Edit.vue
+++ b/src/views/Exercise/Stages/Edit.vue
@@ -58,8 +58,8 @@
           :value="false"
           label="No - EMP has not been Applied"
         />
-      </RadioGroup>         
-    </Checkbox>     
+      </RadioGroup>
+    </Checkbox>
     <button class="govuk-button">
       Save and continue
     </button>


### PR DESCRIPTION
## What's included?
Updates to `store/application.js` so that a check for an accompanying `applicationRecord` can be accessed and used when withdrawing an application from the application view. 
Using this, the button now updates the withdrawn status to both if both exist, if not, only the application status is updated. 

## How to test?
Withdraw an application from an application view. Ensure that the status is updated and reflected in all application lists.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
![image](https://github.com/jac-uk/admin/assets/44227249/febffc89-754f-47c6-b7c1-f17ebad836dd)

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
