### PR TITLE
#2547 Improvements to Custom report v2.1

### DIFF
--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -325,8 +325,6 @@ import _ from 'lodash';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
 import LoadingMessage from '@jac-uk/jac-kit/draftComponents/LoadingMessage.vue';
 import Banner from '@jac-uk/jac-kit/draftComponents/Banner.vue';
-import CheckboxGroup from '@jac-uk/jac-kit/draftComponents/Form/CheckboxGroup.vue';
-import CheckboxItem from '@jac-uk/jac-kit/draftComponents/Form/CheckboxItem.vue';
 import { STATUS } from '@jac-uk/jac-kit/helpers/constants';
 import { applicationRecordCounts, availableStages, availableStatuses } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
@@ -342,8 +340,6 @@ export default {
     draggable,
     LoadingMessage,
     Banner,
-    CheckboxGroup,
-    CheckboxItem,
   },
   mixins: [permissionMixin],
   data() {
@@ -633,6 +629,12 @@ export default {
     selectedStageStatus: {
       handler: function() {
         this.getApplicationRecords();
+      },
+      deep: true,
+    },
+    columns: {
+      handler: function() {
+        this.data = null;
       },
       deep: true,
     },

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -40,9 +40,10 @@
               </select>
               <button
                 class="govuk-button govuk-button--primary moj-button-menu__item moj-page-header-actions__action"
-                @click="openModal('modalRefSaveReport')"
+                :disabled="isLoading || columns.length === 0"
+                @click="generateReport"
               >
-                Save Report
+                Generate Report
               </button>
               <button
                 class="govuk-button govuk-button--primary moj-button-menu__item moj-page-header-actions__action"
@@ -61,7 +62,8 @@
       />
       <div class="govuk-inset-text govuk-!-margin-bottom-7">
         <p class="govuk-body">
-          This report is experimental. Please provide feedback if something doesn't look right.
+          <!-- This report is experimental. Please provide feedback if something doesn't look right. -->
+          Choose the fields you wish to include in your custom report from the dropdown below and then click 'generate' to produce your report on screen. Only candidates with the status 'Applied' will be included in the report.<br>Download the report when you are satisfied with the content.
         </p>
       </div>
       <div class="govuk-grid-row">
@@ -137,67 +139,9 @@
         </div>
       </div>
 
-      <div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-margin-bottom-3">
-        <div class="govuk-grid-column-one-third">
-          <h2>Application status</h2>
-          <CheckboxGroup
-            id="select-status"
-            v-model="statuses"
-            label=""
-          >
-            <CheckboxItem
-              v-for="(status) in STATUS"
-              :key="status"
-              :value="status"
-              :label="$filters.lookup(status)"
-            />
-          </CheckboxGroup>
-        </div>
-
-        <div class="govuk-grid-column-two-thirds">
-          <h2>Stage</h2>
-          <div class="govuk-button-group">
-            <select
-              v-model="selectedStage"
-              class="govuk-select"
-            >
-              <option value="all">
-                All
-              </option>
-              <option
-                v-for="stage in availableStages"
-                :key="stage"
-                :value="stage"
-              >
-                {{ $filters.lookup(stage) }} ({{ $filters.formatNumber(applicationRecordCounts[stage]) }})
-              </option>
-            </select>
-          </div>
-          <div class="govuk-button-group">
-            <select
-              v-if="availableStatuses && availableStatuses.length > 0"
-              v-model="selectedStageStatus"
-              class="govuk-select"
-            >
-              <option
-                value="all"
-              >
-                All
-              </option>
-              <option
-                v-for="item in availableStatuses"
-                :key="item"
-                :value="item"
-              >
-                {{ $filters.lookup(item) }}
-              </option>
-            </select>
-          </div>
-        </div>
-      </div>
-
       <div
         v-if="columns.length > 0"
+        id="column-list"
         class="panel govuk-!-margin-bottom-3"
       >
         <h2 class="govuk-!-margin-bottom-0 govuk-!-margin-top-0">
@@ -416,7 +360,7 @@ export default {
       customReportName: null,
       selectedColumn: '',
       whereClauses: [],
-      columns: [],
+      columns: ['referenceNumber', 'personalDetails.fullName', 'status'],
       warnings: '',
       warningTimeout: null,
       groups: [
@@ -692,12 +636,6 @@ export default {
       },
       deep: true,
     },
-    columns: {
-      handler: function() {
-        this.getApplicationRecords();
-      },
-      deep: true,
-    },
     type: {
       handler: function() {
         this.getApplicationRecords();
@@ -811,6 +749,14 @@ export default {
       const report = this.customReports[event.target.value];
       this.columns = report.columns;
       this.whereClauses = report.whereClauses;
+    },
+    generateReport() {
+      this.getApplicationRecords();
+      // Scroll to the list of columns
+      const element = document.querySelector('#column-list'); // Replace with the actual element selector
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
     },
     downloadReport() {
       const header = [...this.columns].map(col => this.keys[col].label);

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -47,7 +47,7 @@
               </button>
               <button
                 class="govuk-button govuk-button--primary moj-button-menu__item moj-page-header-actions__action"
-                :disabled="isLoading || !data"
+                :disabled="isLoading || !data || columns.length === 0"
                 @click="downloadReport"
               >
                 Download Report


### PR DESCRIPTION
## What's included?
As an Admin, I would like to be able to add selected fields to a custom report before generating data so that the process is more time-efficient.

Closes #2547 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the following page: https://jac-admin-develop--pr2599-feature-2547-improve-w9zbe8i1.web.app/exercise/R5mu47EVqEPf1WbXsLfZ/reports/custom

Test 1
- Ensure the Application Status and Status filters no longer display in the page
- Ensure the Candidate Ref No, Full Name and Application Status fields are selected by default
- Ensure the 'Generate Report' button is visible and enabled (ie dark green), whilst the 'Download Report' button is disabled (pale green/grey)
- After pressing the 'Generate Report' button the page should scroll and the data should load (after a short time). Once the data has loaded the 'Download Report' button should become enabled (dark green)
- Ensure can reorder the following fields by dragging them (Candidate Ref No, Full Name and Application Status fields)
- Ensure can add or remove fields
- Remove the Candidate Ref No, Full Name and Application Status fields and ensure that the 'Generate Report' and Download Report' buttons are both disabled (pale green/grey)

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
