### PR TITLE
2413/ra task page improve

### DIFF
--- a/src/views/Exercise/Reports/ReasonableAdjustments.vue
+++ b/src/views/Exercise/Reports/ReasonableAdjustments.vue
@@ -35,10 +35,6 @@
       </div>
     </div>
 
-    <div class="govuk-grid-row">
-      {{ applicationRecordCounts }}
-    </div>
-
     <div
       v-if="report != null"
       class="govuk-grid-row"
@@ -83,7 +79,7 @@
             :key="status"
             :value="status"
           >
-            {{ $filters.lookup(status) }} ({{ $filters.formatNumber(applicationRecordCounts[status]) }})
+            {{ $filters.lookup(status) }}
           </option>
         </Select>
       </div>

--- a/src/views/Exercise/Reports/ReasonableAdjustments.vue
+++ b/src/views/Exercise/Reports/ReasonableAdjustments.vue
@@ -42,7 +42,7 @@
       <div class="govuk-grid-column-one-half">
         <div class="panel govuk-!-margin-bottom-9">
           <span class="govuk-caption-m">
-            Applications requiring RA
+            Total Reasonable adjustment requests
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
             {{ $filters.formatNumber(report.totalApplications) }}
@@ -52,10 +52,10 @@
       <div class="govuk-grid-column-one-half">
         <div class="panel govuk-!-margin-bottom-9">
           <span class="govuk-caption-m">
-            Reasonable adjustments requests
+            Total Reasonable adjustment requests actioned
           </span>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ $filters.formatNumber(report.rows.length) }}
+            {{ $filters.formatNumber(totalActioned) }}
           </h2>
         </div>
       </div>
@@ -493,6 +493,7 @@ export default {
       open: {},
       otherApplicationRecords: [],
       report: null,
+      totalActioned: 0,
     };
   },
   computed: {
@@ -524,6 +525,9 @@ export default {
     },
     candidateStatus: function() {
       this.$refs['issuesTable'].reload();
+    },
+    applicationRecords: function () {
+      this.totalActioned = this.applicationRecords.filter(appRec => appRec.candidate.reasonableAdjustmentsActioned).length;
     },
   },
   created() {


### PR DESCRIPTION
## What's included?

- Address display issues (overlapping of application id and email, by removing application id and instead linking to application from name field) 
- Include blank options for `RA applies to` and `RA allocated` dropdowns so that Admins can 'deselect' any options they have chosen
- The total applications number is was not correct - it was displaying equal the number of candidates requiring RAs instead, field now labelled correctly
- Remove the Stages filter
- Add 'Mark all candidates as unactioned' button 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Visit an RA report page, and ensure the listed changes are present and the unaction candidates button works as expected.

## Risk - how likely is this to impact other areas?
🟢 Low risk

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
