### PR TITLE
Feature/2579 Exercise dashboard iteration

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -710,7 +710,12 @@ function isClosed(exercise) {
   return isApproved(exercise) && exercise.applicationCloseDate && exercise.applicationCloseDate <= new Date();
 }
 function applicationCounts(exercise) {
-  return exercise && exercise._applications ? exercise._applications : {};
+  const applicationCounts = exercise && exercise._applications ? { ...exercise._applications } : {};
+  // include withdrawn applications in applied count
+  if (applicationCounts && applicationCounts.applied) {
+    applicationCounts.applied = applicationCounts.applied + (applicationCounts.withdrawn || 0);
+  }
+  return applicationCounts;
 }
 function applicationRecordCounts(exercise) {
   return isProcessing(exercise) ? exercise._applicationRecords : {};

--- a/src/views/Exercise/Dashboard/Dashboard.vue
+++ b/src/views/Exercise/Dashboard/Dashboard.vue
@@ -136,7 +136,7 @@ import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
 import { lookup } from '@/filters';
 import { firestore, functions } from '@/firebase';
 import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
-import { applicationCounts, availableStages } from '@/helpers/exerciseHelper';
+import { applicationCounts, applicationRecordCounts, availableStages } from '@/helpers/exerciseHelper';
 import { EXERCISE_STAGE } from '@/helpers/constants';
 import { downloadXLSX } from '@jac-uk/jac-kit/helpers/export';
 import router from '@/router';
@@ -216,6 +216,9 @@ export default {
     applicationCounts() {
       return applicationCounts(this.exercise);
     },
+    applicationRecordCounts() {
+      return applicationRecordCounts(this.exercise);
+    },
     diversityReportType() {
       const types = [
         'gender',
@@ -245,22 +248,24 @@ export default {
       });
     },
     labels() {
+      console.log('this.applicationCounts', this.applicationCounts);
+
       return this.availableStages.map((stage) => {
         const tab = {};
         tab.key = stage;
         switch (stage) {
         case EXERCISE_STAGE.SHORTLISTING:
         case EXERCISE_STAGE.REVIEW:
-          tab.title = 'Applied';
+          tab.title = `Applied (${this.applicationCounts.applied || 0})`;
           break;
         case EXERCISE_STAGE.SELECTION:
-          tab.title = 'Shortlisted';
+          tab.title = `Shortlisted (${this.applicationRecordCounts[EXERCISE_STAGE.SELECTION] || 0})`;
           break;
         case EXERCISE_STAGE.SCC:
-          tab.title = 'Passed SD';
+          tab.title = `Passed SD (${this.applicationRecordCounts[EXERCISE_STAGE.SCC] || 0})`;
           break;
         case EXERCISE_STAGE.RECOMMENDATION:
-          tab.title = 'Recommended to JO';
+          tab.title = `Recommended to JO (${this.applicationRecordCounts[EXERCISE_STAGE.RECOMMENDATION] || 0})`;
           break;
         default:
           tab.title = this.$filters.lookup(stage);

--- a/src/views/Exercise/Dashboard/Dashboard.vue
+++ b/src/views/Exercise/Dashboard/Dashboard.vue
@@ -248,8 +248,6 @@ export default {
       });
     },
     labels() {
-      console.log('this.applicationCounts', this.applicationCounts);
-
       return this.availableStages.map((stage) => {
         const tab = {};
         tab.key = stage;

--- a/src/views/Exercise/Dashboard/OverviewPanels/TotalApplications.vue
+++ b/src/views/Exercise/Dashboard/OverviewPanels/TotalApplications.vue
@@ -6,7 +6,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body-s govuk-!-margin-bottom-0">
-          Applied
+          Applied (includes withdrawals)
         </span>
         <router-link
           :to="{ path: `/exercise/${exerciseId}/applications/applied`}"


### PR DESCRIPTION
## What's included?
closes #2579 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Go to the [preview URL](https://jac-admin-develop--pr2605-feat-2579-exercise-d-u61utu9s.web.app/) and check: 

- [x] Withdrawn candidates are included in counts.
- [x] The text 'Applied' (includes withdrawals)' appears on the dashboard.

  <img width="1251" alt="Screenshot 2024-11-13 at 08 25 53" src="https://github.com/user-attachments/assets/fb2ee92d-aa53-47cc-a552-5fe68d7a8d3e">

- [x] The total number of candidates at each stage are displayed in the tabs for each stage.
  
  <img width="1313" alt="Screenshot 2024-11-13 at 08 26 43" src="https://github.com/user-attachments/assets/2a04c403-7a9d-4dd0-b0cc-a9403e835e79">


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
