### PR TITLE
Ticketing System #357 Allow Pdfs To Be Uploaded When Specifying Download Files For Exercise

### DIFF
--- a/src/components/ModalViews/UploadFiles.vue
+++ b/src/components/ModalViews/UploadFiles.vue
@@ -32,7 +32,7 @@
           :path="buildFileFolder"
           :file-path="$attrs.filePath"
           label=""
-          :types="'.docx'"
+          :types="$attrs.types"
           required
           @update:model-value="changeFileName"
         />

--- a/src/views/Exercise/Details/Downloads/Edit.vue
+++ b/src/views/Exercise/Details/Downloads/Edit.vue
@@ -212,6 +212,7 @@ export default {
         id: 'candidateAssessementForms',
         name: 'candidate-assessement-forms',
         mandatory: false,
+        types: '.docx',
       });
 
       data.push({


### PR DESCRIPTION
## What's included?
This is to fix an issue introduced in the earlier ticket to 'Limit format of SA template uploads to .docx':

Earlier Issue: https://github.com/jac-uk/admin/issues/2391
Earlier PR: https://github.com/jac-uk/admin/pull/2402

The UploadFiles component was passed a prop which originally specified a list of acceptable file types. The above PR removed that list and hardcoded the docx file extension which meant all instances of UploadFiles would only accept that file type.

As a fix I have reverted that change and have specified the docx file type for the Self Assessment template upload.

Closes jac-uk/ticketing-system#357

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

1. Go to a draft exercise at this url: https://jac-admin-develop--pr2485-bugfix-ts-357-allow-8roplgyx.web.app/
2. Go to the Exercise Downloads
3. Ensure for Job Description you can upload a pdf file
4. Ensure for Candidate Assessment Form you can only upload docx files

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
