### PR TITLE
Feature/2505 Apply user role filters on Exercise contacts page

### DIFF
--- a/src/components/RepeatableFields/SelectionExerciseManager.vue
+++ b/src/components/RepeatableFields/SelectionExerciseManager.vue
@@ -21,7 +21,6 @@
 
 <script>
 import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
-import { mapGetters } from 'vuex';
 
 export default {
   components: {
@@ -36,11 +35,10 @@ export default {
       required: true,
       type: Number,
     },
-  },
-  computed: {
-    ...mapGetters({
-      users: 'users/enabledJACUsers',
-    }),
+    users: {
+      type: Array,
+      default: () => [],
+    },
   },
 };
 </script>

--- a/src/components/RepeatableFields/SelectionExerciseOfficer.vue
+++ b/src/components/RepeatableFields/SelectionExerciseOfficer.vue
@@ -21,7 +21,6 @@
 
 <script>
 import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
-import { mapGetters } from 'vuex';
 
 export default {
   name: 'SelectionExerciseOfficer',
@@ -37,11 +36,10 @@ export default {
       required: true,
       type: Number,
     },
-  },
-  computed: {
-    ...mapGetters({
-      users: 'users/enabledJACUsers',
-    }),
+    users: {
+      type: Array,
+      default: () => [],
+    },
   },
 };
 </script>

--- a/src/components/RepeatableFields/SeniorSelectionExerciseManager.vue
+++ b/src/components/RepeatableFields/SeniorSelectionExerciseManager.vue
@@ -21,7 +21,6 @@
 
 <script>
 import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
-import { mapGetters } from 'vuex';
 
 export default {
   name: 'SeniorSelectionExerciseManager',
@@ -37,11 +36,10 @@ export default {
       required: true,
       type: Number,
     },
-  },
-  computed: {
-    ...mapGetters({
-      users: 'users/enabledJACUsers',
-    }),
+    users: {
+      type: Array,
+      default: () => [],
+    },
   },
 };
 </script>

--- a/src/store/users.js
+++ b/src/store/users.js
@@ -124,6 +124,7 @@ export default {
         });
     },
     getUsersByRoleId: (state) => (roleId) => {
+      if (!Array.isArray(state.records)) return [];
       return state.records.filter(user => user.role.id === roleId);
     },
   },

--- a/src/views/Exercise/Details/Contacts/Edit.vue
+++ b/src/views/Exercise/Details/Contacts/Edit.vue
@@ -57,7 +57,7 @@
           v-model="formData.seniorSelectionExerciseManager"
           :component="repeatableFields.SeniorSelectionExerciseManager"
           :pattern="patternJACEmail"
-          :extra-props="{ users: operationsTeamMembers }"
+          :extra-props="{ users: operationsSeniorManagers }"
           required
         />
 
@@ -242,6 +242,12 @@ export default {
     roles() {
       return this.$store.state.roles.records;
     },
+    operationsSeniorManagers() {
+      const role = this.roles.find(role => role.roleName === 'Operations Senior Manager');
+      if (!role) return [];
+      const users = this.$store.getters['users/getUsersByRoleId'](role.id);
+      return users;
+    },
     operationsTeamMembers() {
       const role = this.roles.find(role => role.roleName === 'Operations Team Member');
       if (!role) return [];
@@ -250,7 +256,7 @@ export default {
     },
   },
   async mounted() {
-    await this.$store.dispatch('roles/bind',  { where: [{ field: 'roleName', comparator: 'in', value: ['Operations Team Member'] }] });
+    await this.$store.dispatch('roles/bind',  { where: [{ field: 'roleName', comparator: 'in', value: ['Operations Senior Manager', 'Operations Team Member'] }] });
     await this.$store.dispatch('users/bind', { orderBy: 'displayName', direction: 'asc' });
   },
   async unmounted() {


### PR DESCRIPTION
## What's included?
Closes #2505 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
[Example exercise](https://jac-admin-develop--pr2510-feature-2505-apply-u-cilfp82k.web.app/exercise/TSZHvLiBpittnlOXmMlI/details/contacts/?referrer=exercise-show-overview)

Steps:
1. Go to the exercise contacts page.
2. Amend the "Senior selection exercise manager" fields and check if only users with the "Operations Senior Manager" role appear in the dropdown.
3. Amend the following fields and check if only users with the "Operations Team Member" role appear in the dropdown.
    - Selection exercise manager
    - Selection exercise officers

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
