### PR TITLE
Ticketing System #428 Custom Report NewlIne Chars On Download

### DIFF
--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -328,7 +328,6 @@ import Banner from '@jac-uk/jac-kit/draftComponents/Banner.vue';
 import { STATUS } from '@jac-uk/jac-kit/helpers/constants';
 import { applicationRecordCounts, availableStages, availableStatuses } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
-import { escapeValue } from '@/helpers/csv';
 
 // Prevents warnings and errors associated with using @vue/compat
 draggable.compatConfig = { MODE: 3 };

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -770,14 +770,21 @@ export default {
     downloadReport() {
       const header = [...this.columns].map(col => this.keys[col].label);
       const csv = [[...header]];
+
       for (let i = 0; i < this.data.data.length; i++) {
         csv.push([...this.columns.map(col => this.data.data[i][col])]);
       }
 
       // Convert the 2D array to CSV, ensuring values are properly escaped
+      const escapeValue = value => {
+        if (value == null) return ''; // Handle null or undefined
+        const escaped = String(value).replace(/"/g, '""'); // Escape double quotes
+        return `"${escaped}"`; // Enclose in double quotes
+      };
+
       const mappedCSV = csv
-        .map(row => row.map(escapeValue).join(',')) // Escape each value and join them with commas
-        .join('\n'); // Join each row with a newline
+        .map(row => row.map(escapeValue).join(',')) // Escape each value and join with commas
+        .join('\n'); // Join rows with a newline
 
       const csvContent = `data:text/csv;charset=utf-8,${mappedCSV}`;
       const encodedUri = encodeURI(csvContent);
@@ -787,6 +794,7 @@ export default {
       document.body.appendChild(link);
       link.click();
     },
+
     getDraggableKey(item) {
       // The internal index of the array isnt available in draggable so we have to use this fn to generate one so we can pass a
       // value to item-key


### PR DESCRIPTION
## What's included?
Fixed issue escaping newline chars when downloading the csv file. Previously the newline characters were causing some of the content to appear in the wrong column in the report.

Closes jac-uk/ticketing-system#428

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the following url: https://jac-admin-develop--pr2615-bugfix-ts-428-custom-mzq008u1.web.app/exercise/R5mu47EVqEPf1WbXsLfZ/reports/custom

Generate the report with the columns: 

- Candidate referenceNumber
- Fee paid or salaried sitting day details

... then download the report.
Ensure that no '/n' characters appear in the report and the application referencenNumbers only appear in the left hand column. Generally the report should look fine.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
