### PR TITLE
Feat/adim 2425 correct text in eligibility information on tribunal exercises

### DIFF
--- a/oldTests/unit/views/Exercises/Edit/Eligibility.spec.js
+++ b/oldTests/unit/views/Exercises/Edit/Eligibility.spec.js
@@ -66,7 +66,7 @@ describe.skip('views/Exercise/Edit/Eligibility', () => {
       expect(button.text()).toBe('Save and continue');
     });
 
-    describe('Does Schedule 2(d) or Schedule 3 apply?', () => {
+    describe('Does Schedule 2(d) or Schedule 3(d) apply?', () => {
       it('does not show the question if the role is a court role', () => {
         wrapper.setData({ isCourtOrTribunal: 'court' });
         expect(wrapper.find('#schedule-2d-apply').exists()).toBe(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "admin",
       "version": "1.45.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "4.1.12",
+        "@jac-uk/jac-kit": "4.1.13",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.61.1",
         "@sentry/vue": "^7.61.1",
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "4.1.12",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.12/c8cfc2377238996c71f496e2ac2ab3253967fbed",
-      "integrity": "sha512-qvPX1l5f/NsKJxWS6XVsbDmn96AWYvhRNSYpr4lwu+W6YlE5SJSv0rlpcWwFBDYc19HN/RFdXkK3zc5fg1Iflw==",
+      "version": "4.1.13",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.13/3a52b2f89a7c0367fe5ca25e8cac398bd293945e",
+      "integrity": "sha512-UPO079gE8gQvaK5Q+ETGMEEyyhdhaApmH5gm6x0t5NdmCir4wWURTNOVU8/1+9pSmcvPluf60KU9zDqOw92WGw==",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "admin",
       "version": "1.45.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "4.1.13",
+        "@jac-uk/jac-kit": "4.1.14",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.61.1",
         "@sentry/vue": "^7.61.1",
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "4.1.13",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.13/3a52b2f89a7c0367fe5ca25e8cac398bd293945e",
-      "integrity": "sha512-UPO079gE8gQvaK5Q+ETGMEEyyhdhaApmH5gm6x0t5NdmCir4wWURTNOVU8/1+9pSmcvPluf60KU9zDqOw92WGw==",
+      "version": "4.1.14",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.14/6e73cb7626216ec08c0760cf56b6f68cb62ed34c",
+      "integrity": "sha512-09fwWjalARamkME2yhaFGiz37JpZ5UKKZ2zS3WMEsRiB/ESGoTwawU/r0TcnUG6BcXP9qkO3nOsU3BECAYzZwg==",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "4.1.12",
+    "@jac-uk/jac-kit": "4.1.13",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.61.1",
     "@sentry/vue": "^7.61.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "4.1.13",
+    "@jac-uk/jac-kit": "4.1.14",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.61.1",
     "@sentry/vue": "^7.61.1",

--- a/src/views/Exercise/Details/Eligibility/Edit.vue
+++ b/src/views/Exercise/Details/Eligibility/Edit.vue
@@ -58,7 +58,7 @@
           v-if="isLegal && isTribunal"
           id="schedule-2d-or-3-apply"
           v-model="formData.schedule2Apply"
-          label="Does Schedule 2(d) or Schedule 2(3) apply?"
+          label="Does Schedule 2(d) or Schedule 3(d) apply?"
           hint="This lets appropriate candidates apply, even if they don't have the right qualifications. It only applies to tribunal vacancies."
         >
           <RadioItem
@@ -76,8 +76,8 @@
                 label="Schedule 2(d)"
               />
               <RadioItem
-                value="schedule-2-3"
-                label="Schedule 2(3)"
+                value="schedule-3-d"
+                label="Schedule 3(d)"
               />
             </RadioGroup>
           </RadioItem>

--- a/src/views/Exercise/Details/Eligibility/Edit.vue
+++ b/src/views/Exercise/Details/Eligibility/Edit.vue
@@ -76,7 +76,7 @@
                 label="Schedule 2(d)"
               />
               <RadioItem
-                value="schedule-3-d"
+                value="schedule-2-3"
                 label="Schedule 3(d)"
               />
             </RadioGroup>

--- a/src/views/Exercise/Details/Eligibility/View.vue
+++ b/src/views/Exercise/Details/Eligibility/View.vue
@@ -36,7 +36,7 @@
         class="govuk-summary-list__row"
       >
         <dt class="govuk-summary-list__key">
-          Does Schedule 2(d) or Schedule 3 apply?
+          Does Schedule 2(d) or Schedule 3(d) apply?
         </dt>
         <dd class="govuk-summary-list__value">
           <span v-if="exercise.schedule2DOr3Apply === true || exercise.schedule2Apply">

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -1043,7 +1043,7 @@ export default {
       return selected;
     },
     scheduleApplies(){
-      return (this.exercise.appliedSchedule == 'schedule-2-3' && this.application.applyingUnderSchedule2Three) ||
+      return (this.exercise.appliedSchedule == 'schedule-3-d' && this.application.applyingUnderSchedule2Three) ||
         (this.exercise.appliedSchedule == 'schedule-2-d' && this.application.applyingUnderSchedule2d);
     },
     notCompletedPupillage() {

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -29,7 +29,10 @@
                   :options="[true, false]"
                   type="selection"
                   :is-asked="isApplicationPartAsked('relevantQualifications')"
-                  @change-field="changeQualificationOrMembership"
+                  @change-field="(changes) => {
+                    changeQualificationSchedule()
+                    changeQualificationOrMembership(changes)
+                  }"
                 />
               </dd>
             </div>
@@ -49,7 +52,10 @@
                   :options="[true, false]"
                   type="selection"
                   :is-asked="isApplicationPartAsked('relevantQualifications')"
-                  @change-field="changeQualificationOrMembership"
+                  @change-field="(changes) => {
+                    changeQualificationSchedule()
+                    changeQualificationOrMembership(changes)
+                  }"
                 />
               </dd>
             </div>
@@ -1106,6 +1112,12 @@ export default {
 
       this.$refs.removeModal.closeModal();
 
+    },
+    changeQualificationSchedule() {
+      // reset all qualifications
+      this.$emit('updateApplication', {
+        qualifications: this.application.qualifications.map(q => { return { ...q, type: null };}),
+      });
     },
     changeQualificationOrMembership(obj) {
       let changedObj = this.application[obj.field] || {};

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -1043,7 +1043,7 @@ export default {
       return selected;
     },
     scheduleApplies(){
-      return (this.exercise.appliedSchedule == 'schedule-3-d' && this.application.applyingUnderSchedule2Three) ||
+      return (this.exercise.appliedSchedule == 'schedule-2-3' && this.application.applyingUnderSchedule2Three) ||
         (this.exercise.appliedSchedule == 'schedule-2-d' && this.application.applyingUnderSchedule2d);
     },
     notCompletedPupillage() {

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -8,6 +8,87 @@
         Qualifications
       </h2>
       <div v-if="applicationHasQualifications">
+        <!-- applied schedules -->
+        <div>
+          <dl
+            v-if="exercise.schedule2Apply"
+            class="govuk-summary-list govuk-!-margin-bottom-0"
+          >
+            <div
+              v-if="exercise.appliedSchedule == 'schedule-2-3'"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key widerColumn">
+                Are you applying under Schedule 2(3)?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <InformationReviewRenderer
+                  :data="application.applyingUnderSchedule2Three"
+                  field="applyingUnderSchedule2Three"
+                  :edit="editable"
+                  :options="[true, false]"
+                  type="selection"
+                  :is-asked="isApplicationPartAsked('relevantQualifications')"
+                  @change-field="changeQualificationOrMembership"
+                />
+              </dd>
+            </div>
+
+            <div
+              v-if="exercise.appliedSchedule == 'schedule-2-d'"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key widerColumn">
+                Are you applying under Schedule 2(d)?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <InformationReviewRenderer
+                  :data="application.applyingUnderSchedule2d"
+                  field="applyingUnderSchedule2d"
+                  :edit="editable"
+                  :options="[true, false]"
+                  type="selection"
+                  :is-asked="isApplicationPartAsked('relevantQualifications')"
+                  @change-field="changeQualificationOrMembership"
+                />
+              </dd>
+            </div>
+          </dl>
+
+          <dl
+            v-if="scheduleApplies"
+            class="govuk-summary-list govuk-!-margin-bottom-8"
+          >
+            <dt
+              class="govuk-summary-list__key widerColumn"
+            >
+              Explain how you've gained experience in law.
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <ul class="govuk-list">
+                <li v-if="exercise.appliedSchedule=='schedule-2-3'">
+                  <InformationReviewRenderer
+                    :data="application.experienceUnderSchedule2Three"
+                    field="experienceUnderSchedule2Three"
+                    :edit="editable"
+                    :is-asked="isApplicationPartAsked('relevantQualifications')"
+                    @change-field="changeQualificationOrMembership"
+                  />
+                </li>
+                <li v-if="exercise.appliedSchedule=='schedule-2-d'">
+                  <InformationReviewRenderer
+                    :data="application.experienceUnderSchedule2D"
+                    field="experienceUnderSchedule2D"
+                    :edit="editable"
+                    :is-asked="isApplicationPartAsked('relevantQualifications')"
+                    @change-field="changeQualificationOrMembership"
+                  />
+                </li>
+              </ul>
+            </dd>
+          </dl>
+        </div>
+
         <dl
           v-for="(qualification, index) in application.qualifications"
           :key="qualification.name"
@@ -306,86 +387,7 @@
         />
       </Modal>
     </div>
-    <!-- applied schedules -->
-    <div>
-      <dl
-        v-if="exercise.schedule2Apply"
-        class="govuk-summary-list govuk-!-margin-bottom-0"
-      >
-        <div
-          v-if="exercise.appliedSchedule == 'schedule-2-3'"
-          class="govuk-summary-list__row"
-        >
-          <dt class="govuk-summary-list__key widerColumn">
-            Are you applying under Schedule 2(3)?
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <InformationReviewRenderer
-              :data="application.applyingUnderSchedule2Three"
-              field="applyingUnderSchedule2Three"
-              :edit="editable"
-              :options="[true, false]"
-              type="selection"
-              :is-asked="isApplicationPartAsked('relevantQualifications')"
-              @change-field="changeQualificationOrMembership"
-            />
-          </dd>
-        </div>
 
-        <div
-          v-if="exercise.appliedSchedule == 'schedule-2-d'"
-          class="govuk-summary-list__row"
-        >
-          <dt class="govuk-summary-list__key widerColumn">
-            Are you applying under Schedule 2(d)?
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <InformationReviewRenderer
-              :data="application.applyingUnderSchedule2d"
-              field="applyingUnderSchedule2d"
-              :edit="editable"
-              :options="[true, false]"
-              type="selection"
-              :is-asked="isApplicationPartAsked('relevantQualifications')"
-              @change-field="changeQualificationOrMembership"
-            />
-          </dd>
-        </div>
-      </dl>
-
-      <dl
-        v-if="scheduleApplies"
-        class="govuk-summary-list govuk-!-margin-bottom-8"
-      >
-        <dt
-          class="govuk-summary-list__key widerColumn"
-        >
-          Explain how you've gained experience in law.
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <ul class="govuk-list">
-            <li v-if="exercise.appliedSchedule=='schedule-2-3'">
-              <InformationReviewRenderer
-                :data="application.experienceUnderSchedule2Three"
-                field="experienceUnderSchedule2Three"
-                :edit="editable"
-                :is-asked="isApplicationPartAsked('relevantQualifications')"
-                @change-field="changeQualificationOrMembership"
-              />
-            </li>
-            <li v-if="exercise.appliedSchedule=='schedule-2-d'">
-              <InformationReviewRenderer
-                :data="application.experienceUnderSchedule2D"
-                field="experienceUnderSchedule2D"
-                :edit="editable"
-                :is-asked="isApplicationPartAsked('relevantQualifications')"
-                @change-field="changeQualificationOrMembership"
-              />
-            </li>
-          </ul>
-        </dd>
-      </dl>
-    </div>
     <!-- memberships + professional Memberships -->
     <div
       v-if="hasRelevantMemberships"
@@ -983,7 +985,12 @@ export default {
       }
     },
     qualificationOptions() {
-      return this.exercise.otherQualifications ? [...['advocate-scotland', 'barrister', 'CILEx', 'solicitor'], this.exercise.otherQualifications] : ['advocate-scotland', 'barrister', 'CILEx', 'solicitor'];
+      const options = this.exercise.otherQualifications ? [...['advocate-scotland', 'barrister', 'CILEx', 'solicitor'], this.exercise.otherQualifications] : ['advocate-scotland', 'barrister', 'CILEx', 'solicitor'];
+      if (this.application.applyingUnderSchedule2Three) {
+        options.push('no-legal-qualification');
+      }
+
+      return options;
     },
     exercise() {
       return this.$store.state.exerciseDocument.record;

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -7,94 +7,94 @@
       >
         Qualifications
       </h2>
-      <div v-if="applicationHasQualifications">
-        <!-- applied schedules -->
-        <div>
-          <dl
-            v-if="exercise.schedule2Apply"
-            class="govuk-summary-list govuk-!-margin-bottom-0"
+      <!-- applied schedules -->
+      <div>
+        <dl
+          v-if="exercise.schedule2Apply"
+          class="govuk-summary-list govuk-!-margin-bottom-0"
+        >
+          <div
+            v-if="exercise.appliedSchedule == 'schedule-2-3'"
+            class="govuk-summary-list__row"
           >
-            <div
-              v-if="exercise.appliedSchedule == 'schedule-2-3'"
-              class="govuk-summary-list__row"
-            >
-              <dt class="govuk-summary-list__key widerColumn">
-                Are you applying under Schedule 2(3)?
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <InformationReviewRenderer
-                  :data="application.applyingUnderSchedule2Three"
-                  field="applyingUnderSchedule2Three"
-                  :edit="editable"
-                  :options="[true, false]"
-                  type="selection"
-                  :is-asked="isApplicationPartAsked('relevantQualifications')"
-                  @change-field="(changes) => {
-                    changeQualificationSchedule()
-                    changeQualificationOrMembership(changes)
-                  }"
-                />
-              </dd>
-            </div>
-
-            <div
-              v-if="exercise.appliedSchedule == 'schedule-2-d'"
-              class="govuk-summary-list__row"
-            >
-              <dt class="govuk-summary-list__key widerColumn">
-                Are you applying under Schedule 2(d)?
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <InformationReviewRenderer
-                  :data="application.applyingUnderSchedule2d"
-                  field="applyingUnderSchedule2d"
-                  :edit="editable"
-                  :options="[true, false]"
-                  type="selection"
-                  :is-asked="isApplicationPartAsked('relevantQualifications')"
-                  @change-field="(changes) => {
-                    changeQualificationSchedule()
-                    changeQualificationOrMembership(changes)
-                  }"
-                />
-              </dd>
-            </div>
-          </dl>
-
-          <dl
-            v-if="scheduleApplies"
-            class="govuk-summary-list govuk-!-margin-bottom-8"
-          >
-            <dt
-              class="govuk-summary-list__key widerColumn"
-            >
-              Explain how you've gained experience in law.
+            <dt class="govuk-summary-list__key widerColumn">
+              Are you applying under Schedule 2(3)?
             </dt>
             <dd class="govuk-summary-list__value">
-              <ul class="govuk-list">
-                <li v-if="exercise.appliedSchedule=='schedule-2-3'">
-                  <InformationReviewRenderer
-                    :data="application.experienceUnderSchedule2Three"
-                    field="experienceUnderSchedule2Three"
-                    :edit="editable"
-                    :is-asked="isApplicationPartAsked('relevantQualifications')"
-                    @change-field="changeQualificationOrMembership"
-                  />
-                </li>
-                <li v-if="exercise.appliedSchedule=='schedule-2-d'">
-                  <InformationReviewRenderer
-                    :data="application.experienceUnderSchedule2D"
-                    field="experienceUnderSchedule2D"
-                    :edit="editable"
-                    :is-asked="isApplicationPartAsked('relevantQualifications')"
-                    @change-field="changeQualificationOrMembership"
-                  />
-                </li>
-              </ul>
+              <InformationReviewRenderer
+                :data="application.applyingUnderSchedule2Three"
+                field="applyingUnderSchedule2Three"
+                :edit="editable"
+                :options="[true, false]"
+                type="selection"
+                :is-asked="isApplicationPartAsked('relevantQualifications')"
+                @change-field="(changes) => {
+                  console.log('section changed')
+                  changeQualificationSchedule()
+                  changeQualificationOrMembership(changes)
+                }"
+              />
             </dd>
-          </dl>
-        </div>
+          </div>
 
+          <div
+            v-if="exercise.appliedSchedule == 'schedule-2-d'"
+            class="govuk-summary-list__row"
+          >
+            <dt class="govuk-summary-list__key widerColumn">
+              Are you applying under Schedule 2(d)?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <InformationReviewRenderer
+                :data="application.applyingUnderSchedule2d"
+                field="applyingUnderSchedule2d"
+                :edit="editable"
+                :options="[true, false]"
+                type="selection"
+                :is-asked="isApplicationPartAsked('relevantQualifications')"
+                @change-field="(changes) => {
+                  changeQualificationSchedule()
+                  changeQualificationOrMembership(changes)
+                }"
+              />
+            </dd>
+          </div>
+        </dl>
+
+        <dl
+          v-if="scheduleApplies"
+          class="govuk-summary-list govuk-!-margin-bottom-8"
+        >
+          <dt
+            class="govuk-summary-list__key widerColumn"
+          >
+            Explain how you've gained experience in law.
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <ul class="govuk-list">
+              <li v-if="exercise.appliedSchedule=='schedule-2-3'">
+                <InformationReviewRenderer
+                  :data="application.experienceUnderSchedule2Three"
+                  field="experienceUnderSchedule2Three"
+                  :edit="editable"
+                  :is-asked="isApplicationPartAsked('relevantQualifications')"
+                  @change-field="changeQualificationOrMembership"
+                />
+              </li>
+              <li v-if="exercise.appliedSchedule=='schedule-2-d'">
+                <InformationReviewRenderer
+                  :data="application.experienceUnderSchedule2D"
+                  field="experienceUnderSchedule2D"
+                  :edit="editable"
+                  :is-asked="isApplicationPartAsked('relevantQualifications')"
+                  @change-field="changeQualificationOrMembership"
+                />
+              </li>
+            </ul>
+          </dd>
+        </dl>
+      </div>
+      <div v-if="applicationHasQualifications">
         <dl
           v-for="(qualification, index) in application.qualifications"
           :key="qualification.name"
@@ -1116,7 +1116,7 @@ export default {
     changeQualificationSchedule() {
       // reset all qualifications
       this.$emit('updateApplication', {
-        qualifications: this.application.qualifications.map(q => { return { ...q, type: null };}),
+        qualifications: [],
       });
     },
     changeQualificationOrMembership(obj) {

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -1101,7 +1101,6 @@ export default {
 
     },
     changeQualificationOrMembership(obj) {
-
       let changedObj = this.application[obj.field] || {};
 
       if (obj.hasOwnProperty('change') && obj.extension && obj.hasOwnProperty('index')) { //nested field
@@ -1121,11 +1120,13 @@ export default {
         updatedApplication = {
           [obj.field]: changedObj,
         };
-      } else {
+      } else if (obj.field) {
         updatedApplication = {
           [obj.field]: {
             ...this.application[obj.field], ...changedObj },
         };
+      } else {
+        updatedApplication = changedObj;
       }
 
       this.$emit('updateApplication', updatedApplication);

--- a/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
+++ b/src/views/InformationReview/QualificationsAndMembershipsSummary.vue
@@ -18,7 +18,7 @@
             class="govuk-summary-list__row"
           >
             <dt class="govuk-summary-list__key widerColumn">
-              Are you applying under Schedule 2(3)?
+              Are you applying under Schedule 3(d)?
             </dt>
             <dd class="govuk-summary-list__value">
               <InformationReviewRenderer


### PR DESCRIPTION
## What's included?
Describe the changes included in this pull request and highlight dependencies with other repos/tickets
closes #2425
## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://jac-admin-develop--pr2460-feat-adim-2425-corre-5x3ylj8p.web.app/exercise/X2tDg5AKt18xvzBRJFYW/details/eligibility
- The text should be `Does Schedule 2(d) or Schedule 3(d) apply?`
- Click `Update eligibility information`,  the text should be `Does Schedule 2(d) or Schedule 3(d) apply?` as well.
And the option for schedule 3(d) should be `Schedule 3(d)`
<img width="972" alt="Screenshot 2024-06-25 at 15 54 52" src="https://github.com/jac-uk/admin/assets/156695133/1d415976-1a5e-4648-92e2-48a7a2d24683">

- Go to the preview link: https://jac-admin-develop--pr2460-feat-adim-2425-corre-5x3ylj8p.web.app/exercise/X2tDg5AKt18xvzBRJFYW/applications/applied/application/g6e7d5gxp7FTEDnrwAPv
- In qualification section, the schedule text should be `Are you applying under Schedule 3(d)?`

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
