### PR TITLE
#2544 Custom Report Data Overflow

### DIFF
--- a/src/helpers/csv.js
+++ b/src/helpers/csv.js
@@ -1,0 +1,22 @@
+/**
+ * This function is used when converting arrays into csv strings
+ * It does the following:
+ * - Converts the value to a string using String(value)
+ * - If the value contains a comma (,), double quotes ("), or other special characters, it wraps the value in double quotes
+ * - If the value already contains double quotes, those quotes are escaped by replacing each " with ""
+ * @param {*} value
+ * @returns
+ */
+const escapeValue = (value) => {
+  // Convert the value to a string and wrap in quotes if it contains commas or quotes
+  const stringValue = String(value);
+  if (stringValue.includes(',') || stringValue.includes('"')) {
+    // Escape internal double quotes and wrap the value in quotes
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+};
+
+export {
+  escapeValue
+};

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -273,6 +273,9 @@
               <td
                 v-for="(column, columnIndex) in columns"
                 :key="columnIndex"
+                :style="{
+                  'white-space': keys[column]?.nowrap ? 'nowrap' : ''
+                }"
                 class="govuk-table__cell"
               >
                 {{ isUsingFilter(column) ? $filters.lookup(row[column]) : row[column] }}
@@ -383,6 +386,7 @@ import CheckboxItem from '@jac-uk/jac-kit/draftComponents/Form/CheckboxItem.vue'
 import { STATUS } from '@jac-uk/jac-kit/helpers/constants';
 import { applicationRecordCounts, availableStages, availableStatuses } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
+import { escapeValue } from '@/helpers/csv';
 
 // Prevents warnings and errors associated with using @vue/compat
 draggable.compatConfig = { MODE: 3 };
