### PR TITLE
Feat/admin 2551 update application view in line with character updates in application form

### DIFF
--- a/src/components/Page/InformationReviewSectionRenderer.vue
+++ b/src/components/Page/InformationReviewSectionRenderer.vue
@@ -35,7 +35,7 @@
               v-if="key != 'taskDetails' && key != 'judicialFunctions' && key != 'details' && key != 'startDate' || (edit && key == 'startDate' && showDateRange)"
               class="govuk-summary-list__key widerColumn"
             >
-              {{ $filters.lookup(key) }}
+              {{ lookup(key) }}
             </dt>
             <dt
               v-else-if="key == 'details'"
@@ -456,6 +456,11 @@ export default {
       required: false,
       default: true,
     },
+    customisedLookup: {
+      type: Object,
+      required: false,
+      default: () => {},
+    },
   },
   emits: ['changeField', 'changeTaskDetails', 'changeJudicialFunctions', 'addField', 'removeField'],
   data() {
@@ -522,6 +527,12 @@ export default {
     openModal(index) {
       this.currentIndex = index;
       this.$refs.removeModal.openModal();
+    },
+    lookup(key) {
+      if (this.customisedLookup && this.customisedLookup[key]) {
+        return this.customisedLookup[key];
+      }
+      return this.$filters.lookup(key);
     },
   },
 };

--- a/src/views/Exercise/Applications/Application.vue
+++ b/src/views/Exercise/Applications/Application.vue
@@ -242,7 +242,7 @@
               :is-panel-view="isPanelView"
               @update-application="changeApplication"
             />
-            
+
             <QualificationsAndMembershipsSummary
               :application="application"
               :exercise="exercise"
