### PR TITLE
Feat/2423 align admin with section 2d3d qualifications changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "admin",
       "version": "1.45.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "4.1.12",
+        "@jac-uk/jac-kit": "4.1.13",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.61.1",
         "@sentry/vue": "^7.61.1",
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "4.1.12",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.12/c8cfc2377238996c71f496e2ac2ab3253967fbed",
-      "integrity": "sha512-qvPX1l5f/NsKJxWS6XVsbDmn96AWYvhRNSYpr4lwu+W6YlE5SJSv0rlpcWwFBDYc19HN/RFdXkK3zc5fg1Iflw==",
+      "version": "4.1.13",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.13/3a52b2f89a7c0367fe5ca25e8cac398bd293945e",
+      "integrity": "sha512-UPO079gE8gQvaK5Q+ETGMEEyyhdhaApmH5gm6x0t5NdmCir4wWURTNOVU8/1+9pSmcvPluf60KU9zDqOw92WGw==",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "4.1.12",
+    "@jac-uk/jac-kit": "4.1.13",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.61.1",
     "@sentry/vue": "^7.61.1",

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -29,7 +29,10 @@
                   :options="[true, false]"
                   type="selection"
                   :is-asked="isApplicationPartAsked('relevantQualifications')"
-                  @change-field="changeQualificationOrMembership"
+                  @change-field="(changes) => {
+                    changeQualificationSchedule()
+                    changeQualificationOrMembership(changes)
+                  }"
                 />
               </dd>
             </div>
@@ -49,7 +52,10 @@
                   :options="[true, false]"
                   type="selection"
                   :is-asked="isApplicationPartAsked('relevantQualifications')"
-                  @change-field="changeQualificationOrMembership"
+                  @change-field="(changes) => {
+                    changeQualificationSchedule()
+                    changeQualificationOrMembership(changes)
+                  }"
                 />
               </dd>
             </div>