@@ -556,21 +560,21 @@ export default {
         },
       ],
       keys: {
-        referenceNumber: { label: 'Candidate reference number', type: String },
+        referenceNumber: { label: 'Candidate reference number', type: String, nowrap: true },
         applyingForWelshPost: { label: 'Applying for Welsh Post?', type: Boolean },
         canReadAndWriteWelsh: { label: 'Can read and write Welsh?', type: Boolean },
         canSpeakWelsh: { label: 'Can speak Welsh?', type: Boolean },
         employmentGaps: { label: 'Employment gaps', type: 'Array of objects' },
         firstAssessorType: { label: 'First Assessor Type', type: String },
-        firstAssessorEmail: { label: 'First Assessor Email', type: String },
-        firstAssessorTitle: { label: 'First Assessor Title', type: String },
-        firstAssessorFullName: { label: 'First Assessor Full Name', type: String },
-        firstAssessorPhone: { label: 'First Assessor Phone', type: String },
+        firstAssessorEmail: { label: 'First Assessor Email', type: String, nowrap: true },
+        firstAssessorTitle: { label: 'First Assessor Title', type: String, nowrap: true },
+        firstAssessorFullName: { label: 'First Assessor Full Name', type: String, nowrap: true },
+        firstAssessorPhone: { label: 'First Assessor Phone', type: String, nowrap: true },
         secondAssessorType: { label: 'Second Assessor Type', type: String },
-        secondAssessorEmail: { label: 'Second Assessor Email', type: String },
-        secondAssessorTitle: { label: 'Second Assessor Title', type: String },
-        secondAssessorFullName: { label: 'Second Assessor Full Name', type: String },
-        secondAssessorPhone: { label: 'Second Assessor Phone', type: String },
+        secondAssessorEmail: { label: 'Second Assessor Email', type: String, nowrap: true },
+        secondAssessorTitle: { label: 'Second Assessor Title', type: String, nowrap: true },
+        secondAssessorFullName: { label: 'Second Assessor Full Name', type: String, nowrap: true },
+        secondAssessorPhone: { label: 'Second Assessor Phone', type: String, nowrap: true },
         royalInstitutionCharteredSurveyorsDate: { label: 'Royal Institution Chartered Surveyors Date', type: Date },
         royalInstituteBritishArchitectsInformation: { label: 'Royal Institute of British Architects Information', type: String },
         otherProfessionalMemberships: { label: 'Other Professional Memberships', type: String },
@@ -602,22 +606,22 @@ export default {
         applyingUnderSchedule2Three: { label: 'Applying under schedule 2 3?', type: Boolean },
         '_processing.status': { label: 'Status (admin)', type: String },
         '_processing.stage': { label: 'Stage', type: String },
-        'personalDetails.phone': { label: 'Phone', type: String },
-        'personalDetails.nationalInsuranceNumber': { label: 'National insurance number', type: String },
-        'personalDetails.email': { label: 'Email', type: String },
+        'personalDetails.phone': { label: 'Phone', type: String, nowrap: true },
+        'personalDetails.nationalInsuranceNumber': { label: 'National insurance number', type: String, nowrap: true },
+        'personalDetails.email': { label: 'Email', type: String, nowrap: true },
         'personalDetails.reasonableAdjustments': { label: 'Reasonable adjustments', type: Boolean },
         'personalDetails.reasonableAdjustmentsDetails': { label: 'Reasonable adjustments details', type: String },
-        'personalDetails.dateOfBirth': { label: 'Date of birth', type: Date },
-        'personalDetails.placeOfBirth': { label: 'Place of birth', type: String },
-        'personalDetails.title': { label: 'Title', type: String },
-        'personalDetails.citizenship': { label: 'Citizenship', type: String },
-        'personalDetails.firstName': { label: 'First Name', type: String },
-        'personalDetails.middleNames': { label: 'Middle name(s)', type: String },
-        'personalDetails.lastName': { label: 'Last Name', type: String },
-        'personalDetails.fullName': { label: 'Full Name', type: String },
+        'personalDetails.dateOfBirth': { label: 'Date of birth', type: Date, nowrap: true },
+        'personalDetails.placeOfBirth': { label: 'Place of birth', type: String, nowrap: true },
+        'personalDetails.title': { label: 'Title', type: String, nowrap: true },
+        'personalDetails.citizenship': { label: 'Citizenship', type: String, nowrap: true },
+        'personalDetails.firstName': { label: 'First Name', type: String, nowrap: true },
+        'personalDetails.middleNames': { label: 'Middle name(s)', type: String, nowrap: true },
+        'personalDetails.lastName': { label: 'Last Name', type: String, nowrap: true },
+        'personalDetails.fullName': { label: 'Full Name', type: String, nowrap: true },
         'personalDetails.suffix': { label: 'Suffix', type: String },
         'personalDetails.previousNames': { label: 'Previous known name(s)', type: String },
-        'personalDetails.professionalName': { label: 'Professional name', type: String },
+        'personalDetails.professionalName': { label: 'Professional name', type: String, nowrap: true },
         'personalDetails.address.current': { label: 'Current Address', type: String },
         'personalDetails.address.currentMoreThan5Years': { label: 'Has lived at this address for more than 5 years', type: Boolean },
         'personalDetails.address.previous': { label: 'Previous Addresses', type: String },
@@ -814,8 +818,13 @@ export default {
       for (let i = 0; i < this.data.data.length; i++) {
         csv.push([...this.columns.map(col => this.data.data[i][col])]);
       }
-      const csvContent = `data:text/csv;charset=utf-8,${
-        csv.map(e => e.join(',')).join('\n')}`;
+
+      // Convert the 2D array to CSV, ensuring values are properly escaped
+      const mappedCSV = csv
+        .map(row => row.map(escapeValue).join(',')) // Escape each value and join them with commas
+        .join('\n'); // Join each row with a newline
+
+      const csvContent = `data:text/csv;charset=utf-8,${mappedCSV}`;
       const encodedUri = encodeURI(csvContent);
       const link = document.createElement('a');
       link.setAttribute('href', encodedUri);


### PR DESCRIPTION
## What's included?
Escaping values so that commas in strings do not mess up conversion to a csv. Also escaping double quotes as these are used to escape the commas.

Added a helper to facilitate this.
Added nowrap attribute to the keys array to flag columns which should not be wrapped when the table is displayed. This is being used in the template to prevent the td from wrapping.

Closes #2544 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- Go to the following exercise: http://localhost:8081/exercise/Z2r71rLLFI2m8zOXV3Ev/reports/custom
- Click on the Reports dropdown and select Custom Reports
- Build a report using the following fields: Candidate Reference Number, Employment Gaps, Date Of Birth
- Ensure the Candidate Reference Number **DOES NOT** wrap onto a new line
- Ensure the Employment Gaps **DO** wrap onto a new line
- Ensure the Date Of Birth **DOES NOT** wrap onto a new line
- Download the report and ensure all the data is there, in the correct columns and none of the data wraps onto a new line

See video below:

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