@@ -438,7 +438,9 @@ export default {
       return isNonLegal(this.exercise);
     },
     correctCharacterInformation() {
-      if (this.applicationVersion >= 2) {
+      if (this.characterInformationVersion === 3) {
+        return this.application.characterInformationV3 || {};
+      } else if (this.applicationVersion >= 2) {
         return this.application.characterInformationV2 || {};
       } else {
         return this.application.characterInformation || {};
@@ -454,6 +456,10 @@ export default {
       return this.exercise._applicationVersion || 1;
     },
     characterInformationVersion() {
+      // All exercises launching on or after 15/10/24 use the V3 Character questions
+      if (this.exercise.applicationOpenDate > new Date('2023-10-15')) {
+        return 3;
+      }
       return this.applicationVersion >= 2 ? 2 : 1;
     },
     applications() {

--- a/src/views/InformationReview/CharacterInformationSummary.vue
+++ b/src/views/InformationReview/CharacterInformationSummary.vue
@@ -30,6 +30,19 @@
           />
         </div>
       </dl>
+      <dl
+        v-else-if="isVersion3"
+        class="govuk-summary-list"
+      >
+        <div>
+          <CharacterInformationSummaryV3
+            :form-data="characterInformation || {}"
+            :edit="editable"
+            :is-asked="isAsked"
+            @change-info="changeCharacterInfo"
+          />
+        </div>
+      </dl>
       <dl v-else>
         <div>
           <CharacterInformationSummaryV1
@@ -47,12 +60,14 @@
 <script>
 import CharacterInformationSummaryV1 from '@/views/InformationReview/CharacterInformationSummaryV1.vue';
 import CharacterInformationSummaryV2 from '@/views/InformationReview/CharacterInformationSummaryV2.vue';
+import CharacterInformationSummaryV3 from '@/views/InformationReview/CharacterInformationSummaryV3.vue';
 
 export default {
   name: 'CharacterInformationSummary',
   components: {
     CharacterInformationSummaryV1,
     CharacterInformationSummaryV2,
+    CharacterInformationSummaryV3,
   },
   props: {
     characterInformation: {
@@ -77,6 +92,9 @@ export default {
   },
   emits: ['updateApplication'],
   computed: {
+    isVersion3() {
+      return this.version === 3;
+    },
     isVersion2() {
       return this.version === 2;
     },
@@ -93,12 +111,12 @@ export default {
       }
     },
     changeCharacterInfo(obj) {
-      let myCharacterInfo;
-      if (this.isVersion2) {
-        myCharacterInfo = { ...this.characterInformation, ...obj };
+      const myCharacterInfo = { ...this.characterInformation, ...obj };
+      if (this.isVersion3) {
+        this.$emit('updateApplication', { characterInformationV3: myCharacterInfo });
+      } else if (this.isVersion2) {
         this.$emit('updateApplication', { characterInformationV2: myCharacterInfo });
       } else {
-        myCharacterInfo = { ...this.characterInformation, ...obj };
         this.$emit('updateApplication', { characterInformation: myCharacterInfo });
       }
     },

--- a/src/views/InformationReview/CharacterInformationSummaryV3.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV3.vue
@@ -1,0 +1,754 @@
+<template>
+  <div>
+    <!-- CriminalOffencesSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key widerColumn">
+          Has been convicted of a criminal offence <br>This includes spent convictions, even if they are protected
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.criminalConvictions"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="criminalConvictions"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+
+          <div v-if="formData.criminalConvictions">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.criminalConvictionDetails"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              :edit="edit"
+              field="criminalConvictionDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- CriminalCautionsSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key widerColumn">
+          Has been cautioned for a criminal offence
+          <br> This includes cautions that are spent, even if they are protected
+        </dt>
+
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.criminalCautions"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="criminalCautions"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.criminalCautions">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.criminalCautionDetails"
+              :edit="edit"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              field="criminalCautionDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- FixedPenaltiesSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has received a fixed penalty notice in the last 4 years
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.fixedPenalties"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="fixedPenalties"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.fixedPenalties">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.fixedPenaltyDetails"
+              :display-month-year-only="false"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              :edit="edit"
+              field="fixedPenaltyDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- DrivingDisqualificationDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has been disqualified from driving
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.drivingDisqualifications"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="drivingDisqualifications"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.drivingDisqualifications">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.drivingDisqualificationDetails"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              :edit="edit"
+              field="drivingDisqualificationDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- RecentDrivingConvictionDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Was convicted of any motoring offences in the past 4 years
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.recentDrivingConvictions"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="recentDrivingConvictions"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.recentDrivingConvictions">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.recentDrivingConvictionDetails"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              :edit="edit"
+              field="recentDrivingConvictionDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- bankruptcyDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has been declared bankrupt
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.bankruptcies"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="bankruptcies"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.bankruptcies">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.bankruptcyDetails"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              :edit="edit"
+              field="bankruptcyDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- ivas -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has entered into an Individual Voluntary Agreement (IVA)
+          <br>or other similar arrangement
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.ivas"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="ivas"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.ivas">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.ivaDetails"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              :edit="edit"
+              field="ivaDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- LateTaxReturnSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has filed late tax returns and/or made late tax payments
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.lateTaxReturns"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="lateTaxReturns"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.lateTaxReturns">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.lateTaxReturnDetails"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              :edit="edit"
+              field="lateTaxReturnDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- LateVatReturnSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has filed late VAT returns and/or made late VAT payments
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.lateVatReturns"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="lateVatReturns"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.lateVatReturns">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.lateVatReturnDetails"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              :edit="edit"
+              field="lateVatReturnDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- hmrcFineDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has ever been fined by HMRC
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.hmrcFines"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="hmrcFines"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.hmrcFines">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.hmrcFineDetails"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              field="hmrcFineDetails"
+              :edit="edit"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- hmrcTaxEnquiriesDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          TODO: Has HMRC enquiries into tax affairs
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.hmrcTaxEnquiries"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="hmrcTaxEnquiries"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.hmrcTaxEnquiries">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.hmrcTaxEnquiries"
+              :data-default="emptyObject(['details', 'date', 'title'])"
+              field="hmrcTaxEnquiries"
+              :edit="edit"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- ProfessionalConductSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          The subject of a complaint or an allegation of professional misconduct
+          <br>(Not including complaints that were dismissed in full)
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfProfessionalMisconduct"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfProfessionalMisconduct"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.subjectOfAllegationOrClaimOfProfessionalMisconduct">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.subjectOfAllegationOrClaimOfProfessionalMisconductDetails"
+              :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
+              :edit="edit"
+              field="subjectOfAllegationOrClaimOfProfessionalMisconductDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!--SubjectOfAllegationOrClaimOfNegligenceSummary-->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          The subject of an allegation or claim of professional negligence
+          <br>(Not including claims that were dismissed or withdrawn without a settlement)
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfNegligence"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfNegligence"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.subjectOfAllegationOrClaimOfNegligence">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.subjectOfAllegationOrClaimOfNegligenceDetails"
+              :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
+              :edit="edit"
+              field="subjectOfAllegationOrClaimOfNegligenceDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- SubjectOfAllegationOrClaimOfWrongfulDismissalDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          A subject of an allegation or claim of wrongful dismissal
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfWrongfulDismissal"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfWrongfulDismissal"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.subjectOfAllegationOrClaimOfWrongfulDismissal">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.subjectOfAllegationOrClaimOfWrongfulDismissalDetails"
+              :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
+              :edit="edit"
+              field="subjectOfAllegationOrClaimOfWrongfulDismissalDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- subjectOfAllegationOrClaimOfDiscriminationProceedingDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          A subject of an allegation or claim of discrimination proceedings
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfDiscriminationProceeding"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfDiscriminationProceeding"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.subjectOfAllegationOrClaimOfDiscriminationProceeding">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.subjectOfAllegationOrClaimOfDiscriminationProceedingDetails"
+              :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
+              :edit="edit"
+              field="subjectOfAllegationOrClaimOfDiscriminationProceedingDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- subjectOfAllegationOrClaimOfHarassmentProceedingDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          A subject of an allegation or claim of harassment proceedings
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfAllegationOrClaimOfHarassmentProceeding"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfAllegationOrClaimOfHarassmentProceeding"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.subjectOfAllegationOrClaimOfHarassmentProceeding">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.subjectOfAllegationOrClaimOfHarassmentProceedingDetails"
+              :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
+              :edit="edit"
+              field="subjectOfAllegationOrClaimOfHarassmentProceedingDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- complaintOrDisciplinaryActionDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          A subject of complaints or disciplinary action
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.complaintOrDisciplinaryAction"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="complaintOrDisciplinaryAction"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.complaintOrDisciplinaryAction">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.complaintOrDisciplinaryActionDetails"
+              :data-default="emptyObject(['details','date','investigationConclusionDate','investigations'])"
+              :edit="edit"
+              field="complaintOrDisciplinaryActionDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- requestedToResignDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has been asked to resign from a position
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.requestedToResign"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="requestedToResign"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.requestedToResign">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.requestedToResignDetails"
+              :data-default="emptyObject(['details', 'date' ])"
+              :edit="edit"
+              field="requestedToResignDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- CivilProceedingDetails -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          TODO:A subject of civil proceedings
+          <br>(Not including proceedings that were dismissed or withdrawn without a settlement)
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.subjectOfCivilProceeding"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="subjectOfCivilProceeding"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.subjectOfCivilProceeding">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.subjectOfCivilProceeding"
+              :data-default="emptyObject(['details','date'])"
+              :edit="edit"
+              field="subjectOfCivilProceeding"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- FurtherInformationSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Has any other character issues
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          <InformationReviewRenderer
+            :data="formData.furtherInformation"
+            :edit="edit"
+            :options="[true, false]"
+            type="selection"
+            field="furtherInformation"
+            :is-asked="isAsked"
+            @change-field="changeCharacterFlag"
+          />
+          <div v-if="formData.furtherInformation">
+            <hr>
+            <InformationReviewSectionRenderer
+              :data="formData.furtherInformationDetails"
+              :data-default="emptyObject(['details', 'date'])"
+              :edit="edit"
+              field="furtherInformationDetails"
+              :is-asked="isAsked"
+              @change-field="changeInfo"
+              @remove-field="removeInfo"
+              @add-field="addInfo"
+            />
+          </div>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- DeclarationsSummary -->
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+      <div class="govuk-summary-list__row">
+        <dt :class="requiredStyle">
+          Signed character information declaration
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ $filters.toYesNo(signedDeclaration) }}
+        </dd>
+      </div>
+    </dl>
+  </div>
+</template>
+
+<script>
+import InformationReviewSectionRenderer from '@/components/Page/InformationReviewSectionRenderer.vue';
+import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer.vue';
+import CharacterSummary from '@/views/InformationReview/CharacterSummary.vue';
+
+export default {
+  name: 'CharacterInformationSummaryV2',
+  components: {
+    InformationReviewRenderer,
+    InformationReviewSectionRenderer,
+  },
+  extends: CharacterSummary,
+  computed: {
+    signedDeclaration() {
+      if (this.formData.declaration1 === true &&
+        this.formData.declaration2 === true &&
+        this.formData.declaration3 === true) {
+        return true;
+      }
+      return false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+  .widerColumn {
+    width: 70%;
+  }
+</style>

--- a/src/views/InformationReview/CharacterInformationSummaryV3.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV3.vue
@@ -131,7 +131,7 @@
             <hr>
             <InformationReviewSectionRenderer
               :data="formData.drivingDisqualificationDetails"
-              :data-default="emptyObject(['details', 'startDate', 'endDate' ,'title'])"
+              :data-default="emptyObject(['details', 'date' ,'title'])"
               :edit="edit"
               field="drivingDisqualificationDetails"
               :is-asked="isAsked"

--- a/src/views/InformationReview/CharacterInformationSummaryV3.vue
+++ b/src/views/InformationReview/CharacterInformationSummaryV3.vue
@@ -131,7 +131,7 @@
             <hr>
             <InformationReviewSectionRenderer
               :data="formData.drivingDisqualificationDetails"
-              :data-default="emptyObject(['details', 'date', 'title'])"
+              :data-default="emptyObject(['details', 'startDate', 'endDate' ,'title'])"
               :edit="edit"
               field="drivingDisqualificationDetails"
               :is-asked="isAsked"
@@ -359,26 +359,26 @@
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
-          TODO: Has HMRC enquiries into tax affairs
+          Has HMRC enquiries into tax affairs
         </dt>
         <dd
           class="govuk-summary-list__value"
         >
           <InformationReviewRenderer
-            :data="formData.hmrcTaxEnquiries"
+            :data="formData.hmrcTax"
             :edit="edit"
             :options="[true, false]"
             type="selection"
-            field="hmrcTaxEnquiries"
+            field="hmrcTax"
             :is-asked="isAsked"
             @change-field="changeCharacterFlag"
           />
-          <div v-if="formData.hmrcTaxEnquiries">
+          <div v-if="formData.hmrcTax">
             <hr>
             <InformationReviewSectionRenderer
-              :data="formData.hmrcTaxEnquiries"
+              :data="formData.hmrcTaxDetails"
               :data-default="emptyObject(['details', 'date', 'title'])"
-              field="hmrcTaxEnquiries"
+              field="hmrcTaxDetails"
               :edit="edit"
               :is-asked="isAsked"
               @change-field="changeInfo"
@@ -453,6 +453,10 @@
               :edit="edit"
               field="subjectOfAllegationOrClaimOfNegligenceDetails"
               :is-asked="isAsked"
+              :customised-lookup="{
+                investigations: 'Claim Ongoing',
+                investigationConclusionDate: 'Claim Conclusion Date'
+              }"
               @change-field="changeInfo"
               @remove-field="removeInfo"
               @add-field="addInfo"
@@ -641,28 +645,28 @@
     <dl class="govuk-summary-list govuk-!-margin-bottom-0">
       <div class="govuk-summary-list__row">
         <dt :class="requiredStyle">
-          TODO:A subject of civil proceedings
+          A subject of civil proceedings
           <br>(Not including proceedings that were dismissed or withdrawn without a settlement)
         </dt>
         <dd
           class="govuk-summary-list__value"
         >
           <InformationReviewRenderer
-            :data="formData.subjectOfCivilProceeding"
+            :data="formData.civilProceedings"
             :edit="edit"
             :options="[true, false]"
             type="selection"
-            field="subjectOfCivilProceeding"
+            field="civilProceedings"
             :is-asked="isAsked"
             @change-field="changeCharacterFlag"
           />
-          <div v-if="formData.subjectOfCivilProceeding">
+          <div v-if="formData.civilProceedings">
             <hr>
             <InformationReviewSectionRenderer
-              :data="formData.subjectOfCivilProceeding"
+              :data="formData.civilProceedingsDetails"
               :data-default="emptyObject(['details','date'])"
               :edit="edit"
-              field="subjectOfCivilProceeding"
+              field="civilProceedingsDetails"
               :is-asked="isAsked"
               @change-field="changeInfo"
               @remove-field="removeInfo"
@@ -728,7 +732,7 @@ import InformationReviewRenderer from '@/components/Page/InformationReviewRender
 import CharacterSummary from '@/views/InformationReview/CharacterSummary.vue';
 
 export default {
-  name: 'CharacterInformationSummaryV2',
+  name: 'CharacterInformationSummaryV3',
   components: {
     InformationReviewRenderer,
     InformationReviewSectionRenderer,

--- a/src/views/InformationReview/CharacterSummary.vue
+++ b/src/views/InformationReview/CharacterSummary.vue
@@ -46,6 +46,12 @@ export default {
       if (items.some(item => item === 'date')) {
         obj.date = new Date();
       }
+      if (items.some(item => item === 'startDate')) {
+        obj.startDate = new Date();
+      }
+      if (items.some(item => item === 'endDate')) {
+        obj.endDate = new Date();
+      }
       if (items.some(item => item === 'investigations')) {
         obj.investigations = '';
       }

--- a/src/views/InformationReview/CharacterSummary.vue
+++ b/src/views/InformationReview/CharacterSummary.vue
@@ -35,6 +35,7 @@ export default {
 
   methods: {
     changeCharacterFlag(obj) {
+      console.log('changeCharacterFlag', obj);
       this.$emit('changeInfo', obj);
     },
     emptyObject(items){


### PR DESCRIPTION
## What's included?
Closes #2551

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Check applications of this exercise: https://jac-admin-develop--pr2578-feat-admin-2551-upda-xytxsr0w.web.app/exercise/Biyjd07Xz2usL9yXjtjV/stages/shortlisting
- Click the application link to view the details.
<img width="1282" alt="Screenshot 2024-10-01 at 15 45 54" src="https://github.com/user-attachments/assets/03729d34-5d32-4819-8bcc-8c3849e4b919">

- Click `Edit` button to enter edit mode.
<img width="1363" alt="Screenshot 2024-10-01 at 15 44 52" src="https://github.com/user-attachments/assets/35ca0cb6-2abb-44fa-9eed-4e4297edccce">

- Check fields of `Character information` section, those fields should align to the updates of Apply site: https://app.zenhub.com/workspaces/platform-development-5ea838cd2aec471eb6d14139/issues/gh/jac-uk/apply/1229 
<img width="1293" alt="Screenshot 2024-10-01 at 15 45 25" src="https://github.com/user-attachments/assets/1a658001-edb8-44f7-b3f1-4867d3ff7c7a">


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
