### PR TITLE
Feature/2392 Limit Z-score banding calculation to 2 decimal places

### DIFF
--- a/src/views/Exercise/Tasks/Task/Finalised.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised.vue
@@ -154,11 +154,7 @@ export default {
       // group scores
       const scoreMap = {};
       this.task.finalScores.forEach(scoreData => { // id | panelId | ref | score | scoreSheet
-        if (this.scoreType === 'zScore') {
-          let val = parseFloat(scoreData[this.scoreType]).toFixed(2);
-          if (val === '-0.00') val = '0.00';
-          scoreData[this.scoreType] = val;
-        }
+        scoreData[this.scoreType] = this.formatScore(this.scoreType, scoreData[this.scoreType]);
         if (!scoreMap[scoreData[this.scoreType]]) {
           scoreMap[scoreData[this.scoreType]] = {
             applicationIds: [],
@@ -216,10 +212,7 @@ export default {
       // add outcome stats
       if (this.task.hasOwnProperty('passMark')) {
         scoresInDescendingOrder.forEach(key => {
-          let score = parseFloat(key);
-          if (this.scoreType === 'zScore') {
-            score = score.toFixed(2);
-          }
+          const score = this.formatScore(this.scoreType, key);
           if (score >= this.task.passMark) {
             if (this.task.overrides && this.task.overrides.fail) {
               const failMatches = this.task.overrides.fail.filter(id => scoreMap[score].applicationIds.indexOf(id) >= 0);
@@ -300,6 +293,14 @@ export default {
       const failed = CAT.applications.filter(item => failedIDs.indexOf(item.id) >= 0);
       downloadMeritList(didNotTake, failed, this.task, this.exerciseDiversity, saveData.type, fileName);
       this.$refs['exportModal'].closeModal();
+    },
+    formatScore(type, score) {
+      let val = parseFloat(score);
+      if (type === 'zScore') {
+        val = val.toFixed(2); // 2 decimal places
+        if (val === '-0.00') val = '0.00';
+      }
+      return val;
     },
     async setPassMark(data) {
       if (data) {

--- a/src/views/Exercise/Tasks/Task/Finalised.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised.vue
@@ -154,6 +154,11 @@ export default {
       // group scores
       const scoreMap = {};
       this.task.finalScores.forEach(scoreData => { // id | panelId | ref | score | scoreSheet
+        if (this.scoreType === 'zScore') {
+          let val = parseFloat(scoreData[this.scoreType]).toFixed(2);
+          if (val === '-0.00') val = '0.00';
+          scoreData[this.scoreType] = val;
+        }
         if (!scoreMap[scoreData[this.scoreType]]) {
           scoreMap[scoreData[this.scoreType]] = {
             applicationIds: [],
@@ -211,7 +216,10 @@ export default {
       // add outcome stats
       if (this.task.hasOwnProperty('passMark')) {
         scoresInDescendingOrder.forEach(key => {
-          const score = parseFloat(key);
+          let score = parseFloat(key);
+          if (this.scoreType === 'zScore') {
+            score = score.toFixed(2);
+          }
           if (score >= this.task.passMark) {
             if (this.task.overrides && this.task.overrides.fail) {
               const failMatches = this.task.overrides.fail.filter(id => scoreMap[score].applicationIds.indexOf(id) >= 0);

--- a/src/views/Exercise/Tasks/Task/Finalised.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised.vue
@@ -245,7 +245,8 @@ export default {
       if (!this.scores.length) return 0;
       if (!this.task) return 0;
       if (!this.task.passMark) return 0;
-      const scoreData = this.scores.find(scoreData => scoreData.score === this.task.passMark);
+      const scoreData = this.scores.find(scoreData => scoreData.score === this.formatScore(this.scoreType, this.task.passMark));
+      if (!scoreData) return 0;
       let total = scoreData.rank + scoreData.count - 1;
       if (this.task.overrides) {
         if (this.task.overrides.fail && this.task.overrides.fail.length) {
@@ -299,6 +300,7 @@ export default {
       if (type === 'zScore') {
         val = val.toFixed(2); // 2 decimal places
         if (val === '-0.00') val = '0.00';
+        return parseFloat(val);
       }
       return val;
     },


### PR DESCRIPTION
## What's included?
Closes #2392

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example exercise: https://jac-admin-develop--pr2430-feature-2392-limit-z-9rdeeby0.web.app/exercise/NmzLHCZMAsKjH3GwrCxb/tasks/all/qualifyingTest/finalised/

1. Go to "QT Merit List".
2. Check if a single band for each z-score rounded up to 2 decimal places displays in the table.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
