### PR TITLE
Feature/2419 Reference statuses in Independent Assessments task

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -179,6 +179,9 @@ const lookup = (value) => {
     pje: 'Previous Judicial Experience',
     pr: 'Professional Registration',
 
+    // application record blank status
+    'blank': 'Blank',
+
     // 'xxx': 'xxx',
     null: '[No Answer Provided]',
   };

--- a/src/store/applicationRecords.js
+++ b/src/store/applicationRecords.js
@@ -74,7 +74,7 @@ export default {
 
       if (
         data.stage ||
-        data.status === WITHDRAWAL_STATUS ||
+        data.status ||
         data['flags.empApplied'] != null
       ) {
         context.dispatch('exerciseDocument/refreshApplicationCounts', {}, { root: true });

--- a/src/views/Exercise/Tasks/IndependentAssessments.vue
+++ b/src/views/Exercise/Tasks/IndependentAssessments.vue
@@ -297,25 +297,26 @@
           ])"
         >
           <select
-            id="exercise-stage"
-            v-model="exerciseStage"
+            id="exercise-status"
+            v-model="exerciseStatus"
             class="govuk-select govuk-!-margin-right-3"
           >
             <option value="">
               Choose applications
             </option>
             <option
-              v-for="stage in availableStages"
-              :key="stage"
-              :value="stage"
+              v-for="availableStatus in availableStatuses"
+              :key="availableStatus"
+              :value="availableStatus"
             >
-              {{ $filters.lookup(stage) }} ({{ $filters.formatNumber(applicationRecordCounts[stage]) }})
+              {{ $filters.lookup(availableStatus) }}
+              ({{ applicationRecordCounts.status ? $filters.formatNumber(applicationRecordCounts.status[availableStatus]) : 0 }})
             </option>
           </select>
 
           <ActionButton
             type="primary"
-            :disabled="!exerciseStage"
+            :disabled="!exerciseStatus"
             :action="initialiseAssessments"
           >
             Start assessments
@@ -364,7 +365,7 @@ import Banner from '@jac-uk/jac-kit/draftComponents/Banner.vue';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
 import UploadAssessment from '@/components/ModalViews/UploadAssessment.vue';
 import IndependentAssessmentsRequests from '@/components/ModalViews/IndependentAssessmentsRequests.vue';
-import { isArchived, applicationRecordCounts, availableStages } from '@/helpers/exerciseHelper';
+import { isArchived, applicationRecordCounts, availableStatuses } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
 import TabsList from '@jac-uk/jac-kit/draftComponents/TabsList.vue';
 import { ASSESSOR_TYPES } from '@/helpers/constants';
@@ -412,7 +413,7 @@ export default {
     ];
 
     return {
-      exerciseStage: '',
+      exerciseStatus: '',
       uploadAsssessmentProps: {},
       tabs,
       activeTab: 'notrequested',
@@ -461,9 +462,9 @@ export default {
     applicationRecordCounts() {
       return applicationRecordCounts(this.exercise);
     },
-    availableStages() {
-      const stages = availableStages(this.exercise);
-      return stages.filter(stage => this.applicationRecordCounts[stage]);
+    availableStatuses() {
+      const statuses = availableStatuses(this.exercise);
+      return statuses.filter(status => this.applicationRecordCounts?.status[status]);
     },
     warningMessage() {
       let msg = 'Please add';
@@ -562,9 +563,9 @@ export default {
   },
   methods: {
     async initialiseAssessments() {
-      if (!this.exerciseStage) return;
+      if (!this.exerciseStatus) return;
       try {
-        await httpsCallable(functions, 'initialiseAssessments')({ exerciseId: this.exercise.id, stage: this.exerciseStage });
+        await httpsCallable(functions, 'initialiseAssessments')({ exerciseId: this.exercise.id, status: this.exerciseStatus });
         return true;
       } catch (error) {
         return;

--- a/src/views/Exercise/Tasks/IndependentAssessments.vue
+++ b/src/views/Exercise/Tasks/IndependentAssessments.vue
@@ -464,7 +464,7 @@ export default {
     },
     availableStatuses() {
       const statuses = availableStatuses(this.exercise);
-      return statuses.filter(status => this.applicationRecordCounts?.status[status]);
+      return statuses.filter(status => this.applicationRecordCounts?.status && this.applicationRecordCounts?.status[status]);
     },
     warningMessage() {
       let msg = 'Please add';

--- a/src/views/Exercise/Tasks/IndependentAssessments.vue
+++ b/src/views/Exercise/Tasks/IndependentAssessments.vue
@@ -463,8 +463,12 @@ export default {
       return applicationRecordCounts(this.exercise);
     },
     availableStatuses() {
-      const statuses = availableStatuses(this.exercise);
-      return statuses.filter(status => this.applicationRecordCounts?.status && this.applicationRecordCounts?.status[status]);
+      let statuses = availableStatuses(this.exercise);
+      statuses = statuses.filter(status => this.applicationRecordCounts?.status && this.applicationRecordCounts?.status[status]);
+      if (this.applicationRecordCounts?.status && this.applicationRecordCounts?.status['blank']) {
+        statuses.push('blank');
+      }
+      return statuses;
     },
     warningMessage() {
       let msg = 'Please add';


### PR DESCRIPTION
## What's included?
Closes #2419 

Related PRs:
- [digital-platform: Feature/admin 2419 Reference statuses in Independent Assessments task #1110](https://github.com/jac-uk/digital-platform/pull/1110)
- [digital-platform: Feature/admin 2419 Reference statuses in Independent Assessments task #1114](https://github.com/jac-uk/digital-platform/pull/1114)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example exercises: 
- [Ryan test 1 (Character issues)](https://jac-admin-develop--pr2420-feature-2419-referen-7tqgsgb3.web.app/exercise/IbeEVi4Vtrpv9eVFzhZq/tasks/all/independent-assessments)
- [Ryan test 2 (Character issues)](https://jac-admin-develop--pr2420-feature-2419-referen-7tqgsgb3.web.app/exercise/FpV4enhw0yWFb9htWO7y/tasks/all/independent-assessments)
- [Ryan test 3 (Character issues)](https://jac-admin-develop--pr2420-feature-2419-referen-7tqgsgb3.web.app/exercise/DVGGSXxY0MdhbehA1R98/tasks/all/independent-assessments)
- [Ryan test 4 (Character issues)](https://jac-admin-develop--pr2420-feature-2419-referen-7tqgsgb3.web.app/exercise/XEu94ZOPGM1PRZuEhUdH/tasks/all/independent-assessments)
- [Ryan test 5 (Character issues)](https://jac-admin-develop--pr2420-feature-2419-referen-7tqgsgb3.web.app/exercise/g45SG9vPFlhInL6yDonh/tasks/all/independent-assessments)

Steps:
1. Go to the Independent Assessments task.
2. Check if the options and counts in the dropdown are generated based on the application statuses.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/admin/assets/79906532/2ed7b9f8-b25c-479d-acec-15ffa3448ca9

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
