### PR TITLE
Feature/2631 SCC Report Summary page 

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -1423,6 +1423,10 @@ function availableReportLinks(exercise) {   // TODO this code is a bit specific 
       title: 'Custom',
       name: 'custom',
     },
+    {
+      title: 'SCC Summary Page',
+      name: 'scc-summary',
+    },
   ];
 
   if (exercise._processingVersion < 3) {

--- a/src/helpersTMP/Timeline/exerciseTimeline.js
+++ b/src/helpersTMP/Timeline/exerciseTimeline.js
@@ -27,8 +27,9 @@ const getDateAndTimeString = (date, startTime, endTime) => {
   return `${dateString} - ${startTimeString} to ${endTimeString}`;
 };
 
-const createSelectionDay = (selectionDay) => {
+export const createSelectionDay = (selectionDay) => {
   const selectionDayEntry = {
+    location: selectionDay.selectionDayLocation,
     entry: `Selection Day - ${selectionDay.selectionDayLocation}`,
     date: selectionDay.selectionDayStart,
     dateString: null,

--- a/src/router.js
+++ b/src/router.js
@@ -88,6 +88,7 @@ import ExerciseReportsSift from '@/views/Exercise/Reports/Sift.vue';
 import ExerciseReportsSelectionDays from '@/views/Exercise/Reports/SelectionDays.vue';
 import ExerciseReportsScenario from '@/views/Exercise/Reports/Scenario.vue';
 import ExerciseReportsCommissionerConflicts from '@/views/Exercise/Reports/CommissionerConflicts.vue';
+import ExerciseReportsSccSummary from '@/views/Exercise/Reports/SccSummary.vue';
 
 // Merit list
 import ExerciseReportsMeritList from '@/views/Exercise/Reports/MeritList.vue';
@@ -1230,6 +1231,15 @@ const routes = [
             meta: {
               requiresAuth: true,
               title: 'Commissioner Conflicts | Exercise Reports',
+            },
+          },
+          {
+            name: 'scc-summary',
+            path: 'scc-summary',
+            component: ExerciseReportsSccSummary,
+            meta: {
+              requiresAuth: true,
+              title: 'SCC Summary | Exercise Reports',
             },
           },
         ],

--- a/src/store.js
+++ b/src/store.js
@@ -50,6 +50,8 @@ import bugReport from '@/store/bugReports/document';
 import releases from '@/store/releases';
 import candidateSettings from '@/store/candidateSettings';
 
+import exerciseReportSccSummary from '@/store/exercise/reports/sccSummary';
+
 //const store = new Vuex.Store({
 const store = createStore({
   // Don't use strict mode in production for performance reasons (https://vuex.vuejs.org/guide/strict.html)
@@ -74,6 +76,7 @@ const store = createStore({
     exerciseCreateJourney,
     exerciseDiversity,
     exerciseDocument,
+    exerciseReportSccSummary,
     invitations,
     lateApplicationRequestMsg: new LateApplicationRequestMsg().getModule(),
     lateApplicationResponseMsg: new LateApplicationResponseMsg().getModule(),

--- a/src/store/exercise/reports/sccSummary.js
+++ b/src/store/exercise/reports/sccSummary.js
@@ -1,0 +1,29 @@
+import { doc, setDoc } from '@firebase/firestore';
+import { firestore } from '@/firebase';
+import { firestoreAction } from '@/helpers/vuexfireJAC';
+import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
+
+export default {
+  namespaced: true,
+  actions: {
+    bind: firestoreAction(({ bindFirestoreRef }, exerciseId) => {
+      const firestoreRef = doc(firestore, `exercises/${exerciseId}/reports/sccSummary`);
+      return bindFirestoreRef('record', firestoreRef, { serialize: vuexfireSerialize });
+    }),
+    unbind: firestoreAction(({ unbindFirestoreRef }) => {
+      return unbindFirestoreRef('record');
+    }),
+    update: async (context, { exerciseId, data }) => {
+      const ref = doc(firestore, `exercises/${exerciseId}/reports/sccSummary`);
+      await setDoc(ref, data, { merge: true });
+    },
+  },
+  mutations: {
+    set(state, { name, value }) {
+      state[name] = value;
+    },
+  },
+  state: {
+    record: null,
+  },
+};

--- a/src/views/Exercise/Reports/SccSummary.vue
+++ b/src/views/Exercise/Reports/SccSummary.vue
@@ -234,7 +234,14 @@
             Dates of selection days
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ selectionDays }}
+            <ul class="govuk-list">
+              <li
+                v-for="selectionDay in selectionDays"
+                :key="selectionDay"
+              >
+                {{ selectionDay }}
+              </li>
+            </ul>
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -370,8 +377,7 @@ const exercise = computed(() => store.state.exerciseDocument.record || {});
 const selectionDays = computed(() => {
   const rawData = exercise.value.selectionDays || [];
   return rawData.map((s) => createSelectionDay(s))
-    .map((s) => s.location ? `${s.location} - ${s.dateString}` : s.dateString)
-    .join(', ');
+    .map((s) => s.location ? `${s.location} - ${s.dateString}` : s.dateString);
 });
 const isLoading = ref(false);
 

--- a/src/views/Exercise/Reports/SccSummary.vue
+++ b/src/views/Exercise/Reports/SccSummary.vue
@@ -1,0 +1,462 @@
+<template>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="moj-page-header-actions">
+        <div class="moj-page-header-actions__title">
+          <h2 class="govuk-heading-l">
+            SCC Summary
+          </h2>
+        </div>
+        <div class="moj-page-header-actions__actions float-right">
+          <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper">
+              <ActionButton
+                v-if="
+                  hasPermissions([
+                    PERMISSIONS.exercises.permissions.canReadExercises.value,
+                    PERMISSIONS.applications.permissions.canReadApplications.value,
+                    PERMISSIONS.applicationRecords.permissions.canReadApplicationRecords.value,
+                  ])
+                "
+                class="govuk-!-margin-right-2"
+                :action="downloadSccSummaryReport"
+              >
+                Download SCC Summary
+              </ActionButton>
+              <ActionButton
+                type="primary"
+                :action="refreshReport"
+              >
+                Refresh
+              </ActionButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="exerciseReportSccSummary"
+      class="govuk-grid-column-full"
+    >
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Number of vacancies
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ sccSummaryForm.numberOfVacancies }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Number of candidates proposed for Recommendation
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="numberOfCandidatesProposedForRecommendation"
+              v-model="sccSummaryForm.numberOfCandidatesProposedForRecommendation"
+              type="number"
+              @update:model-value="saveSccSummary('numberOfCandidatesProposedForRecommendation', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Vacancies by jurisdiction/chamber
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="vacanciesByJurisdictionChamber"
+              v-model="sccSummaryForm.vacanciesByJurisdictionChamber"
+              type="number"
+              @update:model-value="saveSccSummary('vacanciesByJurisdictionChamber', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Location details
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ sccSummaryForm.locationDetails }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            VR (includes details of SPTW)
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Annex
+            <TextField
+              id="vr"
+              v-model="sccSummaryForm.vr"
+              type="text"
+              @update:model-value="saveSccSummary('vr', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            &nbsp;
+          </dt>
+          <dd class="govuk-summary-list__value">
+            &nbsp;
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Launch
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ $filters.formatDate(sccSummaryForm.launch, 'long') }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Closed
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ $filters.formatDate(sccSummaryForm.closed, 'long') }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Number of applications
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ sccSummaryForm.numberOfApplications }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Number of withdrawals
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ sccSummaryForm.numberOfWithdrawals }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Number removed on eligibility/ASC
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ sccSummaryForm.numberOfRemovedOnEligibilityOrASC }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            &nbsp;
+          </dt>
+          <dd class="govuk-summary-list__value">
+            &nbsp;
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Number shortlisted
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ sccSummaryForm.numberOfShortlisted }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Method of shortlisting
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <Select
+              id="shortlistingMethod"
+              v-model="sccSummaryForm.shortlistingMethod"
+              @update:model-value="saveSccSummary('shortlistingMethod', $event)"
+            >
+              <option
+                v-for="shortlistingMethod in shortlistingMethods"
+                :key="shortlistingMethod"
+                :value="shortlistingMethod"
+              >
+                {{ shortlistingMethod }}
+              </option>
+            </Select>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Dates of shortlisting
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="shortlistingDates"
+              v-model="sccSummaryForm.shortlistingDates"
+              type="text"
+              @update:model-value="saveSccSummary('shortlistingDates', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            &nbsp;
+          </dt>
+          <dd class="govuk-summary-list__value">
+            &nbsp;
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Statutory consultee(s)
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="statutoryConsultees"
+              v-model="sccSummaryForm.statutoryConsultees"
+              type="text"
+              @update:model-value="saveSccSummary('statutoryConsultees', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            &nbsp;
+          </dt>
+          <dd class="govuk-summary-list__value">
+            &nbsp;
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Selection day tools
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ sccSummaryForm.selectionDayTools }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Number of A-C candidates
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="numberOfACandidates"
+              v-model="sccSummaryForm.numberOfACandidates"
+              type="number"
+              @update:model-value="saveSccSummary('numberOfACandidates', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Dates of selection days
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ sccSummaryForm.datesOfSelectionDays }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            &nbsp;
+          </dt>
+          <dd class="govuk-summary-list__value">
+            &nbsp;
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Date s.94 list Created
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="dateS94ListCreated"
+              v-model="sccSummaryForm.dateS94ListCreated"
+              type="text"
+              @update:model-value="saveSccSummary('dateS94ListCreated', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Candidates Remaining on s.94 list
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="candidatesRemainingOnS94List"
+              v-model="sccSummaryForm.candidatesRemainingOnS94List"
+              type="number"
+              @update:model-value="saveSccSummary('candidatesRemainingOnS94List', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            &nbsp;
+          </dt>
+          <dd class="govuk-summary-list__value">
+            &nbsp;
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Character Checks undertaken
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="characterChecksUndertaken"
+              v-model="sccSummaryForm.characterChecksUndertaken"
+              type="text"
+              @update:model-value="saveSccSummary('characterChecksUndertaken', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Character issues
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <TextField
+              id="characterIssues"
+              v-model="sccSummaryForm.characterIssues"
+              type="text"
+              @update:model-value="saveSccSummary('characterIssues', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Matters requiring a decision
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Annex
+            <TextField
+              id="mattersRequiringADecision"
+              v-model="sccSummaryForm.mattersRequiringADecision"
+              type="text"
+              @update:model-value="saveSccSummary('mattersRequiringADecision', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Previously declared, within guidance
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Annex
+            <TextField
+              id="previouslyDeclaredWithinGuidance"
+              v-model="sccSummaryForm.previouslyDeclaredWithinGuidance"
+              type="text"
+              @update:model-value="saveSccSummary('previouslyDeclaredWithinGuidance', $event)"
+            />
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            High scoring D candidates
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Annex
+            <TextField
+              id="highScoringDCandidates"
+              v-model="sccSummaryForm.highScoringDCandidates"
+              type="text"
+              @update:model-value="saveSccSummary('highScoringDCandidates', $event)"
+            />
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, onBeforeUnmount, reactive, watchEffect } from 'vue';
+import store from '@/store';
+import { httpsCallable } from '@firebase/functions';
+import { functions } from '@/firebase';
+import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
+import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField.vue';
+import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
+import { downloadBase64File } from '@/helpers/file';
+import { hasPermissions } from '@/services/permissionService';
+import PERMISSIONS from '@/permissions';
+
+const exerciseReportSccSummary = computed(() => store.state.exerciseReportSccSummary.record || {});
+const exercise = computed(() => store.state.exerciseDocument.record || {});
+const shortlistingMethods = computed(() => exerciseReportSccSummary.value.methodOfShortlistingArray || []);
+
+const sccSummaryForm = reactive({});
+
+onMounted(async () => {
+  await getData();
+  store.dispatch('exerciseReportSccSummary/bind', exercise.value.id);
+});
+
+onBeforeUnmount(() => {
+  store.dispatch('exerciseReportSccSummary/unbind');
+});
+
+const saveSccSummary = async (field, value) => {
+  await store.dispatch('exerciseReportSccSummary/update', { exerciseId: exercise.value.id, data: { [field]: value } });
+};
+
+const refreshReport = async () => {
+  try {
+    const result = await getData();
+    return result;
+  } catch (error) {
+    return;
+  }
+};
+
+const getData = async () => {
+  const result = await httpsCallable(functions, 'generateSccSummaryReport')({ exerciseId: exercise.value.id });
+  return result;
+};
+
+const downloadSccSummaryReport = async () => {
+  if (!exercise.value.referenceNumber) {
+    console.error('No reference number available');
+    return false;
+  }
+  try {
+    const result = await httpsCallable(
+      functions,
+      'exportSccSummaryReport'
+    )({
+      exerciseId: exercise.value.id,
+      format: 'googledoc',
+    });
+
+    if (!result.data) {
+      console.error('No data received from the function');
+      return false;
+    }
+
+    downloadBase64File(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      result.data,
+      `${exercise.value.referenceNumber}_SCC Summary Report.docx`
+    );
+
+    return true;
+  } catch (error) {
+    console.error('Error downloading SCC Summary Report:', error);
+    return false;
+  }
+};
+
+watchEffect(() => {
+  if (exerciseReportSccSummary.value) {
+    Object.assign(sccSummaryForm, exerciseReportSccSummary.value);
+  }
+});
+
+</script>
+
+<style type="text/css" rel="stylesheet/scss" lang="scss" scoped>
+.govuk-summary-list__value,
+.govuk-summary-list__value:last-child,
+.govuk-summary-list__key {
+  @include govuk-media-query($from: tablet) {
+    width: auto;
+  }
+}
+</style>

