### PR TITLE
Correct Incorrect Text Appearing Due To Lookups

### DIFF
--- a/src/components/ModalViews/IndependentAssessorChange.vue
+++ b/src/components/ModalViews/IndependentAssessorChange.vue
@@ -19,7 +19,7 @@
                 :key="option"
                 :value="option"
               >
-                {{ $filters.lookup(option) }}
+                {{ $filters.lookup(option) }} assessor
               </option>
             </Select>
             <TextField

--- a/src/components/ModalViews/IndependentAssessorChange.vue
+++ b/src/components/ModalViews/IndependentAssessorChange.vue
@@ -19,7 +19,7 @@
                 :key="option"
                 :value="option"
               >
-                {{ $filters.lookup(option) }} assessor
+                {{ $filters.lookup(option) }} Assessor
               </option>
             </Select>
             <TextField

--- a/src/filters.js
+++ b/src/filters.js
@@ -278,9 +278,14 @@ const lookup = (value) => {
   lookup[INDEPENDENT_ASSESSMENTS_STATUS.DECLINED] = 'Declined';
   lookup[INDEPENDENT_ASSESSMENTS_STATUS.DELETED] = 'Deleted';
 
-  lookup[ASSESSOR_TYPES.PROFESSIONAL] = 'Professional assessor';
-  lookup[ASSESSOR_TYPES.JUDICIAL] = 'Judicial assessor';
-  lookup[ASSESSOR_TYPES.PERSONAL] = 'Personal assessor';
+  // Note that when using the assessor lookups below you need to hardcode the word 'assessor' into the template
+  // as 'professional' is used in other places so cannot be used here to map to 'Profeesional assessor'
+  // lookup[ASSESSOR_TYPES.PROFESSIONAL] = 'Professional assessor';
+  // lookup[ASSESSOR_TYPES.JUDICIAL] = 'Judicial assessor';
+  // lookup[ASSESSOR_TYPES.PERSONAL] = 'Personal assessor';
+  lookup[ASSESSOR_TYPES.PROFESSIONAL] = 'Professional';
+  lookup[ASSESSOR_TYPES.JUDICIAL] = 'Judicial';
+  lookup[ASSESSOR_TYPES.PERSONAL] = 'Personal';
 
   // character issues offence category
   lookup[OFFENCE_CATEGORY.SINGLE_MOTORING_OFFENCE] = 'Single motoring offence';

--- a/src/views/Exercise/Dashboard/OverviewPanels/TypeOfExercise.vue
+++ b/src/views/Exercise/Dashboard/OverviewPanels/TypeOfExercise.vue
@@ -2,15 +2,21 @@
   <div class="panel govuk-!-margin-bottom-4">
     <span class="govuk-caption-m">Type of exercise</span>
     <h2 class="govuk-heading-m govuk-!-margin-bottom-0 long-text">
-      <span class="capitalize">{{ $filters.lookup(exercise.typeOfExercise) }}</span>
-      <span
+      <div class="capitalize govuk-!-display-inline-block">
+        {{ exercise.typeOfExercise }}
+      </div>
+      <div
         v-if="exercise.appointmentType"
-        class="capitalize"
-      >, {{ $filters.lookup(exercise.appointmentType) }}</span>
-      <span
+        class="capitalize govuk-!-display-inline-block"
+      >
+        , {{ $filters.lookup(exercise.appointmentType) }}
+      </div>
+      <div
         v-if="exercise.isCourtOrTribunal"
-        class="capitalize"
-      >, {{ $filters.lookup(exercise.isCourtOrTribunal) }}</span>
+        class="capitalize govuk-!-display-inline-block"
+      >
+        , {{ $filters.lookup(exercise.isCourtOrTribunal) }}
+      </div>
     </h2>
     <span class="govuk-caption-s color-middle">
       <span class="vh">&nbsp;</span>
@@ -18,6 +24,7 @@
   </div>
 </template>
 <script>
+//import { capitalizeFirstLetter } from '@/helpers/helpers';
 export default {
   name: 'TypeOfExercise',
   computed: {
@@ -27,3 +34,8 @@ export default {
   },
 };
 </script>
+<style>
+  .capitalize::first-letter {
+    text-transform: uppercase;
+  }
+</style>

--- a/src/views/InformationReview/AssessorsSummary.vue
+++ b/src/views/InformationReview/AssessorsSummary.vue
@@ -32,7 +32,7 @@
             Type
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ $filters.lookup(application.firstAssessorType) }}
+            {{ $filters.lookup(application.firstAssessorType) }} assessor
           </dd>
         </div>
 
@@ -126,7 +126,7 @@
             Type
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ $filters.lookup(application.secondAssessorType) }}
+            {{ $filters.lookup(application.secondAssessorType) }} assessor
           </dd>
         </div>
 


### PR DESCRIPTION
## What's included?
Two issues were reported, one had a ticket raised for it but they are connected so both go fixed in this ticket.
The issues arise because of overlapping references being used in the lookup helper.

**Issue 1)** 'Professional assessor' was being displayed next to occupation. This got flagged by a candidate and reported in the support channel. The fix involved removing the word assessor and hardcoding that in the template. This is a bit of a hack so will be nice to modify the way we do this lookup in the future to prevent this issue from arising again as it surely will.

**Issue 2)** The exercise type field was displaying 'Strategic Leadership Questions' instead of 'Leadership'.

Closes #2600 
Closes #2601 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

**1) Go to the following url : https://jac-admin-develop--pr2603-bugfix-2600-correct-iyu0ze8m.web.app/exercise/MwKzBqbvPyhMZaNXMGP2/dashboard**

Ensure 'Exercise Type' displays 'Leadership' instead of 'Strategic Leadership Questions', eg below:

<img width="1222" alt="Screenshot 2024-11-12 at 16 20 00" src="https://github.com/user-attachments/assets/0e0f7678-0f71-4c45-8079-d3c12c058186">


**2) Go to the following url: https://jac-admin-develop--pr2603-bugfix-2600-correct-iyu0ze8m.web.app/exercise/MwKzBqbvPyhMZaNXMGP2/applications/draft/application/PAjWsYyeuSkMMLIhUfWO**

Ensure the Occupation appears as 'Professional' below instead of 'Professional Assessor' in the Application in Admin

<img width="1131" alt="Screenshot 2024-11-12 at 16 29 36" src="https://github.com/user-attachments/assets/3d856d12-fbf9-4dc2-8151-bfe7960ef1b5">

**3) Go to the following url: https://jac-admin-develop--pr2603-bugfix-2600-correct-iyu0ze8m.web.app/exercise/MwKzBqbvPyhMZaNXMGP2/applications/draft/application/PAjWsYyeuSkMMLIhUfWO**

Ensure the Type appears as 'Professional Assessor' under Independent Assessors in the Application in Admin

<img width="624" alt="Screenshot 2024-11-12 at 16 24 01" src="https://github.com/user-attachments/assets/2b44588e-b9c2-4a8d-b4c3-884cb380a5f1">

**4) Go to the following url: https://jac-admin-develop--pr2603-bugfix-2600-correct-iyu0ze8m.web.app/exercise/MwKzBqbvPyhMZaNXMGP2/applications/draft/application/PAjWsYyeuSkMMLIhUfWO**

Ensure the Assessor Type appears as 'Professional Assessor' under Independent Assessor Change in the Application in Admin after choosing to edit the Application and choosing to Edit the Independent Assessors

<img width="626" alt="Screenshot 2024-11-12 at 16 25 11" src="https://github.com/user-attachments/assets/b6468f3c-cd4f-4014-b68b-18f253ef8377">

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