@@ -1106,6 +1112,12 @@ export default {
 
       this.$refs.removeModal.closeModal();
 
+    },
+    changeQualificationSchedule() {
+      // reset all qualifications
+      this.$emit('updateApplication', {
+        qualifications: this.application.qualifications.map(q => { return { ...q, type: null };}),
+      });
     },
     changeQualificationOrMembership(obj) {
       let changedObj = this.application[obj.field] || {};

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -981,7 +981,7 @@ export default {
         details: null,
       },
       currentIndex: null,
-      applyingSchedule: false,
+      scheduleApplies: false,
     };
   },
   computed: {
@@ -994,7 +994,7 @@ export default {
     },
     qualificationOptions() {
       const options = this.exercise.otherQualifications ? [...['advocate-scotland', 'barrister', 'CILEx', 'solicitor'], this.exercise.otherQualifications] : ['advocate-scotland', 'barrister', 'CILEx', 'solicitor'];
-      if (this.applyingSchedule) {
+      if (this.scheduleApplies) {
         options.push('no-legal-qualification');
       }
 
@@ -1044,10 +1044,6 @@ export default {
 
       return selected;
     },
-    scheduleApplies(){
-      return (this.exercise.appliedSchedule == 'schedule-2-3' && this.application.applyingUnderSchedule2Three) ||
-        (this.exercise.appliedSchedule == 'schedule-2-d' && this.application.applyingUnderSchedule2d);
-    },
     notCompletedPupillage() {
       if (_has(this.application, 'qualifications') && Array.isArray(this.application.qualifications)) {
         const matches = this.application.qualifications.filter(qualification => {
@@ -1061,7 +1057,7 @@ export default {
     },
   },
   mounted() {
-    this.applyingSchedule = this.application.applyingUnderSchedule2Three || this.application.applyingUnderSchedule2d;
+    this.scheduleApplies = this.application.applyingUnderSchedule2Three || this.application.applyingUnderSchedule2d;
   },
   methods: {
     membershipNumberLabel(type) {
@@ -1176,7 +1172,7 @@ export default {
       return isApplicationPartAsked(this.exercise, part);
     },
     scheduleInput(event) {
-      this.applyingSchedule = event.target.value.toLowerCase() === 'true';
+      this.scheduleApplies = event.target.value.toLowerCase() === 'true';
     },
   },
 };

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -29,10 +29,10 @@
                 type="selection"
                 :is-asked="isApplicationPartAsked('relevantQualifications')"
                 @change-field="(changes) => {
-                  console.log('section changed')
                   changeQualificationSchedule()
                   changeQualificationOrMembership(changes)
                 }"
+                @input="scheduleInput"
               />
             </dd>
           </div>
@@ -56,6 +56,7 @@
                   changeQualificationSchedule()
                   changeQualificationOrMembership(changes)
                 }"
+                @input="scheduleInput"
               />
             </dd>
           </div>
@@ -980,6 +981,7 @@ export default {
         details: null,
       },
       currentIndex: null,
+      applyingSchedule: false,
     };
   },
   computed: {
@@ -992,7 +994,7 @@ export default {
     },
     qualificationOptions() {
       const options = this.exercise.otherQualifications ? [...['advocate-scotland', 'barrister', 'CILEx', 'solicitor'], this.exercise.otherQualifications] : ['advocate-scotland', 'barrister', 'CILEx', 'solicitor'];
-      if (this.application.applyingUnderSchedule2Three) {
+      if (this.applyingSchedule) {
         options.push('no-legal-qualification');
       }
 
@@ -1057,6 +1059,9 @@ export default {
       }
       return null;
     },
+  },
+  mounted() {
+    this.applyingSchedule = this.application.applyingUnderSchedule2Three || this.application.applyingUnderSchedule2d;
   },
   methods: {
     membershipNumberLabel(type) {
@@ -1169,6 +1174,9 @@ export default {
     },
     isApplicationPartAsked(part) {
       return isApplicationPartAsked(this.exercise, part);
+    },
+    scheduleInput(event) {
+      this.applyingSchedule = event.target.value.toLowerCase() === 'true';
     },
   },
 };

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -8,6 +8,87 @@
         Qualifications
       </h2>
       <div v-if="applicationHasQualifications">
+        <!-- applied schedules -->
+        <div>
+          <dl
+            v-if="exercise.schedule2Apply"
+            class="govuk-summary-list govuk-!-margin-bottom-0"
+          >
+            <div
+              v-if="exercise.appliedSchedule == 'schedule-2-3'"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key widerColumn">
+                Are you applying under Schedule 2(3)?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <InformationReviewRenderer
+                  :data="application.applyingUnderSchedule2Three"
+                  field="applyingUnderSchedule2Three"
+                  :edit="editable"
+                  :options="[true, false]"
+                  type="selection"
+                  :is-asked="isApplicationPartAsked('relevantQualifications')"
+                  @change-field="changeQualificationOrMembership"
+                />
+              </dd>
+            </div>
+
+            <div
+              v-if="exercise.appliedSchedule == 'schedule-2-d'"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key widerColumn">
+                Are you applying under Schedule 2(d)?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <InformationReviewRenderer
+                  :data="application.applyingUnderSchedule2d"
+                  field="applyingUnderSchedule2d"
+                  :edit="editable"
+                  :options="[true, false]"
+                  type="selection"
+                  :is-asked="isApplicationPartAsked('relevantQualifications')"
+                  @change-field="changeQualificationOrMembership"
+                />
+              </dd>
+            </div>
+          </dl>
+
+          <dl
+            v-if="scheduleApplies"
+            class="govuk-summary-list govuk-!-margin-bottom-8"
+          >
+            <dt
+              class="govuk-summary-list__key widerColumn"
+            >
+              Explain how you've gained experience in law.
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <ul class="govuk-list">
+                <li v-if="exercise.appliedSchedule=='schedule-2-3'">
+                  <InformationReviewRenderer
+                    :data="application.experienceUnderSchedule2Three"
+                    field="experienceUnderSchedule2Three"
+                    :edit="editable"
+                    :is-asked="isApplicationPartAsked('relevantQualifications')"
+                    @change-field="changeQualificationOrMembership"
+                  />
+                </li>
+                <li v-if="exercise.appliedSchedule=='schedule-2-d'">
+                  <InformationReviewRenderer
+                    :data="application.experienceUnderSchedule2D"
+                    field="experienceUnderSchedule2D"
+                    :edit="editable"
+                    :is-asked="isApplicationPartAsked('relevantQualifications')"
+                    @change-field="changeQualificationOrMembership"
+                  />
+                </li>
+              </ul>
+            </dd>
+          </dl>
+        </div>
+
         <dl
           v-for="(qualification, index) in application.qualifications"
           :key="qualification.name"
@@ -306,86 +387,7 @@
         />
       </Modal>
     </div>
-    <!-- applied schedules -->
-    <div>
-      <dl
-        v-if="exercise.schedule2Apply"
-        class="govuk-summary-list govuk-!-margin-bottom-0"
-      >
-        <div
-          v-if="exercise.appliedSchedule == 'schedule-2-3'"
-          class="govuk-summary-list__row"
-        >
-          <dt class="govuk-summary-list__key widerColumn">
-            Are you applying under Schedule 2(3)?
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <InformationReviewRenderer
-              :data="application.applyingUnderSchedule2Three"
-              field="applyingUnderSchedule2Three"
-              :edit="editable"
-              :options="[true, false]"
-              type="selection"
-              :is-asked="isApplicationPartAsked('relevantQualifications')"
-              @change-field="changeQualificationOrMembership"
-            />
-          </dd>
-        </div>
 
-        <div
-          v-if="exercise.appliedSchedule == 'schedule-2-d'"
-          class="govuk-summary-list__row"
-        >
-          <dt class="govuk-summary-list__key widerColumn">
-            Are you applying under Schedule 2(d)?
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <InformationReviewRenderer
-              :data="application.applyingUnderSchedule2d"
-              field="applyingUnderSchedule2d"
-              :edit="editable"
-              :options="[true, false]"
-              type="selection"
-              :is-asked="isApplicationPartAsked('relevantQualifications')"
-              @change-field="changeQualificationOrMembership"
-            />
-          </dd>
-        </div>
-      </dl>
-
-      <dl
-        v-if="scheduleApplies"
-        class="govuk-summary-list govuk-!-margin-bottom-8"
-      >
-        <dt
-          class="govuk-summary-list__key widerColumn"
-        >
-          Explain how you've gained experience in law.
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <ul class="govuk-list">
-            <li v-if="exercise.appliedSchedule=='schedule-2-3'">
-              <InformationReviewRenderer
-                :data="application.experienceUnderSchedule2Three"
-                field="experienceUnderSchedule2Three"
-                :edit="editable"
-                :is-asked="isApplicationPartAsked('relevantQualifications')"
-                @change-field="changeQualificationOrMembership"
-              />
-            </li>
-            <li v-if="exercise.appliedSchedule=='schedule-2-d'">
-              <InformationReviewRenderer
-                :data="application.experienceUnderSchedule2D"
-                field="experienceUnderSchedule2D"
-                :edit="editable"
-                :is-asked="isApplicationPartAsked('relevantQualifications')"
-                @change-field="changeQualificationOrMembership"
-              />
-            </li>
-          </ul>
-        </dd>
-      </dl>
-    </div>
     <!-- memberships + professional Memberships -->
     <div
       v-if="hasRelevantMemberships"
@@ -983,7 +985,12 @@ export default {
       }
     },
     qualificationOptions() {
-      return this.exercise.otherQualifications ? [...['advocate-scotland', 'barrister', 'CILEx', 'solicitor'], this.exercise.otherQualifications] : ['advocate-scotland', 'barrister', 'CILEx', 'solicitor'];
+      const options = this.exercise.otherQualifications ? [...['advocate-scotland', 'barrister', 'CILEx', 'solicitor'], this.exercise.otherQualifications] : ['advocate-scotland', 'barrister', 'CILEx', 'solicitor'];
+      if (this.application.applyingUnderSchedule2Three) {
+        options.push('no-legal-qualification');
+      }
+
+      return options;
     },
     exercise() {
       return this.$store.state.exerciseDocument.record;

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -7,94 +7,94 @@
       >
         Qualifications
       </h2>
-      <div v-if="applicationHasQualifications">
-        <!-- applied schedules -->
-        <div>
-          <dl
-            v-if="exercise.schedule2Apply"
-            class="govuk-summary-list govuk-!-margin-bottom-0"
+      <!-- applied schedules -->
+      <div>
+        <dl
+          v-if="exercise.schedule2Apply"
+          class="govuk-summary-list govuk-!-margin-bottom-0"
+        >
+          <div
+            v-if="exercise.appliedSchedule == 'schedule-2-3'"
+            class="govuk-summary-list__row"
           >
-            <div
-              v-if="exercise.appliedSchedule == 'schedule-2-3'"
-              class="govuk-summary-list__row"
-            >
-              <dt class="govuk-summary-list__key widerColumn">
-                Are you applying under Schedule 2(3)?
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <InformationReviewRenderer
-                  :data="application.applyingUnderSchedule2Three"
-                  field="applyingUnderSchedule2Three"
-                  :edit="editable"
-                  :options="[true, false]"
-                  type="selection"
-                  :is-asked="isApplicationPartAsked('relevantQualifications')"
-                  @change-field="(changes) => {
-                    changeQualificationSchedule()
-                    changeQualificationOrMembership(changes)
-                  }"
-                />
-              </dd>
-            </div>
-
-            <div
-              v-if="exercise.appliedSchedule == 'schedule-2-d'"
-              class="govuk-summary-list__row"
-            >
-              <dt class="govuk-summary-list__key widerColumn">
-                Are you applying under Schedule 2(d)?
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <InformationReviewRenderer
-                  :data="application.applyingUnderSchedule2d"
-                  field="applyingUnderSchedule2d"
-                  :edit="editable"
-                  :options="[true, false]"
-                  type="selection"
-                  :is-asked="isApplicationPartAsked('relevantQualifications')"
-                  @change-field="(changes) => {
-                    changeQualificationSchedule()
-                    changeQualificationOrMembership(changes)
-                  }"
-                />
-              </dd>
-            </div>
-          </dl>
-
-          <dl
-            v-if="scheduleApplies"
-            class="govuk-summary-list govuk-!-margin-bottom-8"
-          >
-            <dt
-              class="govuk-summary-list__key widerColumn"
-            >
-              Explain how you've gained experience in law.
+            <dt class="govuk-summary-list__key widerColumn">
+              Are you applying under Schedule 2(3)?
             </dt>
             <dd class="govuk-summary-list__value">
-              <ul class="govuk-list">
-                <li v-if="exercise.appliedSchedule=='schedule-2-3'">
-                  <InformationReviewRenderer
-                    :data="application.experienceUnderSchedule2Three"
-                    field="experienceUnderSchedule2Three"
-                    :edit="editable"
-                    :is-asked="isApplicationPartAsked('relevantQualifications')"
-                    @change-field="changeQualificationOrMembership"
-                  />
-                </li>
-                <li v-if="exercise.appliedSchedule=='schedule-2-d'">
-                  <InformationReviewRenderer
-                    :data="application.experienceUnderSchedule2D"
-                    field="experienceUnderSchedule2D"
-                    :edit="editable"
-                    :is-asked="isApplicationPartAsked('relevantQualifications')"
-                    @change-field="changeQualificationOrMembership"
-                  />
-                </li>
-              </ul>
+              <InformationReviewRenderer
+                :data="application.applyingUnderSchedule2Three"
+                field="applyingUnderSchedule2Three"
+                :edit="editable"
+                :options="[true, false]"
+                type="selection"
+                :is-asked="isApplicationPartAsked('relevantQualifications')"
+                @change-field="(changes) => {
+                  console.log('section changed')
+                  changeQualificationSchedule()
+                  changeQualificationOrMembership(changes)
+                }"
+              />
             </dd>