--- a/src/views/Exercise/Reports/SccSummary.vue
+++ b/src/views/Exercise/Reports/SccSummary.vue
@@ -18,16 +18,9 @@
                     PERMISSIONS.applicationRecords.permissions.canReadApplicationRecords.value,
                   ])
                 "
-                class="govuk-!-margin-right-2"
                 :action="downloadSccSummaryReport"
               >
                 Download SCC Summary
-              </ActionButton>
-              <ActionButton
-                type="primary"
-                :action="refreshReport"
-              >
-                Refresh
               </ActionButton>
             </div>
           </div>
@@ -170,19 +163,7 @@
             Method of shortlisting
           </dt>
           <dd class="govuk-summary-list__value">
-            <Select
-              id="shortlistingMethod"
-              v-model="sccSummaryForm.shortlistingMethod"
-              @update:model-value="saveSccSummary('shortlistingMethod', $event)"
-            >
-              <option
-                v-for="shortlistingMethod in shortlistingMethods"
-                :key="shortlistingMethod"
-                :value="shortlistingMethod"
-              >
-                {{ shortlistingMethod }}
-              </option>
-            </Select>
+            {{ sccSummaryForm.shortlistingMethod }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -378,7 +359,6 @@ import { httpsCallable } from '@firebase/functions';
 import { functions } from '@/firebase';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
 import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField.vue';
-import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
 import LoadingMessage from '@jac-uk/jac-kit/draftComponents/LoadingMessage.vue';
 import { downloadBase64File } from '@/helpers/file';
 import { hasPermissions } from '@/services/permissionService';
@@ -386,7 +366,6 @@ import PERMISSIONS from '@/permissions';
 
 const exerciseReportSccSummary = computed(() => store.state.exerciseReportSccSummary.record || {});
 const exercise = computed(() => store.state.exerciseDocument.record || {});
-const shortlistingMethods = computed(() => exerciseReportSccSummary.value.methodOfShortlistingArray || []);
 const isLoading = ref(false);
 
 const sccSummaryForm = reactive({});
@@ -404,15 +383,6 @@ onBeforeUnmount(() => {
 
 const saveSccSummary = async (field, value) => {
   await store.dispatch('exerciseReportSccSummary/update', { exerciseId: exercise.value.id, data: { [field]: value } });
-};
-
-const refreshReport = async () => {
-  try {
-    const result = await getData();
-    return result;
-  } catch (error) {
-    return;
-  }
 };
 
 const getData = async () => {

--- a/src/views/Exercise/Reports/SccSummary.vue
+++ b/src/views/Exercise/Reports/SccSummary.vue
@@ -234,7 +234,7 @@
             Dates of selection days
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ sccSummaryForm.datesOfSelectionDays }}
+            {{ selectionDays }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -363,9 +363,16 @@ import LoadingMessage from '@jac-uk/jac-kit/draftComponents/LoadingMessage.vue';
 import { downloadBase64File } from '@/helpers/file';
 import { hasPermissions } from '@/services/permissionService';
 import PERMISSIONS from '@/permissions';
+import { createSelectionDay } from '@/helpersTMP/Timeline/exerciseTimeline';
 
 const exerciseReportSccSummary = computed(() => store.state.exerciseReportSccSummary.record || {});
 const exercise = computed(() => store.state.exerciseDocument.record || {});
+const selectionDays = computed(() => {
+  const rawData = exercise.value.selectionDays || [];
+  return rawData.map((s) => createSelectionDay(s))
+    .map((s) => s.location ? `${s.location} - ${s.dateString}` : s.dateString)
+    .join(', ');
+});
 const isLoading = ref(false);
 
 const sccSummaryForm = reactive({});

--- a/src/views/Exercise/Reports/SccSummary.vue
+++ b/src/views/Exercise/Reports/SccSummary.vue
@@ -34,9 +34,14 @@
         </div>
       </div>
     </div>
-
     <div
-      v-if="exerciseReportSccSummary"
+      v-if="isLoading"
+      class="govuk-grid-column-full"
+    >
+      <LoadingMessage />
+    </div>
+    <div
+      v-else-if="exerciseReportSccSummary"
       class="govuk-grid-column-full"
     >
       <dl class="govuk-summary-list">
@@ -367,13 +372,14 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onBeforeUnmount, reactive, watchEffect } from 'vue';
+import { computed, onMounted, onBeforeUnmount, reactive, watchEffect, ref } from 'vue';
 import store from '@/store';
 import { httpsCallable } from '@firebase/functions';
 import { functions } from '@/firebase';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
 import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField.vue';
 import Select from '@jac-uk/jac-kit/draftComponents/Form/Select.vue';
+import LoadingMessage from '@jac-uk/jac-kit/draftComponents/LoadingMessage.vue';
 import { downloadBase64File } from '@/helpers/file';
 import { hasPermissions } from '@/services/permissionService';
 import PERMISSIONS from '@/permissions';
@@ -381,12 +387,15 @@ import PERMISSIONS from '@/permissions';
 const exerciseReportSccSummary = computed(() => store.state.exerciseReportSccSummary.record || {});
 const exercise = computed(() => store.state.exerciseDocument.record || {});
 const shortlistingMethods = computed(() => exerciseReportSccSummary.value.methodOfShortlistingArray || []);
+const isLoading = ref(false);
 
 const sccSummaryForm = reactive({});
 
 onMounted(async () => {
+  isLoading.value = true;
   await getData();
   store.dispatch('exerciseReportSccSummary/bind', exercise.value.id);
+  isLoading.value = false;
 });
 
 onBeforeUnmount(() => {

--- a/src/views/Exercise/Reports/SccSummary.vue
+++ b/src/views/Exercise/Reports/SccSummary.vue
@@ -67,7 +67,7 @@
             <TextField
               id="vacanciesByJurisdictionChamber"
               v-model="sccSummaryForm.vacanciesByJurisdictionChamber"
-              type="number"
+              type="text"
               @update:model-value="saveSccSummary('vacanciesByJurisdictionChamber', $event)"
             />
           </dd>

--- a/tests/unit/helpers/exerciseHelper.test.js
+++ b/tests/unit/helpers/exerciseHelper.test.js
@@ -1551,6 +1551,10 @@ describe('availableReportLinks', () => {
         { title: 'Merit List', name: 'merit-list' },
         { title: 'Outreach', name: 'outreach' },
         { title: 'Reasonable Adjustments', name: 'reasonable-adjustments' },
+        { title: 'SCC Summary Page', name: 'scc-summary' },
+        { title: 'Scenario Responses', path: `${path}/scenario` },
+        { title: 'Selection day', path: `${path}/selection` },
+        { title: 'Sift', path: `${path}/sift` },
         { title: 'Statutory Consultation', name: 'statutory-consultation' },
       ];
       expect(availableReportLinks(exercise)).toEqual(expectedLinks);
@@ -1572,6 +1576,7 @@ describe('availableReportLinks', () => {
         { title: 'Merit List', name: 'merit-list' },
         { title: 'Outreach', name: 'outreach' },
         { title: 'Reasonable Adjustments', name: 'reasonable-adjustments' },
+        { title: 'SCC Summary Page', name: 'scc-summary' },
         { title: 'Statutory Consultation', name: 'statutory-consultation' },
       ];
       expect(availableReportLinks(exercise)).toEqual(expectedLinks);

--- a/tests/unit/helpers/exerciseHelper.test.js
+++ b/tests/unit/helpers/exerciseHelper.test.js
@@ -1552,9 +1552,6 @@ describe('availableReportLinks', () => {
         { title: 'Outreach', name: 'outreach' },
         { title: 'Reasonable Adjustments', name: 'reasonable-adjustments' },
         { title: 'SCC Summary Page', name: 'scc-summary' },
-        { title: 'Scenario Responses', path: `${path}/scenario` },
-        { title: 'Selection day', path: `${path}/selection` },
-        { title: 'Sift', path: `${path}/sift` },
         { title: 'Statutory Consultation', name: 'statutory-consultation' },
       ];
       expect(availableReportLinks(exercise)).toEqual(expectedLinks);


### PR DESCRIPTION
## What's included?
Closes #2631

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://jac-admin-develop--pr2641-feat-2631-scc-report-w5b13tuh.web.app/exercise/0ySRDHmWM8ARVxSCw7zv
- Click `SCC Summary Page` of reports menu.
- The SCC summary should have data.
- Enter customised fields and click Download SCC Summary, the SCC data should be included.
<img width="1357" alt="Screenshot 2024-12-18 at 09 56 44" src="https://github.com/user-attachments/assets/63efa564-59e7-448d-b0af-2540e0b2df69" />

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of worke

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
