### PR TITLE
Feature/2486 Remove CV as assessment option

### DIFF
--- a/src/views/Exercise/Details/Assessments/Edit.vue
+++ b/src/views/Exercise/Details/Assessments/Edit.vue
@@ -22,28 +22,31 @@
           v-for="method in Object.values(ASSESSMENT_METHOD)"
           :key="method"
         >
-          <Checkbox
-            :id="`assessment-method-${method}`"
-            v-model="formData.assessmentMethods[method]"
-          >
-            {{ $filters.lookup(method) }}
-          </Checkbox>
-          <div
-            v-if="method == ASSESSMENT_METHOD.SELF_ASSESSMENT_WITH_COMPETENCIES && formData.assessmentMethods[method]"
-          >
-            <span
-              class="govuk-hint"
+          <!-- remove CV assessment option -->
+          <template v-if="method !== ASSESSMENT_METHOD.CV">
+            <Checkbox
+              :id="`assessment-method-${method}`"
+              v-model="formData.assessmentMethods[method]"
             >
-              Please add a word limit for each question within the self assessment.
-            </span>
-            <RepeatableFields
-              v-model="formData.selfAssessmentWordLimits"
-              :component="repeatableFields.SelfAssessmentSection"
-              type-name="Self Assessment Section"
-              required
-            />
-            <slot name="removeButton" />
-          </div>
+              {{ $filters.lookup(method) }}
+            </Checkbox>
+            <div
+              v-if="method == ASSESSMENT_METHOD.SELF_ASSESSMENT_WITH_COMPETENCIES && formData.assessmentMethods[method]"
+            >
+              <span
+                class="govuk-hint"
+              >
+                Please add a word limit for each question within the self assessment.
+              </span>
+              <RepeatableFields
+                v-model="formData.selfAssessmentWordLimits"
+                :component="repeatableFields.SelfAssessmentSection"
+                type-name="Self Assessment Section"
+                required
+              />
+              <slot name="removeButton" />
+            </div>
+          </template>
         </div>
         <button class="govuk-button">
           Save and continue


### PR DESCRIPTION
## What's included?
Mentions #2486 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
[Example exercise](https://jac-admin-develop--pr2491-feature-2486-remove-w9dibni0.web.app/exercise/TSZHvLiBpittnlOXmMlI/details/assessments)

Steps:
1. Amend the assessment options of an exercise.
2. Ensure the CV option has been removed.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/user-attachments/assets/19913705-7d5b-4f21-9932-e5da27003fe8

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
