### PR TITLE
TS 490 Add selection setup to task list and create exercise page

### DIFF
--- a/src/views/CreateExercise.vue
+++ b/src/views/CreateExercise.vue
@@ -161,6 +161,10 @@
                 value="downloads"
                 label="Exercise Downloads"
               />
+              <CheckboxItem
+                value="additionalSettings"
+                label="Selection Set-up"
+              />
             </CheckboxGroup>
           </RadioItem>
 

--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -342,6 +342,7 @@ export default {
           data.push({ title: 'Assessment options', id: 'exercise-details-assessments', done: this.exerciseProgress.assessmentOptions, approved: this.approvalProgress['assessmentOptions'] });
           data.push({ title: 'Exercise downloads', id: 'exercise-details-downloads', done: this.exerciseProgress.downloads, approved: this.approvalProgress['downloads'] });
           data.push({ title: 'Application process', id: 'exercise-details-application-content', done: this.exerciseProgress.applicationProcess, approved: this.approvalProgress['applicationProcess'] });
+          data.push({ title: 'Selection set-up', id: 'exercise-details-selection-setup', done: this.exerciseProgress.additionalSettings, approved: this.approvalProgress['additionalSettings'] });
           if (this.exercise.inviteOnly) {
             data.splice(1, 0, { title: 'Exercise invitations', id: 'exercise-details-invitations' , done: this.exerciseProgress.invitations, approved: this.approvalProgress['invitations'] });
           }


### PR DESCRIPTION
## What's included?
Selection set-up has been added to the task list page and the create exercise page.

Closes jac-uk/ticketing-system#490

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to this url: https://jac-admin-develop--pr2636-bugfix-ts-490-missin-uwi0wv3a.web.app/
**Test 1**
- Create a new exercise
- Ensure the Selection Setup appears in the Create An Exercise page, see figure 1 below

**Test 2**
- Ensure the Selection Setup appears in the Task List page, see figure 2 below

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
**Figure 1**

<img width="381" alt="Screenshot 2024-12-09 at 10 23 38" src="https://github.com/user-attachments/assets/9810b240-8e64-4128-a243-1681aa2334bc">


Figure 2
<img width="1211" alt="Screenshot 2024-12-09 at 10 22 32" src="https://github.com/user-attachments/assets/ca9f3bf4-5b14-4bbc-9fc0-42d0fdcd4063">


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
