### PR TITLE
#2544 Custom report data overflow - Make applied checked on page load

### DIFF
--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -407,7 +407,7 @@ export default {
       STATUS,
       type: 'showData',
       data: null,
-      statuses: [],
+      statuses: [STATUS.APPLIED],
       selectedStage: 'all',
       selectedStageStatus: null,
       isLoading: null,


### PR DESCRIPTION
## What's included?
Did some investigation work for @nickaddy.
The only code change was to ensure the applied status is checked on page load

Closes #2544 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
When you go to the custom report page the 'Applied' Application status should be checked by default

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
