### PR TITLE
change exercise reference prefix for external and Welsh GOV

### DIFF
--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -7,6 +7,7 @@ import clone from 'clone';
 import { getExerciseSaveData } from '@/helpers/exerciseHelper';
 import { logEvent } from '@/helpers/logEvent';
 import { checkNested } from '@/helpersTMP/object';
+import { ADVERT_TYPES } from '@/helpers/constants';
 
 const collectionName = 'exercises';
 const collectionRef = collection(firestore, collectionName);
@@ -56,8 +57,15 @@ export default {
         const metaDoc = await transaction.get(metaRef);
         const newExercisesCount = metaDoc.data().exercisesCount + 1;
         const exerciseRef = doc(collection(firestore, 'exercises'));
+
+        let prefix = 'JAC';
+        if (data.advertType === ADVERT_TYPES.EXTERNAL) {
+          prefix = 'EXT';
+        } else if (data.isWelshGov) {
+          prefix = 'GOW';
+        }
         transaction.update(metaRef, { exercisesCount: newExercisesCount });
-        data.referenceNumber = `JAC${  (100000 + newExercisesCount).toString().substr(1)}`;
+        data.referenceNumber = `${prefix}${  (100000 + newExercisesCount).toString().substr(1)}`;
         data.progress = data.progress || { started: true };
         data.state = 'draft';
         data.published = false;

--- a/src/views/CreateExercise.vue
+++ b/src/views/CreateExercise.vue
@@ -86,6 +86,27 @@
 
         <RadioGroup
           v-if="isAdvertTypeExternal !== null && !isAdvertTypeExternal"
+          id="is-a-Welsh-government-exercise"
+          v-model="isWelshGov"
+          label="Is this a Welsh government exercise"
+          required
+          :messages="{
+            required: 'Please specify whether the exercise a Welsh government exercise'
+          }"
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          />
+
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+        </RadioGroup>
+
+        <RadioGroup
+          v-if="isAdvertTypeExternal !== null && !isAdvertTypeExternal"
           id="is-more-info-needed"
           v-model="addMoreInfo"
           label="Do you want to add more information about this exercise now?"
@@ -197,6 +218,7 @@ export default {
     return {
       exerciseName: null,
       isAdvertTypeExternal: null,
+      isWelshGov: false,
       addMoreInfo: null,
       addMoreInfoSelection: null,
     };
@@ -214,6 +236,7 @@ export default {
           name: this.exerciseName,
           exerciseMailbox: this.$store.state.auth.currentUser.email,
           characterChecksEnabled: true,
+          isWelshGov: this.isWelshGov,
         };
 
         if (this.isAdvertTypeExternal) {

--- a/src/views/Exercises.vue
+++ b/src/views/Exercises.vue
@@ -131,7 +131,7 @@ export default {
   data() {
     return {
       tableColumns: [
-        { title: 'Reference', sort: 'referenceNumber', direction: 'asc', default: true },
+        { title: 'Reference', sort: 'createdAt', direction: 'desc', default: true },
         { title: 'Name', sort: 'name' },
         { title: 'Open', sort: 'applicationOpenDate' },
         { title: 'Close', sort: 'applicationCloseDate' },


### PR DESCRIPTION
## What's included?
Closes #2483 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link:
- The exercise table should sort by the number part of reference number
- Create a JAC exercise, the reference number should had `JAC` prefix
- Create a Welsh government exercise, the reference number should had `GOW` prefix
<img width="925" alt="Screenshot 2024-07-30 at 15 49 48" src="https://github.com/user-attachments/assets/ff991e68-3b59-439f-9d2b-840600214767">
- Create a external exercise, the reference number should had `EXT` prefix
 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
