### PR TITLE
Feature/2392 Limit Z-score banding calculation to 2 decimal places

### DIFF
--- a/src/views/Exercise/Tasks/Task/Finalised.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised.vue
@@ -154,7 +154,6 @@ export default {
       // group scores
       const scoreMap = {};
       this.task.finalScores.forEach(scoreData => { // id | panelId | ref | score | scoreSheet
-        scoreData[this.scoreType] = this.formatScore(this.scoreType, scoreData[this.scoreType]);
         if (!scoreMap[scoreData[this.scoreType]]) {
           scoreMap[scoreData[this.scoreType]] = {
             applicationIds: [],
@@ -212,7 +211,7 @@ export default {
       // add outcome stats
       if (this.task.hasOwnProperty('passMark')) {
         scoresInDescendingOrder.forEach(key => {
-          const score = this.formatScore(this.scoreType, key);
+          const score = parseFloat(key);
           if (score >= this.task.passMark) {
             if (this.task.overrides && this.task.overrides.fail) {
               const failMatches = this.task.overrides.fail.filter(id => scoreMap[score].applicationIds.indexOf(id) >= 0);
@@ -245,8 +244,7 @@ export default {
       if (!this.scores.length) return 0;
       if (!this.task) return 0;
       if (!this.task.passMark) return 0;
-      const scoreData = this.scores.find(scoreData => scoreData.score === this.formatScore(this.scoreType, this.task.passMark));
-      if (!scoreData) return 0;
+      const scoreData = this.scores.find(scoreData => scoreData.score === this.task.passMark);
       let total = scoreData.rank + scoreData.count - 1;
       if (this.task.overrides) {
         if (this.task.overrides.fail && this.task.overrides.fail.length) {
@@ -294,15 +292,6 @@ export default {
       const failed = CAT.applications.filter(item => failedIDs.indexOf(item.id) >= 0);
       downloadMeritList(didNotTake, failed, this.task, this.exerciseDiversity, saveData.type, fileName);
       this.$refs['exportModal'].closeModal();
-    },
-    formatScore(type, score) {
-      let val = parseFloat(score);
-      if (type === 'zScore') {
-        val = val.toFixed(2); // 2 decimal places
-        if (val === '-0.00') val = '0.00';
-        return parseFloat(val);
-      }
-      return val;
     },
     async setPassMark(data) {
       if (data) {


### PR DESCRIPTION
## What's included?
#2392 

Revert the changes on [admin](https://github.com/jac-uk/admin/pull/2430) as the z-scores have been limited to 2 decimal places on [digital-platform: Bugfix/2392 Update Z-score calculation](https://github.com/jac-uk/digital-platform/pull/1173).


## Who should test?
✅ Product owner
✅ Developers

## How to test?
Describe the steps required to test & verify this change

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:PRODUCTION
_can be OFF, DEVELOP or STAGING_