-          </dl>
-        </div>
+          </div>
 
+          <div
+            v-if="exercise.appliedSchedule == 'schedule-2-d'"
+            class="govuk-summary-list__row"
+          >
+            <dt class="govuk-summary-list__key widerColumn">
+              Are you applying under Schedule 2(d)?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <InformationReviewRenderer
+                :data="application.applyingUnderSchedule2d"
+                field="applyingUnderSchedule2d"
+                :edit="editable"
+                :options="[true, false]"
+                type="selection"
+                :is-asked="isApplicationPartAsked('relevantQualifications')"
+                @change-field="(changes) => {
+                  changeQualificationSchedule()
+                  changeQualificationOrMembership(changes)
+                }"
+              />
+            </dd>
+          </div>
+        </dl>
+
+        <dl
+          v-if="scheduleApplies"
+          class="govuk-summary-list govuk-!-margin-bottom-8"
+        >
+          <dt
+            class="govuk-summary-list__key widerColumn"
+          >
+            Explain how you've gained experience in law.
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <ul class="govuk-list">
+              <li v-if="exercise.appliedSchedule=='schedule-2-3'">
+                <InformationReviewRenderer
+                  :data="application.experienceUnderSchedule2Three"
+                  field="experienceUnderSchedule2Three"
+                  :edit="editable"
+                  :is-asked="isApplicationPartAsked('relevantQualifications')"
+                  @change-field="changeQualificationOrMembership"
+                />
+              </li>
+              <li v-if="exercise.appliedSchedule=='schedule-2-d'">
+                <InformationReviewRenderer
+                  :data="application.experienceUnderSchedule2D"
+                  field="experienceUnderSchedule2D"
+                  :edit="editable"
+                  :is-asked="isApplicationPartAsked('relevantQualifications')"
+                  @change-field="changeQualificationOrMembership"
+                />
+              </li>
+            </ul>
+          </dd>
+        </dl>
+      </div>
+      <div v-if="applicationHasQualifications">
         <dl
           v-for="(qualification, index) in application.qualifications"
           :key="qualification.name"
