### PR TITLE
#2534 Fix broken layout

### DIFF
--- a/src/views/Exercise/Reports.vue
+++ b/src/views/Exercise/Reports.vue
@@ -1,8 +1,6 @@
 <template>
-  <div class="govuk-grid-row">
-    <div class="print-full-width">
-      <RouterView />
-    </div>
+  <div class="print-full-width">
+    <RouterView />
   </div>
 </template>
 

--- a/src/views/Exercise/Reports/CommissionerConflicts.vue
+++ b/src/views/Exercise/Reports/CommissionerConflicts.vue
@@ -1,21 +1,30 @@
 <template>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        Commissioner Conflicts
-      </h1>
-    </div>
-    <div class="govuk-grid-column-one-third text-right govuk-!-padding-bottom-7">
-      <ActionButton
-        v-if="hasPermissions([
-          PERMISSIONS.exercises.permissions.canReadExercises.value,
-          PERMISSIONS.applications.permissions.canReadApplications.value
-        ])"
-        class="govuk-!-margin-right-2"
-        :action="exportToGoogleDoc"
-      >
-        Export to Word
-      </ActionButton>
+    <div class="govuk-grid-column-full">
+      <div class="moj-page-header-actions govuk-!-margin-bottom-0">
+        <div class="moj-page-header-actions__title">
+          <h2 class="govuk-heading-l">
+            Commissioner Conflicts
+          </h2>
+        </div>
+        <div
+          class="moj-page-header-actions__actions float-right"
+        >
+          <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper">
+              <ActionButton
+                v-if="hasPermissions([
+                  PERMISSIONS.exercises.permissions.canReadExercises.value,
+                  PERMISSIONS.applications.permissions.canReadApplications.value
+                ])"
+                :action="exportToGoogleDoc"
+              >
+                Export to Word
+              </ActionButton>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="govuk-grid-column-full">

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="govuk-grid-row">
     <!-- diversity header -->
     <div
       v-if="hasPermissions([

--- a/src/views/Exercise/Reports/Deployment.vue
+++ b/src/views/Exercise/Reports/Deployment.vue
@@ -1,100 +1,102 @@
 <template>
-  <div class="govuk-grid-column-full">
-    <div class="moj-page-header-actions">
-      <div class="moj-page-header-actions__title">
-        <h2 class="govuk-heading-l">
-          Deployment Report - Location & Jurisdiction Details only
-        </h2>
-        <span
-          v-if="report"
-          class="govuk-body govuk-!-font-size-14"
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="moj-page-header-actions">
+        <div class="moj-page-header-actions__title">
+          <h2 class="govuk-heading-l">
+            Deployment Report - Location & Jurisdiction Details only
+          </h2>
+          <span
+            v-if="report"
+            class="govuk-body govuk-!-font-size-14"
+          >
+            {{ $filters.formatDate(report.createdAt, 'longdatetime') }}
+          </span>
+        </div>
+
+        <div
+          class="moj-page-header-actions__actions float-right"
         >
-          {{ $filters.formatDate(report.createdAt, 'longdatetime') }}
-        </span>
-      </div>
+          <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper">
+              <button
+                class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
+                data-module="govuk-button"
+                :disabled="!hasReportData"
+                @click="exportData()"
+              >
+                Export data
+              </button>
 
