### PR TITLE
2558 Add link to user guidance

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -371,9 +371,16 @@ export default {
           link: { name: 'users' },
         });
       }
+
       tabs.push({
         title: this.userName,
         content: [
+          {
+            title: 'User guidance',
+            link: () => {
+              window.open('https://justiceuk.sharepoint.com/sites/DigitalTeam193/SitePages/How-to-Videos.aspx', '_blank');
+            },
+          },
           { title: 'Sign out', link: () => { this.signOut(); } },
         ],
       });


### PR DESCRIPTION
## What's included?
In the top user menu, included a link 'User guidance' that opens the following link in a new window: https://justiceuk.sharepoint.com/sites/DigitalTeam193/SitePages/How-to-Videos.aspx

Closes #2558 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

1. Click on the dropdown on the far right of the top tabs menu (see Figure 1 below)
2. You should see a link to User Guidance
3. Click the link and it should open a new tab to the User Guidance page

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Figure 1

<img width="1271" alt="Screenshot 2024-09-13 at 00 41 11" src="https://github.com/user-attachments/assets/d09cc9f2-28d2-44e2-8ab7-636ec5a1d384">


## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
