### PR TITLE
Bugfix/2458 Exercises Programme View

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -310,6 +310,13 @@ export default {
               this.$router.push({ name: 'exercises' });
             },
           },
+          {
+            title: 'Programme view',
+            link: () => {
+              this.$store.dispatch('exerciseCollection/showAll');
+              this.$router.push({ name: 'exercises-programme-view' });
+            },
+          },
           { title: 'Create exercise', link: { name: 'create-exercise' } }
         );
         if (this.canUpdateExercises && this.isApproved) {


### PR DESCRIPTION
## What's included?
Add the programme view back to the exercises menu.

![image](https://github.com/user-attachments/assets/f767f8fb-82be-4dbc-a1ef-d4d906baa0d0)


## Who should test?
✅ Product owner
✅ Developers

## How to test?

Check if the "Programme view" appears under the exercises menu.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
