### PR TITLE
Bugfix/TS 342 Stat Con Contact

### DIFF
--- a/src/components/RepeatableFields/StatutoryConsultee.vue
+++ b/src/components/RepeatableFields/StatutoryConsultee.vue
@@ -5,7 +5,7 @@
       v-model="row.name"
       type="email"
       label="Statutory Consultee"
-      required
+      :required="!exercise.statutoryConsultationWaived"
     />
     <slot name="removeButton" />
   </div>
@@ -27,6 +27,11 @@ export default {
     index: {
       required: true,
       type: Number,
+    },
+  },
+  computed: {
+    exercise() {
+      return this.$store.state.exerciseDocument.record;
     },
   },
 };

--- a/src/views/Exercise/Details/Vacancy/View.vue
+++ b/src/views/Exercise/Details/Vacancy/View.vue
@@ -56,11 +56,10 @@
           Waived statutory consultation?
         </dt>
         <dd class="govuk-summary-list__value">
-          <span
-            v-if="exercise.statutoryConsultationWaivedDetails && exercise.statutoryConsultationWaived == true"
-          >
-            Yes: {{ exercise.statutoryConsultationWaivedDetails }}
+          <span v-if="exercise.statutoryConsultationWaived === true">
+            Yes{{ exercise.statutoryConsultationWaivedDetails ? `: ${exercise.statutoryConsultationWaivedDetails}` : '' }}
           </span>
+          <span v-else-if="exercise.statutoryConsultationWaived === false">No</span>
         </dd>
       </div>
       <div class="govuk-summary-list__row">


### PR DESCRIPTION
## What's included?

[User Raised Issue BR_ADMIN_DE_000239 #342](https://github.com/jac-uk/ticketing-system/issues/342)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

[Example exercise](https://jac-admin-develop--pr2526-bugfix-ts-342-stat-c-u197hzqh.web.app/exercise/nVYlHbW1Uivp0PsnVU3D/details/contacts/)

When Stat Con is waived, check if you can complete the contacts section without specifying a Stat Con contact.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

Demo:

[video-30141148-1532855a73cc4873e598363eb3cdd513.webm](https://github.com/user-attachments/assets/4602755c-1e64-4ecb-9019-95cac94f7adb)


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
