### PR TITLE
update jac kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "admin",
       "version": "1.76.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "4.1.48",
+        "@jac-uk/jac-kit": "4.1.49",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.61.1",
         "@sentry/vue": "^7.61.1",
@@ -1693,9 +1693,9 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "4.1.48",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.48/0ce9534f89de794d2b8aa64c96e84f774d53f51b",
-      "integrity": "sha512-f68JNwdAnfrdnqYdqDlAgQScIR87zD0Bj3jPLCOMkrtszQsfia05JTjRxCCxxTa4XI6KptJkDOqZ8K3OtZOjWQ==",
+      "version": "4.1.49",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.49/db584a36751b95430d131a84a156aeaf40d316d7",
+      "integrity": "sha512-9PSYZjypcZrVJ1Z4u8Q1U7Lpb7TohF7yToPVsAZkEuqhLm/Iez0SSSYY+B0LbknPFZ0kKSKygqMorAOF2A+XAA==",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "4.1.48",
+    "@jac-uk/jac-kit": "4.1.49",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.61.1",
     "@sentry/vue": "^7.61.1",


### PR DESCRIPTION
## What's included?
Update jac-kit version, ensure tooltip working.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Tooltip on dashboard should work.
<img width="280" alt="Screenshot 2024-12-02 at 10 39 26" src="https://github.com/user-attachments/assets/f4b3c37c-3300-4b15-857d-660b7e575d75">


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
