### PR TITLE
Bugfix/apply 1192 Membership selection

### DIFF
--- a/src/components/RepeatableFields/Membership.vue
+++ b/src/components/RepeatableFields/Membership.vue
@@ -60,9 +60,9 @@ export default {
     }
   },
   methods: {
-    updateValue(value) {
+    updateValue(event) {
       // @todo when we move lookup to db, we should add these to lookup
-      this.row.value = slugify(value);
+      this.row.value = slugify(event.target.value);
     },
   },
 };


### PR DESCRIPTION
## What's included?
Fix https://app.zenhub.com/workspaces/platform-development-5ea838cd2aec471eb6d14139/issues/gh/jac-uk/apply/1192

- Fix exercise.otherMembership.value always be "object-inputevent"

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://jac-admin-develop--pr2473-bugfix-apply-1192-fi-xhfrt8w2.web.app/exercise/7lsEzMMY182YLyXuqyak/details/eligibility
- Add new memberships
- Apply the vacancy: https://jac-apply-develop.web.app/vacancy/7lsEzMMY182YLyXuqyak/
- Check the `Relevant memberships`, the membership options should can be selected independently. 


https://github.com/jac-uk/admin/assets/156695133/df2d9041-3a1b-43a5-a828-1b7c641c3648



## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
