### PR TITLE
Bugfix/TS 363 Unable to amend reasonable adjustments

### DIFF
--- a/src/views/InformationReview/AssessmentsSummary.vue
+++ b/src/views/InformationReview/AssessmentsSummary.vue
@@ -155,7 +155,7 @@
                 />
               </div>
 
-              <template v-if="editable">
+              <template v-if="editable && !isExtractingSelfAssessment">
                 <a
                   v-if="!editUploadSelfAssessmentMode"
                   href="#"
@@ -427,6 +427,9 @@ export default {
     },
 
     async doFileUpload(val, field) {
+      if (field === 'uploadedSelfAssessment') {
+        this.editUploadSelfAssessmentMode = false;
+      }
       if (val) {
         this.$emit('updateApplication', { [field]: val });
       }

--- a/src/views/InformationReview/AssessmentsSummary.vue
+++ b/src/views/InformationReview/AssessmentsSummary.vue
@@ -139,19 +139,40 @@
             <span v-else>Not yet received</span>
 
             <!-- UPLOAD SELF ASSESSMENT -->
-            <div>
-              <FileUpload
-                v-if="editable"
-                id="self-assessment-upload"
-                ref="self-assessment"
-                v-model="application.uploadedSelfAssessment"
-                name="self-assessment"
-                :path="uploadPath"
-                label="Upload finished self assessment"
-                required
-                :acceptable-extensions="['docx']"
-                @update:model-value="val => doFileUpload(val, 'uploadedSelfAssessment')"
-              />
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+              <div>
+                <FileUpload
+                  v-if="editUploadSelfAssessmentMode"
+                  id="self-assessment-upload"
+                  ref="self-assessment"
+                  v-model="application.uploadedSelfAssessment"
+                  name="self-assessment"
+                  :path="uploadPath"
+                  label="Upload finished self assessment"
+                  required
+                  :acceptable-extensions="['docx']"
+                  @update:model-value="val => doFileUpload(val, 'uploadedSelfAssessment')"
+                />
+              </div>
+
+              <template v-if="editable">
+                <a
+                  v-if="!editUploadSelfAssessmentMode"
+                  href="#"
+                  class="govuk-link change-link print-none"
+                  @click.prevent="toggleEditUploadSelfAssessment"
+                >
+                  Change
+                </a>
+                <button
+                  v-else
+                  type="submit"
+                  class="govuk-button govuk-button--warning"
+                  @click.prevent="toggleEditUploadSelfAssessment"
+                >
+                  Cancel
+                </button>
+              </template>
             </div>
           </dd>
         </div>
@@ -332,6 +353,7 @@ export default {
     return {
       assessorDetails: {},
       isLoadingFile: false,
+      editUploadSelfAssessmentMode: false,
     };
   },
   computed: {
@@ -411,6 +433,9 @@ export default {
     },
     isApplicationPartAsked(part) {
       return isApplicationPartAsked(this.exercise, part);
+    },
+    toggleEditUploadSelfAssessment() {
+      this.editUploadSelfAssessmentMode = !this.editUploadSelfAssessmentMode;
     },
   },
 };


### PR DESCRIPTION
## What's included?

[User Raised Issue BR_ADMIN_PR_000161 #363](https://github.com/jac-uk/ticketing-system/issues/363)

Add edit mode to self-assessment upload.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
[Example application](https://jac-admin-develop--pr2506-bugfix-ts-363-unable-e9jfjbzx.web.app/exercise/aD8YKYEYhQbPThjcaKsM/applications/draft/application/WSf0lOi60wyb1F4Igmic)

Steps:
1. Go to the application view.
2. Check if you can amend the reasonable adjustments.
3. Check if you can upload the self-assessment.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

Demo:

[video-29921303-4da2deb56ddd0a294edeebc07212ee67.webm](https://github.com/user-attachments/assets/1288f049-5690-499e-86db-4517c548116e)

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
