### PR TITLE
#2475 Introduce Processing Version 3.0

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -284,7 +284,7 @@ function getTimelineTasks(exercise, taskType) {
   const timeline = createTimeline(exerciseTimeline(exercise));
   let timelineTasks = timeline.filter(item => item.taskType && (!taskType || item.taskType === taskType));
   let supportedTaskTypes = [];
-  if (exercise._processingVersion >= 2) {
+  if (exercise._processingVersion >= 3) {
     supportedTaskTypes = [
       TASK_TYPE.TELEPHONE_ASSESSMENT,
       TASK_TYPE.SIFT,

--- a/src/views/Exercise/Configuration/ProcessingVersion.vue
+++ b/src/views/Exercise/Configuration/ProcessingVersion.vue
@@ -16,9 +16,14 @@
         required
       >
         <RadioItem
+          :value="3"
+          label="Processing version 3.0"
+          hint="Introduced in July 2024, processing version 3.0 includes a number of new tasks"
+        />
+        <RadioItem
           :value="2"
           label="Processing version 2.0"
-          hint="Introduced in March 2024, processing version 2.0 updates stages and statuses and includes a number of new tasks"
+          hint="Introduced in March 2024, processing version 2.0 updates stages and statuses"
         />
         <RadioItem
           :value="1"

--- a/src/views/Exercise/Details.vue
+++ b/src/views/Exercise/Details.vue
@@ -74,7 +74,7 @@ export default {
           path: `${path}/application-content`,
         },
       ];
-      if (this.exercise._processingVersion >= 2) {
+      if (this.exercise._processingVersion >= 3) {
         sideNavigation.push({
           title: 'Additional settings',
           path: `${path}/additional-settings`,


### PR DESCRIPTION
## What's included?
In 'Processing version 2.0' we introduced a new set of stages and statuses.

Here we are introducing 'Processing version 3.0' which will include new Tasks (PSDQ, Sift, Selection Day etc).

_Note the new tasks were previously included in version 2 and causing confusion for SETs so this change will resolve that._

**To Do**

- [x] Add Processing version 3.0 to the configuration area in Admin (see screen grab below)
- [x] Ensure new tasks only show for version 3+
- [x] Ensure Exercise > Additional Settings only shows for version 3+

**Config page**
<img width="1198" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBL3VuQlE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--a37906b9f8bda33ffa2b2c4badbdd2ed3facb2a6/image.png" alt="image.png" />

**Tasks for 2.0**
<img width="1289" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBLzZuQlE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--b365d67800ece0e52b2f539e135a1ee9caa9c8d5/image.png" alt="image.png" />


**Tasks for 3.0**
<img width="1212" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBLzJuQlE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--02f38cc5c3305ad9bb6c68f78a1acec242146381/image.png" alt="image.png" />


Closes #2475

## Who should test?
✅ Product owner

## How to test?
Try changing processing version to 3.0 and check new tasks appear and nothing blows up! 
Try changing back to 2.0 and back again to 3.0 to try to get it to blow up 😄 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
