### PR TITLE
Feature/2494 Amendments to Additional settings page

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -59,8 +59,8 @@ import ExerciseDetailsVacancyEdit from '@/views/Exercise/Details/Vacancy/Edit.vu
 import ExerciseDetailsPreferences from '@/views/Exercise/Details/Preferences/View.vue';
 import ExerciseDetailsPreferencesEdit from '@/views/Exercise/Details/Preferences/Edit.vue';
 import ExerciseDetailsPreferencesEditV1 from '@/views/Exercise/Details/Preferences/Edit.v1.vue';  // previous edit page
-import ExerciseDetailsAdditionalSettings from '@/views/Exercise/Details/AdditionalSettings/View.vue';
-import ExerciseDetailsAdditionalSettingsEdit from '@/views/Exercise/Details/AdditionalSettings/Edit.vue';
+import ExerciseDetailsSelectionSetup from '@/views/Exercise/Details/SelectionSetup/View.vue';
+import ExerciseDetailsSelectionSetupEdit from '@/views/Exercise/Details/SelectionSetup/Edit.vue';
 
 // Appplications
 import ExerciseApplications from '@/views/Exercise/Applications.vue';
@@ -629,25 +629,25 @@ const routes = [
             ],
           },
           {
-            path: 'additional-settings/',
+            path: 'selection-setup/',
             component: EmptyRouterView,
             children: [
               {
-                name: 'exercise-details-additional-settings',
+                name: 'exercise-details-selection-setup',
                 path: '',
-                component: ExerciseDetailsAdditionalSettings,
+                component: ExerciseDetailsSelectionSetup,
                 meta: {
                   requiresAuth: true,
-                  title: 'Additional Settings | Exercise Details',
+                  title: 'Selection Set-up | Exercise Details',
                 },
               },
               {
-                name: 'exercise-details-additional-settings-edit',
+                name: 'exercise-details-selection-setup-edit',
                 path: 'edit',
-                component: ExerciseDetailsAdditionalSettingsEdit,
+                component: ExerciseDetailsSelectionSetupEdit,
                 meta: {
                   requiresAuth: true,
-                  title: 'Edit Additional Settings | Exercise Details',
+                  title: 'Edit Selection Set-up | Exercise Details',
                 },
               },
             ],

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -374,7 +374,7 @@ export default {
         { title: 'Assessment options', link: { name: 'exercise-details-assessments' } },
         { title: 'Exercise downloads', link: { name: 'exercise-details-downloads' } },
         { title: 'Application process', link: { name: 'exercise-details-application-content' } },
-        { title: 'Additional settings', link: { name: 'exercise-details-additional-settings' } }
+        { title: 'Selection set-up', link: { name: 'exercise-details-selection-setup' } }
       );
       //  }
       //}

--- a/src/views/Exercise/Details/SelectionSetup/Edit.vue
+++ b/src/views/Exercise/Details/SelectionSetup/Edit.vue
@@ -19,35 +19,52 @@
           @save="save"
         />
 
-        <CheckboxGroup
-          id="capabilities"
-          v-model="formData.capabilities"
-          required
-          label="Selection Criteria"
-          :messages="{required: 'Please choose at least one capability'}"
+        <RadioGroup
+          id="assessment-framework"
+          v-model="formData.assessmentFramework"
+          label="The assessment framework used in this exercise is:"
         >
-          <CheckboxItem
-            v-for="capability in capabilities"
-            :key="capability"
-            :value="capability"
-            :label="$filters.lookup(capability)"
+          <RadioItem
+            label="Competencies"
+            value="competencies"
           />
-        </CheckboxGroup>
+          <RadioItem
+            label="Skills & Abilities"
+            value="skills-abilities"
+          />
+        </RadioGroup>
 
-        <CheckboxGroup
-          id="selectionCategories"
-          v-model="formData.selectionCategories"
-          required
-          label="Selection Tools"
-          :messages="{required: 'Please choose at least one'}"
-        >
-          <CheckboxItem
-            v-for="item in selectionCategories"
-            :key="item"
-            :value="item"
-            :label="$filters.lookup(item)"
-          />
-        </CheckboxGroup>
+        <template v-if="formData.assessmentFramework">
+          <CheckboxGroup
+            id="capabilities"
+            v-model="formData.capabilities"
+            required
+            label="Selection Criteria"
+            :messages="{required: 'Please choose at least one capability'}"
+          >
+            <CheckboxItem
+              v-for="capability in capabilities"
+              :key="capability"
+              :value="capability"
+              :label="$filters.lookup(capability)"
+            />
+          </CheckboxGroup>
+
+          <CheckboxGroup
+            id="selectionCategories"
+            v-model="formData.selectionCategories"
+            required
+            label="Selection Tools"
+            :messages="{required: 'Please choose at least one'}"
+          >
+            <CheckboxItem
+              v-for="item in selectionCategories"
+              :key="item"
+              :value="item"
+              :label="$filters.lookup(item)"
+            />
+          </CheckboxGroup>
+        </template>
 
         <button class="govuk-button">
           Save and continue
@@ -60,14 +77,22 @@
 <script>
 import Form from '@jac-uk/jac-kit/draftComponents/Form/Form.vue';
 import ErrorSummary from '@jac-uk/jac-kit/draftComponents/Form/ErrorSummary.vue';
+import RadioGroup from '@jac-uk/jac-kit/draftComponents/Form/RadioGroup.vue';
+import RadioItem from '@jac-uk/jac-kit/draftComponents/Form/RadioItem.vue';
 import CheckboxGroup from '@jac-uk/jac-kit/draftComponents/Form/CheckboxGroup.vue';
 import CheckboxItem from '@jac-uk/jac-kit/draftComponents/Form/CheckboxItem.vue';
 import BackLink from '@jac-uk/jac-kit/draftComponents/BackLink.vue';
-import { CAPABILITIES, SELECTION_CATEGORIES } from '@/helpers/exerciseHelper';
+
+const competenciesCapabilities = ['EJ', 'PBK', 'ACI', 'WCO', 'MWE'];
+const competenciesSelectionCategories = ['interview', 'situational', 'roleplay'];
+const skillsAbilitiesCapabilities = ['L&J', 'PQ', 'L'];
+const skillsAbilitiesSelectionCategories = ['interview', 'situational', 'leadership', 'roleplay'];
 
 export default {
   components: {
     ErrorSummary,
+    RadioGroup,
+    RadioItem,
     CheckboxGroup,
     CheckboxItem,
     BackLink,
@@ -75,10 +100,12 @@ export default {
   extends: Form,
   data(){
     const defaults = {
+      assessmentFramework: null,
       capabilities: null,
       selectionCategories: null,
     };
     const formData = this.$store.getters['exerciseDocument/data'](defaults);
+
     return {
       formData: formData,
     };
@@ -88,10 +115,36 @@ export default {
       return this.$store.getters['exerciseCreateJourney/hasJourney'];
     },
     capabilities() {
-      return CAPABILITIES;
+      switch (this.formData.assessmentFramework) {
+      case 'competencies':
+        return competenciesCapabilities;
+      case 'skills-abilities':
+        return skillsAbilitiesCapabilities;
+      default:
+        return [];
+      }
     },
     selectionCategories() {
-      return SELECTION_CATEGORIES;
+      switch (this.formData.assessmentFramework) {
+      case 'competencies':
+        return competenciesSelectionCategories;
+      case 'skills-abilities':
+        return skillsAbilitiesSelectionCategories;
+      default:
+        return [];
+      }
+    },
+  },
+  watch: {
+    'formData.assessmentFramework': function (newValue) {
+      // set default capabilities and selection categories based on the assessment framework
+      if (newValue === 'competencies') {
+        this.formData.capabilities = competenciesCapabilities;
+        this.formData.selectionCategories = competenciesSelectionCategories;
+      } else if (newValue === 'skills-abilities') {
+        this.formData.capabilities = skillsAbilitiesCapabilities;
+        this.formData.selectionCategories = skillsAbilitiesSelectionCategories;
+      }
     },
   },
   methods: {

--- a/src/views/Exercise/Details/SelectionSetup/Edit.vue
+++ b/src/views/Exercise/Details/SelectionSetup/Edit.vue
@@ -10,7 +10,7 @@
         </div>
 
         <h2 class="govuk-heading-l">
-          Additional settings
+          Selection set-up
         </h2>
 
         <ErrorSummary
@@ -98,7 +98,7 @@ export default {
     async save(isValid) {
       this.formData['progress.additionalSettings'] = isValid ? true : false;
       await this.$store.dispatch('exerciseDocument/save', this.formData);
-      this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']('exercise-details-additional-settings'));
+      this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']('exercise-details-selection-setup'));
     },
   },
 };

--- a/src/views/Exercise/Details/SelectionSetup/View.vue
+++ b/src/views/Exercise/Details/SelectionSetup/View.vue
@@ -4,13 +4,13 @@
       <router-link
         v-if="isEditable"
         class="govuk-link"
-        :to="{name: 'exercise-details-additional-settings-edit'}"
+        :to="{name: 'exercise-details-selection-setup-edit'}"
       >
-        Update additional settings
+        Update selection set-up
       </router-link>
     </div>
     <h2 class="govuk-heading-l">
-      Additional settings
+      Selection set-up
     </h2>
     <div class="govuk-summary-list">
       <div class="govuk-summary-list__row">


### PR DESCRIPTION
## What's included?
Closes #2494 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
[Example exercise](https://jac-admin-develop--pr2520-feature-2494-amendme-7h6mlq9l.web.app/exercise/iJOImbuYiOYfF1g8MEao/details/selection-setup/)

Steps:
1. Go to an exercise.
2. Check if the "Additional settings" page name is changed to "Selection set-up".
3. Check if the radio buttons (Competencies, Skills & Abilities) appear under the "The assessment framework used in this exercise" question.
4. When Competencies is selected, check if the options are displayed correctly.
5. When Skills & Abilities is selected, check if the options are displayed correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

Demo:

[video-30138001-16ba69a35996745200b2b1adfb54c476.webm](https://github.com/user-attachments/assets/007be321-a5e0-44d1-9a99-a46d06c1b96f)

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
