### PR TITLE
Fix sass warning for nested rules

### DIFF
--- a/src/components/RepeatableFields/QuestionConfig.vue
+++ b/src/components/RepeatableFields/QuestionConfig.vue
@@ -330,8 +330,8 @@ export default {
 <style lang="scss" scoped>
 
 .govuk-fieldset {
-  @include govuk-responsive-padding(6);
   border: 2px solid $govuk-border-colour;
+  @include govuk-responsive-padding(6);
 }
 
 .jac-add-another__remove-button {


### PR DESCRIPTION
## What's included?
We were receiving the following sass warning:
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in & {}.

## How to test?
This does not need testing

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
