### PR TITLE
Hotfix/Eligibility Report JAC Comments

### DIFF
--- a/src/views/Exercise/Reports/EligibilityIssuesV2.vue
+++ b/src/views/Exercise/Reports/EligibilityIssuesV2.vue
@@ -209,13 +209,13 @@
                   </Select>
                 </div>
 
-                <!-- reasons not satisfied / JAC comments -->
+                <!-- JAC comments -->
                 <div
                   v-if="issue.result && (showRecommendation(issue, index) || isForStatutoryReasons(issueGroup.issues, issue, index))"
                   class="govuk-!-margin-top-0 govuk-grid-column-full"
                 >
                   <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-                    {{ isForStatutoryReasons(issueGroup.issues, issue, index) ? 'Reasons not satisfied' : 'JAC comments' }}
+                    JAC comments
                   </h4>
                   <TextareaInput
                     :id="`${row.id}_${index}_${issue.type}_reason`"


### PR DESCRIPTION
## What's included?
Rename `Reasons not satisfied` to `JAC comments` in the Eligibility Report.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example exercise on Production: https://jac-apply-admin-production--pr2482-hotfix-eligibility-m6wiapsd.web.app/exercise/IiaXjmpDQd7BQx7ovlv0/reports/eligibility-issues

1. Go to Eligibility Report
2. Check if `Reasons not satisfied` has been renamed to `JAC comments`

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:PRODUCTION
_can be OFF, DEVELOP or STAGING_
