### PR TITLE
Data persistence in candidate views

### DIFF
--- a/src/store/candidates.js
+++ b/src/store/candidates.js
@@ -51,8 +51,8 @@ export default {
     }),
     bindDocs: firestoreAction(async ({ bindFirestoreRef }, id) => {
       await bindFirestoreRef('personalDetails', doc(collectionRef, `${id}/documents/personalDetails`), { serialize: vuexfireSerialize });
-      await bindFirestoreRef('characterInformation', doc(collectionRef, id, 'documents', 'characterInformation'), { serialize: vuexfireSerialize });
-      await bindFirestoreRef('equalityAndDiversitySurvey', doc(collectionRef, id, 'documents', 'equalityAndDiversitySurvey'), { serialize: vuexfireSerialize });
+      await bindFirestoreRef('characterInformation', doc(collectionRef, `${id}/documents/characterInformation`), { serialize: vuexfireSerialize });
+      await bindFirestoreRef('equalityAndDiversitySurvey', doc(collectionRef, `${id}/documents/equalityAndDiversitySurvey`), { serialize: vuexfireSerialize });
       return;
     }),
     unbindDocs: firestoreAction(async ({ unbindFirestoreRef }) => {
@@ -89,6 +89,9 @@ export default {
     },
     resetRecord(state) {
       state.record = null;
+      state.personalDetails = null;
+      state.characterInformation = null;
+      state.equalityAndDiversitySurvey = null;
     },
   },
   state: {

--- a/src/views/Candidates/CandidatesView.vue
+++ b/src/views/Candidates/CandidatesView.vue
@@ -175,7 +175,6 @@ export default {
       this.equalityAndDiversity = this.$store.state.candidates.equalityAndDiversitySurvey;
       this.candidateRecord = this.$store.state.candidates.record;
     });
-    console.log(this.$store.state.candidates);
   },
   unmounted() {
     this.$store.dispatch('candidates/unbindDoc');

--- a/src/views/Candidates/CandidatesView.vue
+++ b/src/views/Candidates/CandidatesView.vue
@@ -55,7 +55,7 @@
         />
       </dl>
       <EqualityAndDiversity
-        :data="equalityAndDiversity || {}"
+        :data="equalityAndDiversity"
       />
     </div>
 
@@ -172,9 +172,10 @@ export default {
       this.loading = false;
       this.personalDetails = this.$store.state.candidates.personalDetails;
       this.characterInformation = this.$store.state.candidates.characterInformation;
-      this.equalityAndDiversity = this.$store.state.candidates.equalityAndDiversity;
+      this.equalityAndDiversity = this.$store.state.candidates.equalityAndDiversitySurvey;
       this.candidateRecord = this.$store.state.candidates.record;
     });