-      <div
-        class="moj-page-header-actions__actions float-right"
-      >
-        <div class="moj-button-menu">
-          <div class="moj-button-menu__wrapper">
-            <button
-              class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
-              data-module="govuk-button"
-              :disabled="!hasReportData"
-              @click="exportData()"
-            >
-              Export data
-            </button>
-
-            <ActionButton
-              v-if="hasPermissions([
-                PERMISSIONS.exercises.permissions.canReadExercises.value,
-                PERMISSIONS.applications.permissions.canReadApplications.value,
-                PERMISSIONS.applicationRecords.permissions.canReadApplicationRecords.value,
-              ])"
-              type="primary"
-              :action="refreshReport"
-            >
-              Refresh
-            </ActionButton>
+              <ActionButton
+                v-if="hasPermissions([
+                  PERMISSIONS.exercises.permissions.canReadExercises.value,
+                  PERMISSIONS.applications.permissions.canReadApplications.value,
+                  PERMISSIONS.applicationRecords.permissions.canReadApplicationRecords.value,
+                ])"
+                type="primary"
+                :action="refreshReport"
+              >
+                Refresh
+              </ActionButton>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <div class="panel govuk-!-margin-bottom-9">
-          <span class="govuk-caption-m">
-            {{ $filters.lookup(applicationRecordStatus) }}
-          </span>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ $filters.formatNumber(totalApplicationRecords) }}
-          </h2>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <div class="panel govuk-!-margin-bottom-9">
+            <span class="govuk-caption-m">
+              {{ $filters.lookup(applicationRecordStatus) }}
+            </span>
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+              {{ $filters.formatNumber(totalApplicationRecords) }}
+            </h2>
+          </div>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <div class="panel govuk-!-margin-bottom-9">
+            <span class="govuk-caption-m">Type of exercise</span>
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+              {{ $filters.lookup(exerciseType) }}
+            </h2>
+          </div>
         </div>
       </div>
-      <div class="govuk-grid-column-one-half">
-        <div class="panel govuk-!-margin-bottom-9">
-          <span class="govuk-caption-m">Type of exercise</span>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ $filters.lookup(exerciseType) }}
-          </h2>
-        </div>
-      </div>
-    </div>
 
-    <Table
-      v-if="report != null"
-      data-key="id"
-      :data="report.rows"
-      :columns="tableColumns"
-      :page-size="1000"
-      local-data
-      @change="getTableData"
-    >
-      <template #row="{row}">
-        <TableCell :title="tableColumns[0].title">
-          <RouterLink
-            :to="{ name: 'exercise-application', params: { applicationId: row.applicationId } }"
-          >
-            {{ row.referenceNumber }}
-          </RouterLink>
-        </TableCell>
-        <TableCell :title="tableColumns[1].title">
-          <RouterLink
-            :to="{ name: 'candidates-view', params: { id: row.candidateId } }"
-          >
-            {{ row.fullName }}
-          </RouterLink>
-        </TableCell>
-      </template>
-    </Table>
-    <Modal
-      ref="infoModal"
-    >
-      <ReportInfo @close="closeModal" />
-    </Modal>
+      <Table
+        v-if="report != null"
+        data-key="id"
+        :data="report.rows"
+        :columns="tableColumns"
+        :page-size="1000"
+        local-data
+        @change="getTableData"
+      >
+        <template #row="{row}">
+          <TableCell :title="tableColumns[0].title">
+            <RouterLink
+              :to="{ name: 'exercise-application', params: { applicationId: row.applicationId } }"
+            >
+              {{ row.referenceNumber }}
+            </RouterLink>
+          </TableCell>
+          <TableCell :title="tableColumns[1].title">
+            <RouterLink
+              :to="{ name: 'candidates-view', params: { id: row.candidateId } }"
+            >
+              {{ row.fullName }}
+            </RouterLink>
+          </TableCell>
+        </template>
+      </Table>
+      <Modal
+        ref="infoModal"
+      >
+        <ReportInfo @close="closeModal" />
+      </Modal>
+    </div>
   </div>
 </template>
 

--- a/src/views/Exercise/Reports/Diversity.vue
+++ b/src/views/Exercise/Reports/Diversity.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="govuk-grid-row">
     <!-- diversity header -->
     <div class="govuk-grid-column-full">
       <div class="moj-page-header-actions">

--- a/src/views/Exercise/Reports/Handover.vue
+++ b/src/views/Exercise/Reports/Handover.vue
@@ -1,37 +1,38 @@
 <template>
