### PR TITLE
2422/eligib v2 improve

### DIFF
--- a/src/views/Exercise/Reports/EligibilityIssuesV2.vue
+++ b/src/views/Exercise/Reports/EligibilityIssuesV2.vue
@@ -248,7 +248,7 @@ import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
 import { debounce } from 'lodash';
 import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox.vue';
 import { downloadBase64File } from '@/helpers/file';
-// import { APPLICATION_STATUS } from '@/helpers/constants';
+import { APPLICATION_STATUS } from '@/helpers/constants';
 
 export default {
   name: 'EligibilityIssuesV2',
@@ -276,8 +276,7 @@ export default {
       showNotMet: false,
       statutoryTypes: ['pq', 'pqe'],
       nonStatutoryTypes: ['pje', 'rls'],
-      applicationStatusOptions: ['shortlistingOutcomePassed'],
-      // APPLICATION_STATUS,
+      applicationStatusOptions: APPLICATION_STATUS,
     };
   },
   computed: {

--- a/src/views/Exercise/Reports/EligibilityIssuesV2.vue
+++ b/src/views/Exercise/Reports/EligibilityIssuesV2.vue
@@ -248,7 +248,7 @@ import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
 import { debounce } from 'lodash';
 import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox.vue';
 import { downloadBase64File } from '@/helpers/file';
-import { APPLICATION_STATUS } from '@/helpers/constants';
+import { availableStatuses } from '@/helpers/exerciseHelper';
 
 export default {
   name: 'EligibilityIssuesV2',
@@ -276,10 +276,12 @@ export default {
       showNotMet: false,
       statutoryTypes: ['pq', 'pqe'],
       nonStatutoryTypes: ['pje', 'rls'],
-      applicationStatusOptions: APPLICATION_STATUS,
     };
   },
   computed: {
+    applicationStatusOptions(){
+      return [...availableStatuses(this.exercise), ...''];
+    },
     exercise() {
       return this.$store.state.exerciseDocument.record;
     },

--- a/src/views/Exercise/Reports/EligibilityIssuesV2.vue
+++ b/src/views/Exercise/Reports/EligibilityIssuesV2.vue
@@ -122,7 +122,11 @@
               <div class="govuk-grid-column-two-thirds">
                 <div class="candidate-name govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-0">
                   {{ row.referenceNumber }}
-                  <span v-if="row.candidate">{{ row.candidate.fullName }}</span>
+                  <span v-if="row.candidate">{{ row.candidate.fullName }}
+                    <span class="govuk-caption-m">
+                      {{ $filters.lookup(row.status) }}
+                    </span>
+                  </span>
                 </div>
               </div>
               <div class="govuk-grid-column-one-third text-right  govuk-!-margin-top-8 govuk-!-margin-bottom-0">
@@ -135,7 +139,6 @@
                 </RouterLink>
               </div>
             </div>
-
             <!-- statutory eligibility issues -->
             <div
               v-for="(issueGroup, issueGroupIndex) in row.issueGroups"
@@ -171,7 +174,6 @@
                     <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">
                       Candidate comments:
                     </h4>
-                    {{ issue }}
                     {{ issue.candidateComments || '' }}
                   </div>
                 </div>
@@ -352,7 +354,7 @@ export default {
     },
     async gatherReportData() {
       // fetch data
-      const response = await httpsCallable(functions, 'exportApplicationEligibilityIssues')({ exerciseId: this.exercise.id, format: 'excel' });
+      const response = await httpsCallable(functions, 'exportApplicationEligibilityIssues')({ exerciseId: this.exercise.id, format: 'annex', status: this.filterStatus === 'all' ? null : this.filterStatus });
       const reportData = [];
       // get headers
       reportData.push(response.data.headers.map(header => header.title));
@@ -413,7 +415,7 @@ export default {
     async downloadSCCAnnexReport() {
       if (!this.exercise.referenceNumber) return; // abort if no ref
       try {
-        const result = await httpsCallable(functions, 'exportApplicationEligibilityIssues')({ exerciseId: this.exercise.id, format: 'annex' });
+        const result = await httpsCallable(functions, 'exportApplicationEligibilityIssues')({ exerciseId: this.exercise.id, format: 'annex', status: this.filterStatus === 'all' ? null : this.filterStatus });
         if (!result.data) return;
         downloadBase64File(
           'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/src/views/Exercise/Reports/EligibilityIssuesV2.vue
+++ b/src/views/Exercise/Reports/EligibilityIssuesV2.vue
@@ -280,7 +280,7 @@ export default {
   },
   computed: {
     applicationStatusOptions(){
-      return [...availableStatuses(this.exercise), ...''];
+      return availableStatuses(this.exercise);
     },
     exercise() {
       return this.$store.state.exerciseDocument.record;


### PR DESCRIPTION
## What's included?

- Add a status dropdown filter at the top of the screen
- Only candidates with the selected status should be displayed onscreen
- Only candidates with the selected status should be included in the report

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
[[Here]](https://jac-admin-develop--pr2426-2422-eligib-v2-impro-cdxiwph3.web.app/exercise/X2tDg5AKt18xvzBRJFYW/reports/eligibility-issues)

Observe the new filter - ensure that it correctly displays only candidates with the selected status. 
Candidates status shows under their name - if they have no status, no status should appear.
 ## note downloads will only work as set out in the ticket when [this digital platform ticket](https://github.com/jac-uk/digital-platform/pull/1119) is deployed or merged and released.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
🟠 Medium risk - this does change code that is shared with other areas
🔴 High risk - this includes a lot of changes to shared code

## Additional context

https://github.com/jac-uk/admin/assets/44227249/442a1acb-ed7e-4915-91f3-5d183e84331f

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
