### PR TITLE
Update releases to display last fetched date time

### DIFF
--- a/src/store/releases.js
+++ b/src/store/releases.js
@@ -1,15 +1,20 @@
 import { httpsCallable } from '@firebase/functions';
 import { functions } from '@/firebase';
+import dayjs from 'dayjs';
 
 const module = {
   namespaced: true,
   state: {
     records: [],
-    lastFetched: null,
+    availability: false,
+    lastFetched: null,    // dayjs() object
   },
   mutations: {
     setRecords(state, value) {
       state.records = value;
+    },
+    setAvailability(state, value) {
+      state.availability = value;
     },
     setLastFetched(state, value) {
       state.lastFetched = value;
@@ -19,6 +24,13 @@ const module = {
     async getLatestReleases({ commit }) {
       const records = await httpsCallable(functions, 'getLatestReleases')();
       commit('setRecords', records.data);
+      commit('setAvailability', records.data.length > 0);
+      commit('setLastFetched', dayjs());
+    },
+  },
+  getters: {
+    getLastFetchedDT: (state) => {
+      return state.lastFetched ? state.lastFetched.format('YYYY-MM-DD HH:mm:ss') : '';
     },
   },
 };

--- a/src/views/ReleasesList.vue
+++ b/src/views/ReleasesList.vue
@@ -1,32 +1,38 @@
 <template>
   <div>
-    <h1
-      class="govuk-heading-xl govuk-!-margin-bottom-6"
-    >
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
       Latest Releases
-    </h1>
-    <Table
-      data-key="id"
-      :data="tableData"
-      :page-size="50"
-      :columns="tableColumns"
-      @change="getTableData"
-    >
-      <template #row="{row}">
-        <TableCell :title="tableColumns[0].title">
-          {{ row.title }}
-        </TableCell>
-        <TableCell :title="tableColumns[1].title">
-          {{ row.tag_name }}
-        </TableCell>
-        <TableCell :title="tableColumns[2].title">
-          {{ row.author }}
-        </TableCell>
-        <TableCell :title="tableColumns[3].title">
-          {{ row.published_at ? formatDate(row.published_at) : '' }}
-        </TableCell>
-      </template>
-    </Table>
+    </h2>
+
+    <div v-if="availability">
+      <div>Last fetched: {{ lastFetchedDT }}</div>
+      <Table
+        data-key="id"
+        :data="tableData"
+        :page-size="50"
+        :columns="tableColumns"
+        @change="getTableData"
+      >
+        <template #row="{row}">
+          <TableCell :title="tableColumns[0].title">
+            {{ row.title }}
+          </TableCell>
+          <TableCell :title="tableColumns[1].title">
+            {{ row.tag_name }}
+          </TableCell>
+          <TableCell :title="tableColumns[2].title">
+            {{ row.author }}
+          </TableCell>
+          <TableCell :title="tableColumns[3].title">
+            {{ row.published_at ? formatDate(row.published_at) : '' }}
+          </TableCell>
+        </template>
+      </Table>
+    </div>
+
+    <div v-else>
+      Unavailable
+    </div>
   </div>
 </template>
 
@@ -35,6 +41,7 @@ import permissionMixin from '@/permissionMixin';
 import dayjs from 'dayjs';
 import Table from '@jac-uk/jac-kit/components/Table/Table.vue';
 import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
+import { mapState, mapGetters } from 'vuex';
 
 export default {
   name: 'ReleasesList',
@@ -54,11 +61,19 @@ export default {
     };
   },
   computed: {
+    ...mapGetters({
+      lastFetchedDT: 'releases/getLastFetchedDT',
+    }),
+    ...mapState('releases', [
+      'availability',
+    ]),
+
     tableData() {
       return this.$store.state.releases.records;
     },
   },
   created() {
+    // Can make the calls synchronously below
     this.$store.dispatch('releases/getLatestReleases');
   },
   methods: {


### PR DESCRIPTION
## What's included?
Display the date and time the releases were last fetched and indicate explicitly if data isnt currently available as the Zenhub API is a bit flaky.

https://jac-admin-develop--pr2546-hotfix-update-releas-a6fko0le.web.app/latest-releases

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Ensure the date and time that the data was fetched is displayed along with the data. If there is no data then ensure it displays a message saying it is 'unavailable'.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