-  <div class="govuk-grid-column-full">
-    <div class="moj-page-header-actions">
-      <div class="moj-page-header-actions__title">
-        <h2 class="govuk-heading-l">
-          Handover Report - HR Details only
-        </h2>
-      </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="moj-page-header-actions">
+        <div class="moj-page-header-actions__title">
+          <h2 class="govuk-heading-l">
+            Handover Report - HR Details only
+          </h2>
+        </div>
 
-      <div
-        class="moj-page-header-actions__actions float-right"
-      >
-        <div class="moj-button-menu">
-          <div class="moj-button-menu__wrapper">
-            <button
-              class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
-              data-module="govuk-button"
-              :disabled="!hasReportData"
-              @click="exportData()"
-            >
-              Export data
-            </button>
+        <div
+          class="moj-page-header-actions__actions float-right"
+        >
+          <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper">
+              <button
+                class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
+                data-module="govuk-button"
+                :disabled="!hasReportData"
+                @click="exportData()"
+              >
+                Export data
+              </button>
 
-            <ActionButton
-              v-if="hasPermissions([
-                PERMISSIONS.exercises.permissions.canReadExercises.value,
-                PERMISSIONS.applicationRecords.permissions.canReadApplicationRecords.value,
-                PERMISSIONS.applications.permissions.canReadApplications.value
-              ])"
-              type="primary"
-              :action="refreshReport"
-            >
-              Refresh
-            </ActionButton>
+              <ActionButton
+                v-if="hasPermissions([
+                  PERMISSIONS.exercises.permissions.canReadExercises.value,
+                  PERMISSIONS.applicationRecords.permissions.canReadApplicationRecords.value,
+                  PERMISSIONS.applications.permissions.canReadApplications.value
+                ])"
+                type="primary"
+                :action="refreshReport"
+              >
+                Refresh
+              </ActionButton>
             <!--            <ActionButton-->
             <!--              v-if="totalApplicationRecords"-->
             <!--              type="primary"-->
@@ -39,64 +40,65 @@
             <!--            >-->
             <!--              Transfer Handover Data-->
             <!--            </ActionButton>-->
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <div class="panel govuk-!-margin-bottom-9">
-          <span class="govuk-caption-m">
-            Approved for immediate appointment
-          </span>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ $filters.formatNumber(totalApplicationRecords) }}
-          </h2>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <div class="panel govuk-!-margin-bottom-9">
+            <span class="govuk-caption-m">
+              Approved for immediate appointment
+            </span>
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+              {{ $filters.formatNumber(totalApplicationRecords) }}
+            </h2>
+          </div>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <div class="panel govuk-!-margin-bottom-9">
+            <span class="govuk-caption-m">Type of exercise</span>
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+              {{ $filters.lookup(exerciseType) }}
+            </h2>
+          </div>
         </div>
       </div>
-      <div class="govuk-grid-column-one-half">
-        <div class="panel govuk-!-margin-bottom-9">
-          <span class="govuk-caption-m">Type of exercise</span>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-            {{ $filters.lookup(exerciseType) }}
-          </h2>
-        </div>
-      </div>
+
+      <Table
+        v-if="report != null"
+        data-key="id"
+        :data="report.rows"
+        :columns="tableColumns"
+        :page-size="1000"
+        local-data
+        @change="getTableData"
+      >
+        <template #row="{row}">
+          <TableCell :title="tableColumns[0].title">
+            <RouterLink
+              :to="{ name: 'exercise-application', params: { applicationId: row.applicationId } }"
+            >
+              {{ row.referenceNumber }}
+            </RouterLink>
+          </TableCell>
+          <TableCell :title="tableColumns[1].title">
+            <RouterLink
+              :to="{ name: 'candidates-view', params: { id: row.candidateId } }"
+            >
+              {{ row.fullName }}
+            </RouterLink>
+          </TableCell>
+        </template>
+      </Table>
+
+      <Modal
+        ref="infoModal"
+      >
+        <ReportInfo @close="closeModal" />
+      </Modal>
     </div>
