### PR TITLE
Bugfix/TS 343 Unable to amend application data

### DIFF
--- a/src/components/Page/EditableField.vue
+++ b/src/components/Page/EditableField.vue
@@ -587,24 +587,32 @@ export default {
             field: this.field,
             change: this.localField,
           };
-        } if (this.config.id != undefined) { // is indexed item
-          resultObj = {
-            ...resultObj,
-            index: this.config.id,
-          };
-        } if (this.extension != undefined) { // is nested item
-          resultObj = {
-            ...resultObj,
-            extension: this.extension,
-          };
+          if (this.index != undefined) { // is indexed item
+            resultObj = {
+              ...resultObj,
+              index: this.index,
+            };
+          }
+          if (this.config.id != undefined) { // is indexed item
+            resultObj = {
+              ...resultObj,
+              index: this.config.id,
+            };
+          }
+          if (this.extension != undefined) { // is nested item
+            resultObj = {
+              ...resultObj,
+              extension: this.extension,
+            };
+          }
+        } else {
+          resultObj = { [this.field]: this.config ? this.config.answers.find(ans => ans.answer === this.localField).id : this.localField }; // else
         }
-      } else {
-        resultObj = { [this.field]: this.config ? this.config.answers.find(ans => ans.answer === this.localField).id : this.localField }; // else
+
+        this.$emit('changeField', resultObj);
+
+        this.editField = false;
       }
-
-      this.$emit('changeField', resultObj);
-
-      this.editField = false;
     },
     getConfigAnswer(answerId) {
       const match = this.config.answers.find(ans => ans.id === answerId);


### PR DESCRIPTION
## What's included?
Closes [User Raised Issue BR_ADMIN_PR_000141 #343](https://github.com/jac-uk/ticketing-system/issues/343)

- Fix the save functionality in the `EditableField` component.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example application: https://jac-admin-develop--pr2476-bugfix-ts-343-unable-n0mpgeth.web.app/exercise/g45SG9vPFlhInL6yDonh/applications/draft/application/0h8NUJ5GPEiIBfL35Shh

Steps:
1. Go to an application and amend the data.
2. Check if the data can be saved correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo: 

https://github.com/jac-uk/admin/assets/79906532/b86eb976-c146-4264-a5d0-9ecf2360349c


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