+    console.log(this.$store.state.candidates);
   },
   unmounted() {
     this.$store.dispatch('candidates/unbindDoc');

--- a/src/views/Candidates/CandidatesView.vue
+++ b/src/views/Candidates/CandidatesView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="candidateRecord && !loading">
     <h1
       class="govuk-heading-xl govuk-!-margin-bottom-6"
     >
@@ -55,7 +55,7 @@
         />
       </dl>
       <EqualityAndDiversity
-        :data="equalityAndDiversity"
+        :data="equalityAndDiversity || {}"
       />
     </div>
 
@@ -80,6 +80,11 @@
       <UpdateLoginEmail :candidate-id="getUserId" />
     </div>
   </div>
+  <div
+    v-else-if="loading"
+  >
+    <LoadingMessage />
+  </div>
 </template>
 
 <script>
@@ -91,6 +96,7 @@ import CharacterInformationSummary from '@/views/InformationReview/CharacterInfo
 import EqualityAndDiversity from '@jac-uk/jac-kit/draftComponents/Candidates/EqualityAndDiversity.vue';
 import UpdateLoginEmail from '@/views/Candidates/UpdateLoginEmail.vue';
 import permissionMixin from '@/permissionMixin';
+import LoadingMessage from '@jac-uk/jac-kit/draftComponents/LoadingMessage.vue';
 
 export default {
   name: 'CandidatesView',
@@ -102,6 +108,7 @@ export default {
     PersonalDetailsSummary,
     CharacterInformationSummary,
     EqualityAndDiversity,
+    LoadingMessage,
   },
   mixins: [permissionMixin],
   data() {
@@ -109,6 +116,11 @@ export default {
       editMode: false,
       activeTab: 'details',
       candidateId: '',
+      candidateRecord: null,
+      personalDetails: null,
+      characterInformation: null,
+      equalityAndDiversity: null,
+      loading: true,
     };
   },
   computed: {
@@ -136,23 +148,8 @@ export default {
         });
       return tabs;
     },
-    candidateRecord() {
-      return this.$store.state.candidates.record;
-    },
-    personalDetails() {
-      const localDocs = this.$store.state.candidates.personalDetails;
-      return localDocs || {};
-    },
-    characterInformation() {
-      const localDocs = this.$store.state.candidates.characterInformation;
-      return localDocs || {};
-    },
     characterInformationVersion() {
       return this.characterInformation._versionNumber ? this.characterInformation._versionNumber : 1;
-    },
-    equalityAndDiversity() {
-      const localDocs = this.$store.state.candidates.equalityAndDiversitySurvey;
-      return localDocs || {};
     },
     myFullName() {
       return this.personalDetails ? this.personalDetails.fullName : this.candidateRecord.fullName;
@@ -165,21 +162,34 @@ export default {
     },
   },
   async created() {
-    this.candidateId = this.getUserId;
-    this.$store.dispatch('candidates/bindDoc', this.candidateId);
-    this.$store.dispatch('candidates/bindDocs', this.candidateId);
+    this.candidateId = this.getUserId || this.$route.params.id;
+    await Promise.all([
+      this.$store.commit('candidates/resetRecord'),
+      this.$store.dispatch('candidates/unbindDoc'),
+      this.$store.dispatch('candidates/bindDoc', this.candidateId),
+      this.$store.dispatch('candidates/bindDocs', this.candidateId),
+    ]).then(() => {
+      this.loading = false;
+      this.personalDetails = this.$store.state.candidates.personalDetails;
+      this.characterInformation = this.$store.state.candidates.characterInformation;
+      this.equalityAndDiversity = this.$store.state.candidates.equalityAndDiversity;
+      this.candidateRecord = this.$store.state.candidates.record;
+    });
   },
   unmounted() {
     this.$store.dispatch('candidates/unbindDoc');
     this.$store.dispatch('candidates/unbindDocs');
+    this.$store.commit('candidates/resetRecord');
   },
   methods: {
     makeFullName(obj) {
-      if (obj.firstName && this.personalDetails.lastName) {
-        obj.fullName = `${obj.firstName} ${this.personalDetails.lastName}`;
-      }
-      if (obj.lastName && this.personalDetails.firstName) {
-        obj.fullName = `${this.personalDetails.firstName} ${obj.lastName}`;
+      if (obj) {
+        if (obj.firstName && this.personalDetails.lastName) {
+          obj.fullName = `${obj.firstName} ${this.personalDetails.lastName}`;
+        }
+        if (obj.lastName && this.personalDetails.firstName) {
+          obj.fullName = `${this.personalDetails.firstName} ${obj.lastName}`;
+        }
       }
       return obj;
     },


### PR DESCRIPTION
## What's included?
Details in the candidate view, (Character Information, Equality and Diversity) were getting stuck when looking through different individuals, in circumstances when there were no answers. 
(ie. candidate A has answers for Char Info and E&D survey, Candidate B has none, Navigating to candidate A, then to Candidate B, you see candidate A's answers for Char Info and E&D).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Ensure no answers persist when looking through different candidates. 

- Start from each of the below urls
- Navigate to the candidate list
- then to any candidate with 0 applications (or any candidate with no char info/e&d data).

| Develop | Preview |
|---|---|
| [Candidate with Char Info and E&D](https://admin-develop.judicialappointments.digital/candidates/pdg1OwBW2aY5H9qSh6lP2AZo1Vf2) | [Candidate with Char Info and E&D](https://jac-admin-develop--pr2613-bugfix-candidate-det-uncycwwu.web.app/candidates/pdg1OwBW2aY5H9qSh6lP2AZo1Vf2) |
___

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
