### PR TITLE
update test assessment link

### DIFF
--- a/src/views/Exercise/Tasks/IndependentAssessments.vue
+++ b/src/views/Exercise/Tasks/IndependentAssessments.vue
@@ -240,11 +240,12 @@
               <div>
                 <a
                   v-if="(isNotRequested || isRequested) && testAssessmentUrl"
-                  target="_blank"
-                  :href="`${testAssessmentUrl}/sign-in?email=${row.assessor.email}&ref=assessments/${row.id}`"
-                  style="display: block; line-height: 40px; white-space: nowrap;"
+                  style="display: block; line-height: 40px; white-space: nowrap; min-width: 250px;"
+                  href="javascript: void(0)"
+                  class="govuk-link"
+                  @click="onTestAppClick(row)"
                 >
-                  Test the assessments app
+                  {{ !loadingTestAppLink ? 'Test the assessments app' : 'Creating link...' }}
                 </a>
 
                 <ActionButton
@@ -430,6 +431,7 @@ export default {
       modalParams: null,
       modalCallback: null,
       selectedItems: [],
+      loadingTestAppLink: false,
     };
   },
   computed: {
@@ -690,6 +692,25 @@ export default {
     },
     resetSelectedItems() {
       this.selectedItems = [];
+    },
+    async onTestAppClick(assessment) {
+      try {
+        this.loadingTestAppLink = true;
+        const response = await httpsCallable(functions, 'getTestAssessmentAppLink')({
+          assessmentId: assessment.id,
+        });
+        if (response && response.data) {
+          window.open(response.data, '_blank'); // eslint-disable-line
+          return;
+        }
+        //window.open(`${this.testAssessmentUrl}/assessment/${assessment.id}`, '_blank');
+
+      } catch (error) {
+        console.error(error);
+      } finally {
+        this.loadingTestAppLink = false;
+      }
+
     },
   },
 };


### PR DESCRIPTION
## What's included?
closes https://github.com/jac-uk/digital-platform/issues/1244

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://admin-develop.judicialappointments.digital/exercise/Biyjd07Xz2usL9yXjtjV/tasks/all/independent-assessments
- Click `Test request`, it should send email notification contains sign-in request link.
- Click `Send requests`, it should send email notification contains sign-in request link.
- Click `Test reminder`, it should send email notification contains sign-in request link.
- Click `Send reminder`, it should send email notification contains sign-in request link.
- Click `Test the assessments app`, it should open the assessment link in new page.
<img width="1209" alt="Screenshot 2024-12-24 at 17 29 06" src="https://github.com/user-attachments/assets/f488f7d1-4baa-4dbc-b17a-98d69673b5df" />
<img width="1242" alt="Screenshot 2024-12-24 at 17 30 02" src="https://github.com/user-attachments/assets/8d1a77a0-2085-4dd2-9747-7f269c466753" />


--


[Test the assessments app](javascript: void(0))

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
