### PR TITLE
Signpost users to changes in Handover report

### DIFF
--- a/src/components/ModalViews/ReportInfo.vue
+++ b/src/components/ModalViews/ReportInfo.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="report-info">
+    <div class="modal__title govuk-!-padding-2 govuk-heading-m">
+      Report Info
+    </div>
+    <div class="modal__content govuk-!-margin-6">
+      <div class="govuk-grid-row">
+        <p class="govuk-body">
+          There are now two reports for JO. The new Handover report, which contains HR details of candidates only, and the new Deployment report, which contains Location and Jurisdiction details, where relevant, only.
+        </p>
+        <div class=" text-center">
+          <button
+            type="button"
+            class="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+            @click="closeModal"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  name: 'ReportInfo',
+  emits: ['close'],
+  methods: {
+    closeModal() {
+      this.$emit('close');
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  .modal .report-info .govuk-form-group,
+  .modal .report-info .govuk-inset-text {
+    text-align: left;
+  }
+  /*
+  .late-application .modal__title {
+    color: #ffffff;
+  }
+  */
+  .form-row {
+    margin-bottom: 1em;
+  }
+</style>

--- a/src/views/Exercise/Reports/Deployment.vue
+++ b/src/views/Exercise/Reports/Deployment.vue
@@ -3,7 +3,7 @@
     <div class="moj-page-header-actions">
       <div class="moj-page-header-actions__title">
         <h2 class="govuk-heading-l">
-          Deployment
+          Deployment Report - Location & Jurisdiction Details only
         </h2>
         <span
           v-if="report"
@@ -90,6 +90,11 @@
         </TableCell>
       </template>
     </Table>
+    <Modal
+      ref="infoModal"
+    >
+      <ReportInfo @close="closeModal" />
+    </Modal>
   </div>
 </template>
 
@@ -105,6 +110,8 @@ import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
 import { EXERCISE_STAGE, APPLICATION_STATUS } from '@jac-uk/jac-kit/helpers/constants';
 import permissionMixin from '@/permissionMixin';
+import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
+import ReportInfo from '@/components/ModalViews/ReportInfo.vue';
 
 export default {
   name: 'DeploymentReport',
@@ -112,6 +119,8 @@ export default {
     Table,
     TableCell,
     ActionButton,
+    Modal,
+    ReportInfo,
   },
   mixins: [permissionMixin],
   data() {
@@ -154,6 +163,9 @@ export default {
           this.report = vuexfireSerialize(snap);
         }
       });
+  },
+  mounted() {
+    this.openModal();
   },
   unmounted() {
     if (this.unsubscribe) {
@@ -204,6 +216,12 @@ export default {
           fileName: `${this.exercise.referenceNumber} - ${title}.xlsx`,
         }
       );
+    },
+    openModal() {
+      this.$refs.infoModal.openModal();
+    },
+    closeModal() {
+      this.$refs.infoModal.closeModal();
     },
   },
 };

--- a/src/views/Exercise/Reports/Handover.vue
+++ b/src/views/Exercise/Reports/Handover.vue
@@ -3,7 +3,7 @@
     <div class="moj-page-header-actions">
       <div class="moj-page-header-actions__title">
         <h2 class="govuk-heading-l">
-          Handover
+          Handover Report - HR Details only
         </h2>
       </div>
 
@@ -91,6 +91,12 @@
         </TableCell>
       </template>
     </Table>
+
+    <Modal
+      ref="infoModal"
+    >
+      <ReportInfo @close="closeModal" />
+    </Modal>
   </div>
 </template>
 
@@ -106,6 +112,8 @@ import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
 import { APPLICATION_STATUS } from '@jac-uk/jac-kit/helpers/constants';
 import permissionMixin from '@/permissionMixin';
+import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
+import ReportInfo from '@/components/ModalViews/ReportInfo.vue';
 
 export default {
   name: 'HandoverReport',
@@ -113,6 +121,8 @@ export default {
     Table,
     TableCell,
     ActionButton,
+    Modal,
+    ReportInfo,
   },
   mixins: [permissionMixin],
   data() {
@@ -149,6 +159,9 @@ export default {
           this.report = vuexfireSerialize(snap);
         }
       });
+  },
+  mounted() {
+    this.openModal();
   },
   unmounted() {
     if (this.unsubscribe) {
@@ -215,6 +228,12 @@ export default {
         },
         styles
       );
+    },
+    openModal() {
+      this.$refs.infoModal.openModal();
+    },
+    closeModal() {
+      this.$refs.infoModal.closeModal();
     },
   },
 };


### PR DESCRIPTION
## What's included?
Change titles on handover and deployment report pages and add modals with some info text.

Closes #2416 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
**Test 1**
- go to the handover page: https://jac-admin-develop--pr2418-feature-2416-signpos-mufjgmf7.web.app/exercise/fTacPXarp6IcSonlh2VH/reports/handover
- a popup should open immediately saying: "There are now two reports for JO. The new Handover report, which contains HR details of candidates only, and the new Deployment report, which contains Location and Jurisdiction details, where relevant, only."
- see that the title has changed to: "Handover Report - HR Details only"

**Test 2**
- go to the deployment page: https://jac-admin-develop--pr2418-feature-2416-signpos-mufjgmf7.web.app/exercise/fTacPXarp6IcSonlh2VH/reports/deployment
- a popup should open immediately saying: "There are now two reports for JO. The new Handover report, which contains HR details of candidates only, and the new Deployment report, which contains Location and Jurisdiction details, where relevant, only."
- see that the title has changed to: "Deployment Report - Location & Jurisdiction Details only"

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