-
-    <Table
-      v-if="report != null"
-      data-key="id"
-      :data="report.rows"
-      :columns="tableColumns"
-      :page-size="1000"
-      local-data
-      @change="getTableData"
-    >
-      <template #row="{row}">
-        <TableCell :title="tableColumns[0].title">
-          <RouterLink
-            :to="{ name: 'exercise-application', params: { applicationId: row.applicationId } }"
-          >
-            {{ row.referenceNumber }}
-          </RouterLink>
-        </TableCell>
-        <TableCell :title="tableColumns[1].title">
-          <RouterLink
-            :to="{ name: 'candidates-view', params: { id: row.candidateId } }"
-          >
-            {{ row.fullName }}
-          </RouterLink>
-        </TableCell>
-      </template>
-    </Table>
-
-    <Modal
-      ref="infoModal"
-    >
-      <ReportInfo @close="closeModal" />
-    </Modal>
   </div>
 </template>
 

--- a/src/views/Exercise/Reports/MeritList.vue
+++ b/src/views/Exercise/Reports/MeritList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="govuk-grid-row">
     <!-- diversity header -->
     <div class="govuk-grid-column-full">
       <div class="moj-page-header-actions govuk-!-margin-bottom-0">

--- a/src/views/Exercise/Reports/Outreach.vue
+++ b/src/views/Exercise/Reports/Outreach.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="govuk-grid-row">
     <!-- report header -->
     <div class="govuk-grid-column-full">
       <div class="moj-page-header-actions">

--- a/src/views/Exercise/Reports/StatutoryConsultation.vue
+++ b/src/views/Exercise/Reports/StatutoryConsultation.vue
@@ -1,79 +1,81 @@
 <template>
-  <div class="govuk-grid-column-full">
-    <div class="moj-page-header-actions">
-      <div class="moj-page-header-actions__title">
-        <h2 class="govuk-heading-l">
-          Statutory Consultation
-        </h2>
-      </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="moj-page-header-actions">
+        <div class="moj-page-header-actions__title">
+          <h2 class="govuk-heading-l">
+            Statutory Consultation
+          </h2>
+        </div>
 
-      <div
-        class="moj-page-header-actions__actions float-right"
-      >
-        <div class="moj-button-menu">
-          <div class="moj-button-menu__wrapper">
-            <button
-              class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
-              data-module="govuk-button"
-              :disabled="!hasReportData"
-              @click="exportData()"
-            >
-              Export data
-            </button>
+        <div
+          class="moj-page-header-actions__actions float-right"
+        >
+          <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper">
+              <button
+                class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action"
+                data-module="govuk-button"
+                :disabled="!hasReportData"
+                @click="exportData()"
+              >
+                Export data
+              </button>
 
