### PR TITLE
Feature/2580 clarifications on character agency

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -1383,7 +1383,7 @@ function availableReportLinks(exercise) {
       name: 'reasonable-adjustments',
     },
     {
-      title: 'Agency',
+      title: 'Agency Character Checks',
       name: 'agency',
     },
     {

--- a/src/router.js
+++ b/src/router.js
@@ -750,7 +750,7 @@ const routes = [
             name: 'exercise-tasks-character-checks',
             meta: {
               requiresAuth: true,
-              title: 'Character Checks | Exercise Tasks',
+              title: 'Character Checks Consent | Exercise Tasks',
             },
           },
           {

--- a/src/router.js
+++ b/src/router.js
@@ -1065,7 +1065,7 @@ const routes = [
             component: ExerciseReportsAgency,
             meta: {
               requiresAuth: true,
-              title: 'Agency | Exercise Reports',
+              title: 'Agency Character Checks | Exercise Reports',
             },
           },
           {

--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -263,7 +263,7 @@ export default {
           }
           links.push(
             {
-              title: 'Character Checks',
+              title: 'Character Checks Consent',
               link: {
                 path: `${path}/character-checks`,
               },
@@ -305,7 +305,7 @@ export default {
       case 'selection':
         links.push(
           {
-            title: 'Character Checks',
+            title: 'Character Checks Consent',
             link: {
               path: `${path}/character-checks`,
             },

--- a/src/views/Exercise/Reports/Agency.vue
+++ b/src/views/Exercise/Reports/Agency.vue
@@ -4,7 +4,7 @@
       <div class="moj-page-header-actions">
         <div class="moj-page-header-actions__title">
           <h2 class="govuk-heading-l">
-            Agency
+            Agency Character Checks
           </h2>
         </div>
 

--- a/src/views/Exercise/Tasks/CharacterChecks.vue
+++ b/src/views/Exercise/Tasks/CharacterChecks.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1 class="govuk-heading-l">
-      Character checks
+      Character Checks Consent
     </h1>
     <dl class="govuk-summary-list govuk-!-margin-bottom-7">
       <div class="govuk-summary-list__row">

--- a/tests/unit/helpers/exerciseHelper.test.js
+++ b/tests/unit/helpers/exerciseHelper.test.js
@@ -1540,7 +1540,7 @@ describe('availableReportLinks', () => {
       };
       const path = `/exercise/${exercise.id}/reports`;
       const expectedLinks = [
-        { title: 'Agency', name: 'agency' },
+        { title: 'Agency Character Checks', name: 'agency' },
         { title: 'Character Annex', name: 'character-issues' },
         { title: 'Commissioner conflicts', path: `${path}/commissioner-conflicts` },
         { title: 'Custom', name: 'custom' },
@@ -1565,7 +1565,7 @@ describe('availableReportLinks', () => {
         shortlistingMethods: [],
       };
       const expectedLinks = [
-        { title: 'Agency', name: 'agency' },
+        { title: 'Agency Character Checks', name: 'agency' },
         { title: 'Character Annex', name: 'character-issues' },
         { title: 'Custom', name: 'custom' },
         { title: 'Deployment', name: 'deployment' },


### PR DESCRIPTION
## What's included?
Closes #2580 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
[Example exercise](https://jac-admin-develop--pr2588-feature-2580-clarifi-bzj5wvmx.web.app/exercise/Biyjd07Xz2usL9yXjtjV/dashboard)

1. Go to the "Character Checks" task and check if the text "Character Checks" is updated to "Character Checks Consent".
2. Go to the "Agency" report and check if the text "Agency" is updated to "Agency Character Checks".

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/user-attachments/assets/dc02fdea-b64a-4ae5-8535-92c02fe5e75c

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
