### PR TITLE
#2471 Add validation to the exercise application edit screen

### DIFF
--- a/src/components/Form/DateInput.vue
+++ b/src/components/Form/DateInput.vue
@@ -1,0 +1,295 @@
+<template>
+  <div
+    class="govuk-form-group"
+    :class="{ 'govuk-form-group--error': hasError }"
+  >
+    <fieldset
+      class="govuk-fieldset"
+      :aria-describedby="hint ? `${id}-hint` : null"
+      role="group"
+    >
+      <legend
+        v-if="label && displayLabel"
+        class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-2"
+      >
+        {{ label }}
+      </legend>
+
+      <span
+        v-if="hint"
+        :id="`${id}-hint`"
+        class="govuk-hint"
+      >
+        {{ hint }}
+      </span>
+
+      <FormFieldError
+        :id="id"
+        :error-message="errorMessage"
+      />
+
+      <div
+        :id="id"
+        class="govuk-date-input"
+      >
+        <template v-if="type === 'datetime'">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label
+                class="govuk-label govuk-date-input__label"
+                :for="`${id}-hour`"
+              >
+                Hour
+              </label>
+              <input
+                :id="`${id}-hour`"
+                ref="hourInput"
+                v-model.lazy="hourInput"
+                class="govuk-input govuk-date-input__input govuk-input--width-2"
+                type="number"
+              >
+            </div>
+          </div>
+          <div class="govuk-date-input__item govuk-!-margin-right-7">
+            <div class="govuk-form-group">
+              <label
+                class="govuk-label govuk-date-input__label"
+                :for="`${id}-minute`"
+              >
+                Minute
+              </label>
+              <input
+                :id="`${id}-minute`"
+                ref="minuteInput"
+                v-model.lazy="minuteInput"
+                class="govuk-input govuk-date-input__input govuk-input--width-2"
+                type="number"
+              >
+            </div>
+          </div>
+        </template>
+
+        <div
+          v-if="type === 'date' || type === 'datetime'"
+          class="govuk-date-input__item"
+        >
+          <div class="govuk-form-group">
+            <label
+              class="govuk-label govuk-date-input__label"
+              :for="`${id}-day`"
+            >
+              Day
+            </label>
+            <input
+              :id="`${id}-day`"
+              ref="dayInput"
+              v-model.lazy="dayInput"
+              class="govuk-input govuk-date-input__input govuk-input--width-2"
+              oninput="this.value=this.value.slice(0,this.maxLength)"
+              maxlength="2"
+              type="number"
+              :disabled="disabled"
+              @keydown="handleDay"
+            >
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <label
+              class="govuk-label govuk-date-input__label"
+              :for="`${id}-month`"
+            >
+              Month
+            </label>
+            <input
+              :id="`${id}-month`"
+              ref="monthInput"
+              v-model.lazy="monthInput"
+              class="govuk-input govuk-date-input__input govuk-input--width-2"
+              oninput="this.value=this.value.slice(0,this.maxLength)"
+              maxlength="2"
+              type="number"
+              :disabled="disabled"
+              @keydown="handleMonth"
+            >
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <label
+              class="govuk-label govuk-date-input__label"
+              :for="`${id}-year`"
+            >
+              Year
+            </label>
+            <input
+              :id="`${id}-year`"
+              ref="yearInput"
+              v-model.lazy="yearInput"
+              class="govuk-input govuk-date-input__input govuk-input--width-4"
+              oninput="this.value=this.value.slice(0,this.maxLength)"
+              maxlength="4"
+              type="number"
+              :disabled="disabled"
+              @keydown="handleYear"
+            >
+          </div>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+</template>
+
+<script>
+import parseAndClipNumber from '@jac-uk/jac-kit/helpers/Form/parseAndClipNumber';
+import validateYear from '@jac-uk/jac-kit/helpers/Form/validateYear';
+import zeroPad from '@jac-uk/jac-kit/helpers/Form/zeroPad';
+import FormField from '@jac-uk/jac-kit/draftComponents/Form/FormField.vue';
+import FormFieldError from '@jac-uk/jac-kit/draftComponents/Form/FormFieldError.vue';
+export default {
+  compatConfig: {
+    COMPONENT_V_MODEL: false,
+    // or, for full vue 3 compat in this component:
+    //MODE: 3,
+  },
+  components: {
+    FormFieldError,
+  },
+  extends: FormField,
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    type: {
+      default: 'date',
+      validator: value => ['date', 'month', 'datetime'].indexOf(value) !== -1,
+    },
+    modelValue: {
+      required: true,
+      validator: value => value instanceof Date || value === null || value === undefined,
+    },
+    displayLabel: { // Need to be able to suppress displaying the label when we want more control over it
+      type: Boolean,
+      default: true,
+    },
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return {
+      day: null,
+      month: null,
+      year: null,
+      hour: null,
+      minute: null,
+    };
+  },
+  computed: {
+
+    hourInput: {
+      get() {
+        return zeroPad(this.hour);
+      },
+      set(value) {
+        this.hour = parseAndClipNumber(value, 0, 23);
+      },
+    },
+    minuteInput: {
+      get() {
+        return zeroPad(this.minute);
+      },
+      set(value) {
+        this.minute = parseAndClipNumber(value, 0, 59);
+      },
+    },
+    dayInput: {
+      get() {
+        return zeroPad(this.day);
+      },
+      set(value) {
+        this.day = parseAndClipNumber(value, 1, 31);
+      },
+    },
+    monthInput: {
+      get() {
+        return zeroPad(this.month);
+      },
+      set(value) {
+        this.month = parseAndClipNumber(value, 1, 12);
+      },
+    },
+    yearInput: {
+      get() {
+        return this.year;
+      },
+      set(value) {
+        this.year = validateYear(value);
+      },
+    },
+    dateConstructor() {
+      const day = this.type === 'month' ? 1 : this.day;
+      const month = this.month;
+      const year = this.year;
+      const hour = this.type === 'datetime' ? this.hour : 13; // default time to 1pm. this avoids BST issue we would have if we defaulted to 0
+      const minute = this.type === 'datetime' ? this.minute : 0;
+      if (!day || !month || !year) {
+        return null;
+      }
+      return [year, month - 1, day, hour, minute];
+    },
+    date: {
+      get() {
+        if (this.dateConstructor === null) {
+          return null;
+        } else {
+          return new Date(...this.dateConstructor);
+        }
+      },
+      set(value) {
+        if (value instanceof Date) {
+          this.day = value.getDate();
+          this.month = value.getMonth() + 1;
+          this.year = value.getFullYear();
+          this.hour = value.getHours();
+          this.minute = value.getMinutes();
+        }
+      },
+    },
+  },
+  watch: {
+    date(value) {
+      this.$emit('update:modelValue', value);
+    },
+    modelValue(newValue, oldValue) {
+      if (!this.datesAreEqual(newValue, oldValue)) {
+        this.date = newValue;
+      }
+    },
+  },
+  created() {
+    this.date = this.modelValue;
+  },
+  methods: {
+    datesAreEqual(date1, date2) {
+      return date1 instanceof Date && date2 instanceof Date && date1.toISOString() === date2.toISOString();
+    },
+    handleDay(e) {
+      if (!['Backspace', 'ArrowRight', 'ArrowLeft', 'Tab', 'Shift'].some((item) => item === e.key) && e.target.value.length === e.target.maxLength) {
+        this.$refs['monthInput'].focus();
+      }
+    },
+    handleMonth(e) {
+      if (!['Backspace', 'ArrowRight', 'ArrowLeft', 'Tab', 'Shift'].some((item) => item === e.key) && e.target.value.length === e.target.maxLength) {
+        this.$refs['yearInput'].focus();
+      } else if (!e.target.value && e.key === 'Backspace') {
+        this.$refs['dayInput'].focus();
+      }
+    },
+    handleYear(e) {
+      if (!e.target.value && e.key === 'Backspace') {
+        this.$refs['monthInput'].focus();
+      }
+    },
+  },
+};
+</script>