-            <ActionButton
-              v-if="hasPermissions([
-                PERMISSIONS.applications.permissions.canReadApplications.value,
-                PERMISSIONS.exercises.permissions.canReadExercises.value
-              ])"
-              type="primary"
-              :action="refreshReport"
-            >
-              Refresh
-            </ActionButton>
+              <ActionButton
+                v-if="hasPermissions([
+                  PERMISSIONS.applications.permissions.canReadApplications.value,
+                  PERMISSIONS.exercises.permissions.canReadExercises.value
+                ])"
+                type="primary"
+                :action="refreshReport"
+              >
+                Refresh
+              </ActionButton>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <Table
-          data-key="id"
-          :data="applicationRecords"
-          :columns="tableColumns"
-          page-item-type="number"
-          :page-size="50"
-          :custom-search="{
-            placeholder: 'Search candidate names',
-            handler: candidateSearch,
-            field: 'candidate.id',
-          }"
-          :total="total"
-          @change="getTableData"
-        >
-          <template #row="{row}">
-            <TableCell :title="tableColumns[0].title">
-              <RouterLink
-                class="govuk-link"
-                :to="{name: 'exercise-applications-application', params: { applicationId: row.id, status: 'applied' }}"
-                target="_blank"
-              >
-                {{ row.application.referenceNumber }}
-              </RouterLink>
-            </TableCell>
-            <TableCell :title="tableColumns[1].title">
-              {{ row.candidate && row.candidate.fullName }}
-            </TableCell>
-            <TableCell :title="tableColumns[2].title">
-              <TextareaInput
-                :id="`statutory-consultation-note-${row.candidate.id}`"
-                :value="row.statutoryConsultation && row.statutoryConsultation.note"
-                @input="saveStatutoryConsultationNote(row, $event)"
-              />
-            </TableCell>
-          </template>
-        </Table>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <Table
+            data-key="id"
+            :data="applicationRecords"
+            :columns="tableColumns"
+            page-item-type="number"
+            :page-size="50"
+            :custom-search="{
+              placeholder: 'Search candidate names',
+              handler: candidateSearch,
+              field: 'candidate.id',
+            }"
+            :total="total"
+            @change="getTableData"
+          >
+            <template #row="{row}">
+              <TableCell :title="tableColumns[0].title">
+                <RouterLink
+                  class="govuk-link"
+                  :to="{name: 'exercise-applications-application', params: { applicationId: row.id, status: 'applied' }}"
+                  target="_blank"
+                >
+                  {{ row.application.referenceNumber }}
+                </RouterLink>
+              </TableCell>
+              <TableCell :title="tableColumns[1].title">
+                {{ row.candidate && row.candidate.fullName }}
+              </TableCell>
+              <TableCell :title="tableColumns[2].title">
+                <TextareaInput
+                  :id="`statutory-consultation-note-${row.candidate.id}`"
+                  :value="row.statutoryConsultation && row.statutoryConsultation.note"
+                  @input="saveStatutoryConsultationNote(row, $event)"
+                />
+              </TableCell>
+            </template>
+          </Table>
+        </div>
       </div>
     </div>
   </div>

--- a/src/views/Exercise/Stages.vue
+++ b/src/views/Exercise/Stages.vue
@@ -1,8 +1,6 @@
 <template>
-  <div class="govuk-grid-row">
-    <div class="exercise-stages print-full-width">
-      <RouterView />
-    </div>
+  <div class="exercise-stages print-full-width">
+    <RouterView />
   </div>
 </template>
 

--- a/src/views/Exercise/Tasks.vue
+++ b/src/views/Exercise/Tasks.vue
@@ -1,8 +1,6 @@
 <template>
-  <div class="govuk-grid-row">
-    <div class="print-full-width">
-      <RouterView />
-    </div>
+  <div class="print-full-width">
+    <RouterView />
   </div>
 </template>
 

--- a/src/views/Exercise/Tasks/Task/Completed.vue
+++ b/src/views/Exercise/Tasks/Task/Completed.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <div class="govuk-grid-row">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-        {{ $filters.lookup(type) }}
-      </h1>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="text-right">
+      <div class="govuk-grid-column-one-half">
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+          {{ $filters.lookup(type) }}
+        </h1>
+      </div>
+      <div class="text-right govuk-grid-column-one-half">
         <ActionButton
           v-if="showEmailButton && hasPermissions([
             PERMISSIONS.applications.permissions.canReadApplications.value,
@@ -18,7 +18,6 @@
         >
           Send report notfication
         </ActionButton>
-
         <FullScreenButton />
       </div>
     </div>


### PR DESCRIPTION
## What's included?
Fixes the layout of:
 - [x] Tasks
 - [x] Reports
 - [x] Stages

Note: I have removed `govuk-grid-row` from the top-level templates for Tasks, Reports and Stages. It is easier to manage if grid row and column code is together in the same file. 

Closes #2534

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Check all views in Admin and update the parent ticket with any additional views that need fixing

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Before (content too wide)
<img width="1232" alt="image" src="https://github.com/user-attachments/assets/b4a0dcdc-5992-4993-abea-27c2082cefdc">


After (content same width as header)
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/4263e882-f209-4ccf-b497-1ccff323d528">


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