@@ -1116,7 +1116,7 @@ export default {
     changeQualificationSchedule() {
       // reset all qualifications
       this.$emit('updateApplication', {
-        qualifications: this.application.qualifications.map(q => { return { ...q, type: null };}),
+        qualifications: [],
       });
     },
     changeQualificationOrMembership(obj) {

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -1101,7 +1101,6 @@ export default {
 
     },
     changeQualificationOrMembership(obj) {
-
       let changedObj = this.application[obj.field] || {};
 
       if (obj.hasOwnProperty('change') && obj.extension && obj.hasOwnProperty('index')) { //nested field
@@ -1121,11 +1120,13 @@ export default {
         updatedApplication = {
           [obj.field]: changedObj,
         };
-      } else {
+      } else if (obj.field) {
         updatedApplication = {
           [obj.field]: {
             ...this.application[obj.field], ...changedObj },
         };
+      } else {
+        updatedApplication = changedObj;
       }
 
       this.$emit('updateApplication', updatedApplication);


### PR DESCRIPTION
## What's included?
closes #2423 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://jac-admin-develop--pr2457-feat-2423-align-admi-o5n9agb4.web.app/exercise/X2tDg5AKt18xvzBRJFYW/applications/applied/application/g6e7d5gxp7FTEDnrwAPv
- Click Edit
- Change and save the answer for `Are you applying under Schedule 2(3)?`
    - If the answer is `Yes`, it should appear `None of above` option for Qualification
    - If the answer is `No`, it should not appear `None of above` option for Qualification
    - If the answer is changes, the Qualification(s) should be reset
<img width="1024" alt="Screenshot 2024-06-25 at 11 04 50" src="https://github.com/jac-uk/admin/assets/156695133/ba6f22ca-71d8-4cd1-8542-c67bece9e3e2">

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