--- a/src/components/Form/TextField.vue
+++ b/src/components/Form/TextField.vue
@@ -1,0 +1,118 @@
+<template>
+  <div
+    class="govuk-form-group"
+    :class="{ 'govuk-form-group--error': hasError }"
+  >
+    <label
+      v-show="displayLabel"
+      :for="id"
+      class="govuk-heading-m govuk-!-margin-bottom-2"
+    >
+      {{ label }}
+    </label>
+    <span
+      v-if="hint"
+      class="govuk-hint"
+    >
+      {{ hint }}
+    </span>
+    <FormFieldError
+      :id="id"
+      :error-message="errorMessage"
+    />
+    <input
+      :id="id"
+      v-model="value"
+      class="govuk-input"
+      :class="[inputClass, { 'govuk-input--error': hasError }]"
+      :type="fieldType"
+      :autocomplete="localAutocomplete"
+      :disabled="disabled"
+      @input="validate"
+    >
+  </div>
+</template>
+
+<script>
+import FormField from '@jac-uk/jac-kit/draftComponents/Form/FormField.vue';
+import FormFieldError from '@jac-uk/jac-kit/draftComponents/Form/FormFieldError.vue';
+export default {
+  // Below needs to be included while using vue2 compat mode else get warnings - check if it actually does get rid of the warnings!!
+  compatConfig: {
+    MODE: 3,
+  },
+  components: {
+    FormFieldError,
+  },
+  extends: FormField,
+  props: {
+    inputClass: {
+      default: '',
+      type: String,
+    },
+    modelValue: {
+      default: '',
+      type: [String, Number],
+    },
+    type: {
+      default: 'text',
+      type: String,
+    },
+    autocomplete: {
+      default: 'on',
+      type: String,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    displayLabel: { // Need to be able to suppress displaying the label when we want more control over it
+      type: Boolean,
+      default: true,
+    },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    value: {
+      get() {
+        return this.modelValue;
+      },
+      set(val) {
+        if (typeof val === 'string') {
+          val = val.trim();
+        }
+
+        switch (this.type) {
+        case 'number':
+          this.$emit('update:modelValue', val ? parseFloat(val) : '');
+          break;
+        default:
+          this.$emit('update:modelValue', val);
+        }
+      },
+    },
+    localAutocomplete() {
+      if (this.autocomplete === 'off') {
+        return 'new-password';  // To force prevent autofill!
+      }
+      switch (this.type) {
+      case 'tel':
+      case 'email':
+        return this.type;
+      default:
+        return null;
+      }
+    },
+
+    fieldType() {
+      switch (this.type) {
+      case 'text':
+      case 'email':
+        return 'text'; // we are using custom email validation, so don't use html5 input types
+      default:
+        return this.type;
+      }
+    },
+  },
+};
+</script>

--- a/src/components/Form/TextareaInput.vue
+++ b/src/components/Form/TextareaInput.vue
@@ -1,0 +1,139 @@
+<template>
+  <div
+    class="govuk-form-group"
+    :class="{'govuk-form-group--error': hasError}"
+  >
+    <label
+      v-show="displayLabel"
+      :for="id"
+      :class="labelHidden ? 'govuk-visually-hidden' : 'govuk-heading-m govuk-!-margin-bottom-2'"
+    >
+      {{ label }}
+    </label>
+    <CustomHTML
+      v-if="hint"
+      :value="hint"
+      class="govuk-hint"
+    />
+    <FormFieldError
+      :id="id"
+      :error-message="errorMessage"
+    />
+    <textarea
+      :id="id"
+      v-model="text"
+      class="govuk-textarea"
+      :class="disabled ? 'disabled': ''"
+      name="word-count"
+      :rows="rows"
+      :disabled="disabled"
+      :style="style"
+      @keydown="handleLimit($event)"
+      @keyup="handleLimit($event)"
+      @change="validate"
+    />
+
+    <div
+      v-if="wordLimit"
+      class="govuk-hint govuk-character-count__message"
+    >
+      <span
+        :class="wordsTooMany > 0 ? 'govuk-error-message' : ''"
+      >
+        {{ wordLimitCount }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+import FormField from '@jac-uk/jac-kit/draftComponents/Form/FormField.vue';
+import FormFieldError from '@jac-uk/jac-kit/draftComponents/Form/FormFieldError.vue';
+import CustomHTML from '@jac-uk/jac-kit/components/CustomHTML.vue';
+export default {
+  compatConfig: {
+    COMPONENT_V_MODEL: false,
+    // or, for full vue 3 compat in this component:
+    //MODE: 3,
+  },
+  name: 'TextareaInput',
+  components: {
+    FormFieldError,
+    CustomHTML,
+  },
+  extends: FormField,
+  props: {
+    modelValue: {
+      default: '',
+      type: String,
+    },
+    rows: {
+      default: '5',
+      type: String,
+    },
+    wordLimit: {
+      required: false,
+      default: 0,
+      type: Number,
+    },
+    labelHidden: {
+      default: false,
+      type: Boolean,
+    },
+    disabled: {
+      default: false,
+      type: Boolean,
+    },
+    style: {
+      default: () => {},
+      type: Object,
+    },
+    displayLabel: { // Need to be able to suppress displaying the label when we want more control over it
+      type: Boolean,
+      default: true,
+    },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    wordsTooMany() {
+      return this.words.length - this.wordLimit;
+    },
+    wordLimitCount() {
+      let result;
+      const plural = Math.abs(this.wordsTooMany) > 1 ? 's' : '';
+      if (this.words.length > this.wordLimit) {
+        result = `You have ${this.wordsTooMany} word${plural} too many`;
+      } else if (Math.floor(this.wordLimit * 0.20) > Math.abs(this.wordsTooMany)) {
+        result = `You have ${Math.abs(this.wordsTooMany)} word${plural} remaining`;
+      } else {
+        result = `${this.words.length}/${this.wordLimit}`;
+      }
+      if (this.wordsTooMany == 0) {
+        result = 'You have no words remaining';
+      }
+      return result;
+    },
+    text: {
+      get() {
+        return this.modelValue;
+      },
+      set(val) {
+        this.$emit('update:modelValue', val);
+      },
+    },
+  },
+
+  methods: {
+    handleLimit(e){
+      if (this.wordLimit && [8, 46].indexOf(e.keyCode) === -1) {
+        this.handleValidate();
+      }
+    },
+  },
+};
+</script>
+<style>
+.disabled {
+  background-color: darkgrey;
+}
+</style>

--- a/src/components/Page/EditableField.vue
+++ b/src/components/Page/EditableField.vue
@@ -216,6 +216,8 @@
         :id="`editable-field-${id}`"
         v-model="localField"
         type="email"
+        :required="isRequired"
+        :label="errorFieldName"
       />
 
       <TextField
@@ -223,18 +225,28 @@
         :id="`editable-field-${id}`"
         v-model="localField"
         type="tel"
+        :required="isRequired"
+        :display-label="displayLabel"
+        :label="errorFieldName"
       />
 
       <TextField
         v-if="isText || isRoute"
         :id="`editable-field-${id}`"
         v-model="localField"
+        :required="isRequired"
+        :display-label="displayLabel"
+        :label="errorFieldName"
       />
 
       <TextareaInput
         v-if="isTextarea"
         :id="`editable-field-${id}`"
         v-model="localField"
+        :required="isRequired"
+        :display-label="displayLabel"
+        :label="errorFieldName"
+        :word-limit="typeProps.wordLimit"
       />
 
       <DateInput
@@ -243,6 +255,9 @@
         v-model="localField"
         :type="(displayMonthYearOnly ? 'month' : 'date')"
         :value="localField"
+        :required="isRequired"
+        :display-label="displayLabel"
+        :label="errorFieldName"
       />
 
       <Select
@@ -365,9 +380,9 @@
 </template>
 
 <script>
-import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField.vue';
-import TextareaInput from '@jac-uk/jac-kit/draftComponents/Form/TextareaInput.vue';
-import DateInput from '@jac-uk/jac-kit/draftComponents/Form/DateInput.vue';
+import TextField from '@/components/Form/TextField.vue';
+import TextareaInput from '@/components/Form/TextareaInput.vue';
+import DateInput from '@/components/Form/DateInput.vue';
 import formatEmail from '@jac-uk/jac-kit/helpers/Form/formatEmail';
 import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
 import CheckboxGroup from '@jac-uk/jac-kit/draftComponents/Form/CheckboxGroup.vue';
@@ -445,6 +460,23 @@ export default {
       type: Object,
       required: false,
       default: null,
+    },
+    displayLabel: {
+      type: Boolean,
+      default: false,
+    },
+    errorFieldName: {
+      type: String,
+      default: '',
+    },
+    isRequired: {
+      type: Boolean,
+      default: false,
+    },
+    typeProps: {
+      type: Object,
+      required: false,
+      default: () => ({}),
     },
   },
   emits: ['changeField'],

--- a/src/components/Page/InformationReviewRenderer.vue
+++ b/src/components/Page/InformationReviewRenderer.vue
@@ -15,6 +15,9 @@
           :extension="extension"
           :display-month-year-only="displayMonthYearOnly"
           :is-asked="isAsked"
+          :is-required="isRequired"
+          :display-label="displayLabel"
+          :error-field-name="errorFieldName"
           @change-field="changeField"
         />
       </div>
@@ -32,6 +35,9 @@
           :extension="extension"
           type="route"
           :is-asked="isAsked"
+          :is-required="isRequired"
+          :display-label="displayLabel"
+          :error-field-name="errorFieldName"
           @change-field="changeField"
         />
       </div>
@@ -48,6 +54,9 @@
           type="email"
           :extension="extension"
           :is-asked="isAsked"
+          :is-required="isRequired"
+          :display-label="displayLabel"
+          :error-field-name="errorFieldName"
           @change-field="changeField"
         />
       </div>
@@ -64,6 +73,9 @@
           type="tel"
           :extension="extension"
           :is-asked="isAsked"
+          :is-required="isRequired"
+          :display-label="displayLabel"
+          :error-field-name="errorFieldName"
           @change-field="changeField"
         />
       </div>
@@ -119,6 +131,30 @@
             @change-field="changeField"
           />
         </span>
+      </div>
+
+      <div
+        v-else-if="isTextarea"
+      >
+        <EditableField
+          :id="field"
+          :edit-mode="edit"
+          :value="data"
+          :field="field"
+          :extension="extension"
+          :type="type"
+          :type-props="typeProps"
+          :index="index"
+          :is-asked="isAsked"
+          :disable-submit-on-error="disableSubmitOnError"
+          :disable-universal-validation="disableUniversalValidation"
+          :word-limit="typeProps.wordLimit"
+          :is-required="isRequired"
+          :display-label="displayLabel"
+          :error-field-name="errorFieldName"
+          @change-field="changeField"
+          @edit-field="editField"
+        />
       </div>
 
       <div
@@ -249,6 +285,18 @@ export default {
       required: false,
       default: false,
     },
+    displayLabel: {
+      type: Boolean,
+      default: false,
+    },
+    isRequired: {
+      type: Boolean,
+      default: false,
+    },
+    errorFieldName: {
+      type: String,
+      default: '',
+    },
   },
   emits: ['changeField', 'editField'],
   data() {
@@ -278,6 +326,9 @@ export default {
     },
     isRouted() {
       return this.$props.type === 'route';
+    },
+    isTextarea() {
+      return this.$props.type === 'textarea';
     },
   },
   methods: {

--- a/src/views/InformationReview/AssessmentsSummary.vue
+++ b/src/views/InformationReview/AssessmentsSummary.vue
@@ -47,7 +47,12 @@
                 extension="answerDetails"
                 field="selectionCriteriaAnswers"
                 type="textarea"
+                class="govuk-!-padding-top-2"
                 :is-asked="isApplicationPartAsked('statementOfSuitability')"
+                :is-required="true"
+                :display-label="false"
+                :type-props="{ wordLimit: item.wordLimit || defaultWordCount }"
+                error-field-name="statutory eligibility requirement"
                 @change-field="changeAssessmentInfo"
               />
             </div>
@@ -322,6 +327,7 @@ import DownloadLink from '@jac-uk/jac-kit/draftComponents/DownloadLink.vue';
 import FileUpload from '@jac-uk/jac-kit/draftComponents/Form/FileUpload.vue';
 import Spinner from '@jac-uk/jac-kit/components/Spinner.vue';
 import AssessmentSection from '@/components/RepeatableFields/AssessmentSection.vue';
+import { DEFAULT_WORD_COUNT } from '@/helpers/constants';
 export default {
   name: 'AssessmentsSummary',
   components: {
@@ -350,10 +356,12 @@ export default {
   },
   emits: ['updateApplication'],
   data() {
+    const defaultWordCount = DEFAULT_WORD_COUNT.ADDITIONAL_SELECTION_CRITERIA;
     return {
       assessorDetails: {},
       isLoadingFile: false,
       editUploadSelfAssessmentMode: false,
+      defaultWordCount: defaultWordCount,
     };
   },
   computed: {

--- a/src/views/InformationReview/PersonalDetailsSummary.vue
+++ b/src/views/InformationReview/PersonalDetailsSummary.vue
@@ -33,6 +33,9 @@
               type="route"
               :data="hasPersonalDetails ? personalDetails.title : ''"
               :is-asked="isAsked"
+              :is-required="true"
+              :display-label="false"
+              error-field-name="title"
               @change-field="changeUserDetails"
             />
           </dd>
@@ -52,6 +55,9 @@
               type="route"
               field="firstName"
               :is-asked="isAsked"
+              :is-required="true"
+              :display-label="false"
+              error-field-name="first name"
               @change-field="changeUserDetails"
             />
           </dd>
@@ -89,6 +95,9 @@
               type="route"
               field="lastName"
               :is-asked="isAsked"
+              :is-required="true"
+              :display-label="false"
+              error-field-name="last name"
               @change-field="changeUserDetails"
             />
           </dd>
@@ -194,6 +203,9 @@
               type="email"
               field="email"
               :is-asked="isAsked"
+              :is-required="true"
+              :display-label="false"
+              error-field-name="email"
               @change-field="changeUserDetails"
             />
           </dd>
@@ -230,6 +242,9 @@
               type="date"
               field="dateOfBirth"
               :is-asked="isAsked"
+              :is-required="true"
+              :display-label="false"
+              error-field-name="date of birth"
               @change-field="changeUserDetails"
             />
           </dd>
@@ -265,6 +280,9 @@
               :data="(hasPersonalDetails ? $filters.formatNIN(personalDetails.nationalInsuranceNumber): '')"
               field="nationalInsuranceNumber"
               :is-asked="isAsked"
+              :is-required="true"
+              :display-label="false"
+              error-field-name="NI number"
               @change-field="changeUserDetails"
             />
           </dd>


### PR DESCRIPTION
## What's included?
Added validation to the application edit screen.

Closes #2471 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- Go to an exercise with some applications and open one of them, for example: https://jac-admin-develop--pr2533-feature-2471-add-val-7q46xm8x.web.app/exercise/9OEv0lIZ4N8SWPmWJ4sx/applications/applied/application/jglQ5IG3HgOLNVeBwcYx
- Click the edit button
- Try to empty some of the required fields such as title, first name, date of birth and statutory eligibility requirement (when set to 'Yes' the textarea should be required) and when you press the 'save' button you should get an error
- Try to empty on of the non-required fields such as middle name. This should be allowed.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

https://github.com/user-attachments/assets/19d5fcf1-2de4-4723-8232-bd32ac7e5a0d

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
