### PR TITLE
Bugfix/TS 373 Approve Exercise with Basic Advert

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -580,7 +580,7 @@ function isReadyForApproval(data) {
 }
 function isReadyForApprovalFromAdvertType(data) {
   if (data === null) return false;
-  return (!data.advertType || [ADVERT_TYPES.FULL, ADVERT_TYPES.EXTERNAL, ADVERT_TYPES.LISTING, ADVERT_TYPES.BASIC].includes(data.advertType));
+  return (!data.advertType || [ADVERT_TYPES.FULL, ADVERT_TYPES.EXTERNAL].includes(data.advertType));
 }
 function isApprovalRejected(data) {
   if (data === null) return false;

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -580,7 +580,7 @@ function isReadyForApproval(data) {
 }
 function isReadyForApprovalFromAdvertType(data) {
   if (data === null) return false;
-  return (!data.advertType || [ADVERT_TYPES.FULL, ADVERT_TYPES.EXTERNAL, ADVERT_TYPES.LISTING].includes(data.advertType));
+  return (!data.advertType || [ADVERT_TYPES.FULL, ADVERT_TYPES.EXTERNAL, ADVERT_TYPES.LISTING, ADVERT_TYPES.BASIC].includes(data.advertType));
 }
 function isApprovalRejected(data) {
   if (data === null) return false;

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -97,7 +97,7 @@
     </div>
     <div class="govuk-grid-column-full govuk-!-margin-top-6">
       <button
-        v-if="canUpdateExercises && isDraft"
+        v-if="canUpdateExercises && isDraft && isReadyForApprovalFromAdvertType"
         :disabled="!isReadyToSubmit"
         class="govuk-button govuk-!-margin-right-3"
         @click="openApprovalModal"


### PR DESCRIPTION
## What's included?
- Hide `Submit for approval` button if the exercise advert is `basic` or `listing`.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
[Example exercise](https://jac-admin-develop--pr2555-bugfix-ts-373-approv-iwpfc0je.web.app/exercise/Biyjd07Xz2usL9yXjtjV/details/overview)

Steps:
1. Go to an exercise and change the advert type to `listing` or `basic`.
3. Check if "Submit for approval" is invisible. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/user-attachments/assets/5d29c00a-0956-4238-8d2a-dd31e7d9b776

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
