### PR TITLE
Feature/2455 Add blank option to status filter menu on Character report page

### DIFF
--- a/src/views/Exercise/Reports/CharacterIssues.vue
+++ b/src/views/Exercise/Reports/CharacterIssues.vue
@@ -683,7 +683,7 @@ export default {
         }
         localParams.orderBy = ['status', 'documentId'];
       } else {
-        firestoreRef = query(firestoreRef, where('status', '==', candidateStatus));
+        firestoreRef = query(firestoreRef, where('status', '==', candidateStatus === 'blank' ? '' : candidateStatus));
         localParams.orderBy = 'documentId';
       }
       const res = await tableAsyncQuery(this.applicationRecords, firestoreRef, localParams, null);

--- a/src/views/Exercise/Reports/CharacterIssues.vue
+++ b/src/views/Exercise/Reports/CharacterIssues.vue
@@ -564,15 +564,11 @@ export default {
     },
     availableStages() {
       const stageCounts = this.applicationStageCounts || {};
-      return Object.entries(stageCounts)
-        .filter(([,count]) => count > 0)
-        .map(([stage]) => stage);
+      return Object.keys(stageCounts).filter(status => stageCounts[status] > 0);
     },
     availableStatuses() {
       const statusCounts = this.applicationStatusCounts[this.exerciseStage] || {};
-      const statuses = Object.entries(statusCounts)
-        .filter(([,count]) => count > 0)
-        .map(([status]) => status);
+      const statuses = Object.keys(statusCounts).filter(status => statusCounts[status] > 0);
       const blankStatusIndex = statuses.indexOf('blank');
       if (blankStatusIndex > -1) {
         // move 'blank' to the end of the list

--- a/src/views/Exercise/Reports/CharacterIssues.vue
+++ b/src/views/Exercise/Reports/CharacterIssues.vue
@@ -570,9 +570,15 @@ export default {
     },
     availableStatuses() {
       const statusCounts = this.applicationStatusCounts[this.exerciseStage] || {};
-      return Object.entries(statusCounts)
+      const statuses = Object.entries(statusCounts)
         .filter(([,count]) => count > 0)
         .map(([status]) => status);
+      const blankStatusIndex = statuses.indexOf('blank');
+      if (blankStatusIndex > -1) {
+        // move 'blank' to the end of the list
+        return [...statuses.filter((_, index) => index !== blankStatusIndex), 'blank'];
+      }
+      return statuses;
     },
   },
   watch: {


### PR DESCRIPTION
## What's included?
Closes #2455 

Related PR: [digital-platform: Feature/admin 2455 Add blank option to status filter menu on Character report page #1120](https://github.com/jac-uk/digital-platform/pull/1120)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example exercise: [Ryan test 1 (Character issues)](https://jac-admin-develop--pr2456-feature-2455-add-bla-k48oo9hx.web.app/exercise/IbeEVi4Vtrpv9eVFzhZq/reports/character-issues)

1. Go to the "Character Issues" report.
2. Check if the "Blank" status appears in the status dropdown.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Screenshot:

<img width="1208" alt="Screenshot 2024-06-24 at 13 45 31" src="https://github.com/jac-uk/admin/assets/79906532/5f326b68-89ab-44da-bc24-1c91b496ef69">

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
