### PR TITLE
Feat/admin 2412 changes to navigation

### DIFF
--- a/src/components/Navigation/SideNavigation.vue
+++ b/src/components/Navigation/SideNavigation.vue
@@ -13,7 +13,7 @@
       >
         <li
           class="moj-side-navigation__item"
-          :class="{'moj-side-navigation__item--active': isActive}"
+          :class="{'moj-side-navigation__item--active': isActive || href === $route.path}"
         >
           <a
             class="moj-side-navigation__link"

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -89,6 +89,7 @@ export {
   applicationRecordCounts,
   availableStages,
   availableStatuses,
+  availableReportLinks,
   getPreviousStage,
   getNextStage,
   getStagePassingStatuses,
@@ -1265,6 +1266,97 @@ function availableStatuses(exercise, stage) {
       return statuses;
     }
   }
+}
+
+function availableReportLinks(exercise) {
+  const path = `/exercise/${exercise.id}/reports`;
+  const links = [
+    {
+      title: 'Diversity',
+      name: 'exercise-reports-diversity',
+    },
+    {
+      title: 'Merit List',
+      name: 'merit-list',
+    },
+    {
+      title: 'Outreach',
+      name: 'outreach',
+    },
+    {
+      title: 'Character Annex',
+      name: 'character-issues',
+    },
+    {
+      title: 'Eligibility Annex',
+      name: 'eligibility-issues',
+    },
+    {
+      title: 'Reasonable Adjustments',
+      name: 'reasonable-adjustments',
+    },
+    {
+      title: 'Agency',
+      name: 'agency',
+    },
+    {
+      title: 'Handover',
+      name: 'handover',
+    },
+    {
+      title: 'Deployment',
+      name: 'deployment',
+    },
+    {
+      title: 'Statutory Consultation',
+      name: 'statutory-consultation',
+    },
+    {
+      title: 'Custom',
+      name: 'custom',
+    },
+  ];
+
+  if (exercise.shortlistingMethods && exercise.shortlistingMethods.length) {
+    if (
+      (exercise.shortlistingMethods.indexOf('paper-sift') >= 0 && exercise.siftStartDate)
+      || (exercise.shortlistingMethods.indexOf('name-blind-paper-sift') >= 0 && exercise.nameBlindSiftStartDate)
+    ) {
+      links.push(
+        {
+          title: 'Sift',
+          path: `${path}/sift`,
+        }
+      );
+    }
+  }
+  if (exercise.scenarioTestDate) {  // TODO: remove this when we have better support for scenarios
+    links.push(
+      {
+        title: 'Scenario Responses',
+        path: `${path}/scenario`,
+      }
+    );
+  }
+  if (exercise.selectionDays) {
+    links.push(
+      {
+        title: 'Selection day',
+        path: `${path}/selection`,
+      }
+    );
+  }
+  if (exercise?._applicationContent?.registration?.commissionerConflicts) {
+    links.push(
+      {
+        title: 'Commissioner conflicts',
+        path: `${path}/commissioner-conflicts`,
+      }
+    );
+  }
+
+  links.sort((a, b) => a.title.localeCompare(b.title));
+  return links;
 }
 
 function shortlistingStatuses(exercise) {

--- a/src/router.js
+++ b/src/router.js
@@ -1038,7 +1038,7 @@ const routes = [
             component: ExerciseReportsCharacterIssues,
             meta: {
               requiresAuth: true,
-              title: 'Character Issues | Exercise Reports',
+              title: 'Character Annex | Exercise Reports',
             },
           },
           {

--- a/src/router.js
+++ b/src/router.js
@@ -1047,7 +1047,7 @@ const routes = [
             component: ExerciseReportsEligibilityIssues,
             meta: {
               requiresAuth: true,
-              title: 'Eligibility Issues | Exercise Reports',
+              title: 'Eligibility Annex | Exercise Reports',
             },
           },
           {

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -264,15 +264,12 @@ export default {
 
       if (content.length) {
         subNavigation.push({
-          title: 'Exercise',
+          title: 'Exercise Set-up',
           link: { name: 'exercise-overview' },
           content: content,
         });
       }
 
-      if ((this.exercise.applications || this.hasOpened) && this.hasPermissions([this.PERMISSIONS.applications.permissions.canReadApplications.value])) {
-        subNavigation.push({ link: { name: `exercise-applications-${STATUS.APPLIED}` }, title: 'Applications' });
-      }
       if (this.isProcessing) {
         subNavigation.push({ link: { name: 'exercise-tasks', params: { stage: 'all' } }, title: 'Tasks' });
         subNavigation.push({ link: { name: 'exercise-stage-list', params: { stage: EXERCISE_STAGE.REVIEW } }, title: 'Stages', content: this.stageLinks });

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -118,7 +118,7 @@ import { mapState } from 'vuex';
 import { isEditable, hasQualifyingTests, isProcessing, applicationCounts, isApproved, isArchived, availableStages } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
 import { functions } from '@/firebase';
-import { STATUS, ADVERT_TYPES, EXERCISE_STAGE } from '../helpers/constants';
+import { ADVERT_TYPES, EXERCISE_STAGE } from '../helpers/constants';
 import { useExercise } from '@/composables/useExercise';
 import TabMenu from '@/components/Navigation/TabMenu2.vue';
 import { availableReportLinks } from '../helpers/exerciseHelper';

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -115,12 +115,13 @@ import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
 import ChangeNoOfTestApplications from '@/components/ModalViews/ChangeNoOfTestApplications.vue';
 import { mapState } from 'vuex';
-import { isEditable, hasQualifyingTests, isProcessing, applicationCounts, isApproved, isArchived } from '@/helpers/exerciseHelper';
+import { isEditable, hasQualifyingTests, isProcessing, applicationCounts, isApproved, isArchived, availableStages } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
 import { functions } from '@/firebase';
 import { STATUS, ADVERT_TYPES, EXERCISE_STAGE } from '../helpers/constants';
 import { useExercise } from '@/composables/useExercise';
 import TabMenu from '@/components/Navigation/TabMenu2.vue';
+import { availableReportLinks } from '../helpers/exerciseHelper';
 
 export default {
   name: 'ExerciseView',
@@ -214,6 +215,26 @@ export default {
     applicationCounts() {
       return applicationCounts(this.exercise);
     },
+    stageLinks() {
+      const exercise = this.exercise;
+      const path = `/exercise/${exercise.id}/stages`;
+      const stages = availableStages(exercise);
+      const links = [];
+      stages.forEach(stage => {
+        const count = (exercise._applicationRecords && exercise._applicationRecords[stage]) || 0;
+        links.push({
+          title: `${this.$filters.lookup(stage)} (${this.$filters.formatNumber(count)})`, // TODO get label
+          link: `${path}/${stage}`,
+        });
+      });
+      return links;
+    },
+    reportLinks() {
+      return availableReportLinks(this.exercise).map((link) => ({
+        title: link.title,
+        link,
+      }));
+    },
     tabs() {
       if (!this.exercise) { return []; }
       const path = `/exercise/${this.exercise.id}`;
@@ -254,8 +275,8 @@ export default {
       }
       if (this.isProcessing) {
         subNavigation.push({ link: { name: 'exercise-tasks', params: { stage: 'all' } }, title: 'Tasks' });
-        subNavigation.push({ link: { name: 'exercise-stage-list', params: { stage: EXERCISE_STAGE.REVIEW } }, title: 'Stages' });
-        subNavigation.push({ link: { name: 'exercise-reports-diversity' }, title: 'Reports' });
+        subNavigation.push({ link: { name: 'exercise-stage-list', params: { stage: EXERCISE_STAGE.REVIEW } }, title: 'Stages', content: this.stageLinks });
+        subNavigation.push({ link: { name: 'exercise-reports-diversity' }, title: 'Reports', content: this.reportLinks });
       }
       return subNavigation;
     },

--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -40,7 +40,7 @@
               data-module="govuk-button"
               @click="openModal"
             >
-              Late Application
+              A Late Application
             </button>
           </div>
         </div>

--- a/src/views/Exercise/Dashboard/OverviewPanels/TotalApplications.vue
+++ b/src/views/Exercise/Dashboard/OverviewPanels/TotalApplications.vue
@@ -6,27 +6,42 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body-s govuk-!-margin-bottom-0">
-          Draft
-        </span>
-        <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
-          {{ numberOfDraftApplications }}
-        </h2>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <span class="govuk-body-s govuk-!-margin-bottom-0">
           Applied
         </span>
-        <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
-          {{ numberOfAppliedApplications }}
-        </h2>
+        <router-link
+          :to="{ path: `/exercise/${exerciseId}/applications/applied`}"
+          class="govuk-link govuk-link--no-underline govuk-link-active-colour"
+        >
+          <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
+            {{ numberOfAppliedApplications }}
+          </h2>
+        </router-link>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body-s govuk-!-margin-bottom-0">
-          Withdrawn
+          Draft
         </span>
-        <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
-          {{ numberOfWithdrawnApplications }}
-        </h2>
+        <router-link
+          :to="{ path: `/exercise/${exerciseId}/applications/draft`}"
+          class="govuk-link govuk-link--no-underline govuk-link-active-colour"
+        >
+          <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
+            {{ numberOfDraftApplications }}
+          </h2>
+        </router-link>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <span class="govuk-body-s govuk-!-margin-bottom-0">
+          Withdrew
+        </span>
+        <router-link
+          :to="{ path: `/exercise/${exerciseId}/applications/withdrawn`}"
+          class="govuk-link govuk-link--no-underline govuk-link-active-colour"
+        >
+          <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
+            {{ numberOfWithdrawnApplications }}
+          </h2>
+        </router-link>
       </div>
     </div>
     <!-- <span class="govuk-body-s tiny-text">Last Updated: {{ $filters.formatDate(applicationCounts._lastUpdated, 'datetime') }}</span> -->
@@ -37,6 +52,9 @@ import { applicationCounts } from '@/helpers/exerciseHelper';
 export default {
   name: 'TotalApplications',
   computed: {
+    exerciseId() {
+      return this.$store.state.exerciseDocument.record ? this.$store.state.exerciseDocument.record.id : null;
+    },
     exercise() {
       return this.$store.getters['exerciseDocument/data']();
     },

--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -1,10 +1,5 @@
 <template>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter print-none">
-      <SideNavigation
-        :pages="sideNavigation"
-      />
-    </div>
     <div class="govuk-grid-column-three-quarters print-full-width">
       <RouterView />
     </div>
@@ -12,18 +7,9 @@
 </template>
 
 <script>
-import SideNavigation from '@/components/Navigation/SideNavigation.vue';
-import { availableReportLinks } from '@/helpers/exerciseHelper';
 
 export default {
   components: {
-    SideNavigation,
-  },
-  computed: {
-    sideNavigation() {
-      const exercise = this.$store.state.exerciseDocument.record;
-      return availableReportLinks(exercise);
-    },
   },
 };
 </script>

--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -36,7 +36,7 @@ export default {
           name: 'outreach',
         },
         {
-          title: 'Character Issues',
+          title: 'Character Annex',
           name: 'character-issues',
         },
         {

--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -40,7 +40,7 @@ export default {
           name: 'character-issues',
         },
         {
-          title: 'Eligibility Issues',
+          title: 'Eligibility Annex',
           name: 'eligibility-issues',
         },
         {

--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -107,6 +107,7 @@ export default {
         );
       }
 
+      sideNavigation.sort((a, b) => a.title.localeCompare(b.title));
       return sideNavigation;
     },
   },

--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -13,6 +13,7 @@
 
 <script>
 import SideNavigation from '@/components/Navigation/SideNavigation.vue';
+import { availableReportLinks } from '@/helpers/exerciseHelper';
 
 export default {
   components: {
@@ -21,94 +22,7 @@ export default {
   computed: {
     sideNavigation() {
       const exercise = this.$store.state.exerciseDocument.record;
-      const path = `/exercise/${exercise.id}/reports`;
-      const sideNavigation = [
-        {
-          title: 'Diversity',
-          name: 'exercise-reports-diversity',
-        },
-        {
-          title: 'Merit List',
-          name: 'merit-list',
-        },
-        {
-          title: 'Outreach',
-          name: 'outreach',
-        },
-        {
-          title: 'Character Annex',
-          name: 'character-issues',
-        },
-        {
-          title: 'Eligibility Annex',
-          name: 'eligibility-issues',
-        },
-        {
-          title: 'Reasonable Adjustments',
-          name: 'reasonable-adjustments',
-        },
-        {
-          title: 'Agency',
-          name: 'agency',
-        },
-        {
-          title: 'Handover',
-          name: 'handover',
-        },
-        {
-          title: 'Deployment',
-          name: 'deployment',
-        },
-        {
-          title: 'Statutory Consultation',
-          name: 'statutory-consultation',
-        },
-        {
-          title: 'Custom',
-          name: 'custom',
-        },
-      ];
-
-      if (exercise.shortlistingMethods && exercise.shortlistingMethods.length) {
-        if (
-          (exercise.shortlistingMethods.indexOf('paper-sift') >= 0 && exercise.siftStartDate)
-          || (exercise.shortlistingMethods.indexOf('name-blind-paper-sift') >= 0 && exercise.nameBlindSiftStartDate)
-        ) {
-          sideNavigation.push(
-            {
-              title: 'Sift',
-              path: `${path}/sift`,
-            }
-          );
-        }
-      }
-      if (exercise.scenarioTestDate) {  // TODO: remove this when we have better support for scenarios
-        sideNavigation.push(
-          {
-            title: 'Scenario Responses',
-            path: `${path}/scenario`,
-          }
-        );
-      }
-      if (exercise.selectionDays) {
-        sideNavigation.push(
-          {
-            title: 'Selection day',
-            path: `${path}/selection`,
-          }
-        );
-      }
-      if (exercise?._applicationContent?.registration?.commissionerConflicts) {
-        sideNavigation.push(
-          {
-            title: 'Commissioner conflicts',
-            path: `${path}/commissioner-conflicts`,
-          }
-        );
-      }
-
-      sideNavigation.sort((a, b) => a.title.localeCompare(b.title));
-      return sideNavigation;
+      return availableReportLinks(exercise);
     },
   },
 };

--- a/src/views/Exercise/Reports/CharacterIssues.vue
+++ b/src/views/Exercise/Reports/CharacterIssues.vue
@@ -4,7 +4,7 @@
       <div class="moj-page-header-actions">
         <div class="moj-page-header-actions__title">
           <h2 class="govuk-heading-l">
-            Character Issues
+            Character Annex
           </h2>
           <span
             v-if="characterIssuesReport"
@@ -690,7 +690,7 @@ export default {
     async exportData() {
       if (!this.exercise.referenceNumber) return; // abort if no ref
       try {
-        const title = 'Character Issues';
+        const title = 'Character Annex';
         const xlsxData = await this.gatherReportData();
 
         downloadXLSX(xlsxData, {

--- a/src/views/Exercise/Reports/EligibilityIssuesV1.vue
+++ b/src/views/Exercise/Reports/EligibilityIssuesV1.vue
@@ -4,7 +4,7 @@
       <div class="moj-page-header-actions">
         <div class="moj-page-header-actions__title">
           <h2 class="govuk-heading-l">
-            Eligibility Issues
+            Eligibility Annex
           </h2>
           <span
             v-if="eligibilityIssuesReport"
@@ -320,7 +320,7 @@ export default {
     },
     async exportData() {
       try {
-        const title = 'Eligibility Issues';
+        const title = 'Eligibility Annex';
         const xlsxData = await this.gatherReportData();
 
         downloadXLSX(

--- a/src/views/Exercise/Reports/EligibilityIssuesV2.vue
+++ b/src/views/Exercise/Reports/EligibilityIssuesV2.vue
@@ -4,7 +4,7 @@
       <div class="moj-page-header-actions">
         <div class="moj-page-header-actions__title">
           <h2 class="govuk-heading-l">
-            Eligibility Issues v2
+            Eligibility Annex v2
           </h2>
           <span
             v-if="eligibilityIssuesReport"
@@ -368,7 +368,7 @@ export default {
     },
     async exportData() {
       try {
-        const title = 'Eligibility Issues';
+        const title = 'Eligibility Annex';
         const xlsxData = await this.gatherReportData();
 
         downloadXLSX(

--- a/src/views/Exercise/Reports/Index.vue
+++ b/src/views/Exercise/Reports/Index.vue
@@ -20,7 +20,7 @@
           class="govuk-link govuk-body-l"
           :to="{name: 'exercise-show-report-character-issues'}"
         >
-          Character Issues
+          Character Annex
         </router-link>
       </li>
 

--- a/src/views/Exercise/Reports/Index.vue
+++ b/src/views/Exercise/Reports/Index.vue
@@ -38,7 +38,7 @@
           class="govuk-link govuk-body-l"
           :to="{name: 'exercise-show-report-eligibility-issues'}"
         >
-          Eligibility Issues
+          Eligibility Annex
         </router-link>
       </li>
 

--- a/src/views/Exercise/Stages.vue
+++ b/src/views/Exercise/Stages.vue
@@ -1,10 +1,5 @@
 <template>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter print-none">
-      <SideNavigation
-        :pages="sideNavigation"
-      />
-    </div>
     <div class="exercise-stages govuk-grid-column-three-quarters print-full-width">
       <RouterView />
     </div>
@@ -12,28 +7,10 @@
 </template>
 
 <script>
-import SideNavigation from '@/components/Navigation/SideNavigation.vue';
-import { availableStages } from '../../helpers/exerciseHelper';
 
 export default {
   components: {
-    SideNavigation,
-  },
-  computed: {
-    sideNavigation() {
-      const exercise = this.$store.state.exerciseDocument.record;
-      const path = `/exercise/${exercise.id}/stages`;
-      const stages = availableStages(exercise);
-      const sideNavigation = [];
-      stages.forEach(stage => {
-        const count = (exercise._applicationRecords && exercise._applicationRecords[stage]) || 0;
-        sideNavigation.push({
-          title: `${this.$filters.lookup(stage)} (${this.$filters.formatNumber(count)})`, // TODO get label
-          path: `${path}/${stage}`,
-        });
-      });
-      return sideNavigation;
-    },
+
   },
 };
 </script>

--- a/src/views/Exercise/Tasks.vue
+++ b/src/views/Exercise/Tasks.vue
@@ -1,10 +1,5 @@
 <template>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter print-none">
-      <SideNavigation
-        :pages="sideNavigation"
-      />
-    </div>
     <div class="govuk-grid-column-three-quarters print-full-width">
       <RouterView />
     </div>
@@ -12,15 +7,10 @@
 </template>
 
 <script>
-import SideNavigation from '@/components/Navigation/SideNavigation.vue';
-import { isProcessing, getTaskTypes, TASK_STATUS } from '@/helpers/exerciseHelper';
-import { TASK_TYPE } from '@/helpers/constants';
-import { lookup } from '@/filters';
 
 export default {
   name: 'Tasks',
   components: {
-    SideNavigation,
   },
   computed: {
     exercise() {
@@ -28,106 +18,6 @@ export default {
     },
     stage() {
       return this.$route.params.stage;
-    },
-    sideNavigation() {
-      const exercise = this.exercise;
-      const stage = this.stage;
-      const path = `/exercise/${exercise.id}/tasks/${this.stage}`;
-      const sideNavigation = [];
-      switch (stage) {
-      case 'all':
-        getTaskTypes(exercise).forEach(taskType => {
-          const task = this.$store.getters['tasks/getTask'](taskType);
-          let tag;
-          if (task && task.status === TASK_STATUS.COMPLETED) {
-            tag = {
-              title: 'Done',
-              class: 'govuk-tag--blue',
-            };
-          }
-          sideNavigation.push(
-            {
-              title: lookup(taskType),
-              tag: tag,
-              path: `${path}/${taskType}`,
-            }
-          );
-        });
-        if (isProcessing(exercise)) {
-          if (!(exercise.assessmentMethods && exercise.assessmentMethods.independentAssessments === false)) {
-            sideNavigation.push({
-              title: 'Independent Assessments',
-              path: `${path}/independent-assessments`,
-            });
-          }
-          sideNavigation.push(
-            {
-              title: 'Character Checks',
-              path: `${path}/character-checks`,
-            }
-          );
-        }
-        break;
-      case 'shortlisting':
-        if (isProcessing(exercise)) {
-          if (!(exercise.assessmentMethods && exercise.assessmentMethods.independentAssessments === false)) {
-            sideNavigation.push({
-              title: 'Independent Assessments',
-              path: `${path}/independent-assessments`,
-            });
-          }
-        }
-        getTaskTypes(exercise, stage).forEach(taskType => {
-          const task = this.$store.getters['tasks/getTask'](taskType);
-          let tag;
-          if (task && task.status === TASK_STATUS.COMPLETED) {
-            tag = {
-              title: 'Done',
-              class: 'govuk-tag--blue',
-            };
-          }
-          sideNavigation.push(
-            {
-              title: lookup(taskType),
-              tag: tag,
-              path: `${path}/${taskType}`,
-            }
-          );
-        });
-        break;
-      case 'selection':
-        sideNavigation.push(
-          {
-            title: 'Character Checks',
-            path: `${path}/character-checks`,
-          }
-        );
-        getTaskTypes(exercise, stage).forEach(taskType => {
-          const task = this.$store.getters['tasks/getTask'](taskType);
-          let tag;
-          if (task && task.status === TASK_STATUS.COMPLETED) {
-            tag = {
-              title: 'Done',
-              class: 'govuk-tag--blue',
-            };
-          }
-          sideNavigation.push(
-            {
-              title: lookup(taskType),
-              tag: tag,
-              path: `${path}/${taskType}`,
-            }
-          );
-        });
-        sideNavigation.push(
-          {
-            title: lookup(TASK_TYPE.SELECTION_OUTCOME),
-            path: `${path}/${TASK_TYPE.SELECTION_OUTCOME}`,
-          }
-        );
-        break;
-      }
-      return sideNavigation;
     },
   },
   watch: {

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -29,7 +29,7 @@ const routes = [
   ['exercise-not-found', 'Exercise Not Found'],
   ['page-not-found', 'Page Not Found'],
   ['exercise-reports-character-checks', 'Character Checks'],
-  ['exercise-reports-character-issues', 'Character Issues'],
+  ['exercise-reports-character-issues', 'Character Annex'],
   ['exercise-reports-diversity-dashboard', 'Diversity Dashboard'],
   ['exercise-reports-eligibility-issues', 'Eligibility Annex'],
   ['exercise-reports-education-and-career-history', 'Education and Career History'],

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -31,7 +31,7 @@ const routes = [
   ['exercise-reports-character-checks', 'Character Checks'],
   ['exercise-reports-character-issues', 'Character Issues'],
   ['exercise-reports-diversity-dashboard', 'Diversity Dashboard'],
-  ['exercise-reports-eligibility-issues', 'Eligibility Issues'],
+  ['exercise-reports-eligibility-issues', 'Eligibility Annex'],
   ['exercise-reports-education-and-career-history', 'Education and Career History'],
   ['exercise-reports-jo-handover-report', 'JO Handover Report'],
   ['exercise-reports-statutory-consultation-table', 'Statutory Consultation Table'],


### PR DESCRIPTION
## What's included?
closes #2412 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link:
- [x] Reorder figures in Applications box on Dashboard
- [x] Change `Withdrawn` > `Withdrew`
- [x] Link to Applications/Applied page from Applied number on Dashboard
- [x] Link to Applications/Withdrawn page from Withdrawn number on Dashboard
- [x] Link to Applications/Draft page from Draft number on Dashboard
<img width="541" alt="Screenshot 2024-07-29 at 16 51 54" src="https://github.com/user-attachments/assets/d36dc7b4-df2f-4618-a72e-d0bdae65ec01">

- [x] Remove `Applications` from top navigation
- [x] Amend `Exercise` to `Exercise Set-up` in top navigation
<img width="753" alt="Screenshot 2024-07-29 at 16 45 46" src="https://github.com/user-attachments/assets/faa31778-9401-4846-ad79-021fc0522c1f">

- [x] Replicate the new onClick menu for Tasks, remove sidebar
<img width="781" alt="Screenshot 2024-07-29 at 17 49 31" src="https://github.com/user-attachments/assets/a47d8805-8566-4964-a128-ed12aa9be489">

- [x] Replicate the new onClick menu for Reports, remove sidebar
<img width="1077" alt="Screenshot 2024-07-29 at 16 47 41" src="https://github.com/user-attachments/assets/e5bda97a-c670-45e5-8f34-c98d47088940">

- [x] Replicate the new onClick menu for Stages, remove sidebar
<img width="1077" alt="Screenshot 2024-07-29 at 16 47 41" src="https://github.com/user-attachments/assets/01aff267-9e08-4ffe-aa5f-494796ca002c">

- [x] Sort the options in the `Reports` menu a-z
<img width="896" alt="Screenshot 2024-07-29 at 16 50 14" src="https://github.com/user-attachments/assets/198c6abc-a67b-47c3-a3ec-e2c13f87e162">

- [x] Rename `Character issues` and `Eligibility issues` links to `Character Annex` and `Eligibility Annex` respectively


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
