### PR TITLE
Updates to QT tasks on Admin

### DIFF
--- a/src/views/Exercise/Tasks/Task/Completed.vue
+++ b/src/views/Exercise/Tasks/Task/Completed.vue
@@ -40,6 +40,7 @@ import { beforeRouteEnter } from './helper';
 import { getTaskSteps } from '@/helpers/exerciseHelper';
 import FullScreenButton from '@/components/Page/FullScreenButton.vue';
 import ProgressBar from '@/components/Page/ProgressBar.vue';
+import { httpsCallable } from '@firebase/functions';
 import { functions } from '@/firebase';
 import { TASK_TYPE } from '@/helpers/constants';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
@@ -103,7 +104,7 @@ export default {
   methods: {
     notifyCandidates() {
       // Dont do this async as we just want to fire and forget
-      functions.httpsCallable('sendPublishedFeedbackReportNotifications')({ exerciseId: this.exerciseId, type: this.type });
+      httpsCallable(functions, 'sendPublishedFeedbackReportNotifications')({ exerciseId: this.exerciseId, type: this.type });
       return true;
     },
   },


### PR DESCRIPTION
## What's included?
Fix call to send generic report feedback notification from this original PR: https://github.com/jac-uk/digital-platform/pull/1014

Closes #2577 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the following url: https://jac-admin-develop--pr2596-feature-2577-update-6w0hsi9s.web.app/exercise/AwRoe9iF2ufJ6MWJqACf/tasks/all/situationalJudgement/completed
- Press the 'send report notification' button
- Success should appear on the button
- An email should be sent to the candidates for this exercise

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
