### PR TITLE
Update Custom report with latest working preferences

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -21,7 +21,8 @@ hasSelfAssessment,
 exerciseApplicationParts,
 configuredApplicationParts,
 applicationContentList,
-unselectedApplicationParts
+unselectedApplicationParts,
+isNewAdditionalWorkingPreferencesQuestionType
 */
 
 export {
@@ -103,7 +104,8 @@ export {
   isApplicationVersionGreaterThan,
   isApplicationVersionLessThan,
   isJAC00187,
-  isPublished
+  isPublished,
+  isNewAdditionalWorkingPreferencesQuestionType
 };
 
 // const EXERCISE_STATES = ['draft', 'ready', 'approved', 'shortlisting', 'selection', 'recommendation', 'handover', 'archived'];
@@ -1562,4 +1564,8 @@ function canApplyFullApplicationSubmitted(exercise) {
   const applyFullApplicationSubmitted = isStagedExercise && exercise.applicationOpenDate >= new Date(2024, 7, 18);
 
   return applyFullApplicationSubmitted;
+}
+
+function isNewAdditionalWorkingPreferencesQuestionType(exercise) {
+  return exercise.additionalWorkingPreferences && exercise.additionalWorkingPreferences.some((el) => 'groupAnswers' in el);
 }

--- a/src/views/Exercise/Details/Preferences/View/AdditionalWorkingPreferences.vue
+++ b/src/views/Exercise/Details/Preferences/View/AdditionalWorkingPreferences.vue
@@ -33,6 +33,7 @@
 <script>
 import QuestionConfigView from '@/components/QuestionConfig/View.vue';
 import WorkingPreferencesQuestionView from '@/components/WorkingPreferencesQuestion/View.vue';
+import { isNewAdditionalWorkingPreferencesQuestionType } from '@/helpers/exerciseHelper';
 
 export default {
   name: 'AdditionalWorkingPreferences',
@@ -47,8 +48,8 @@ export default {
     },
   },
   computed: {
-    isNewQuestionType(){
-      return this.exercise.additionalWorkingPreferences && this.exercise.additionalWorkingPreferences.some((el) => 'groupAnswers' in el);
+    isNewQuestionType() {
+      return isNewAdditionalWorkingPreferencesQuestionType(this.exercise);
     },
   },
 };

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -381,10 +381,27 @@ export default {
       return statuses;
     },
     groups() {
-      return this.defaultGroups.concat(this.preferenceGroups);
+      let groups = this.defaultGroups.slice();
+      if (this.exercise.typeOfExercise === 'non-legal') {
+        groups = groups.concat([
+          {
+            name: 'Experience',
+            keys: ['experience'],
+          },
+        ]);
+
+      }
+      groups = groups.concat(this.preferenceGroups);
+      return groups;
     },
     keys() {
-      return _.merge(this.defaultKeys, this.preferenceKeys);
+      let keys = _.clone(this.defaultKeys);
+      if (this.exercise.typeOfExercise === 'non-legal') {
+        keys = _.merge(keys, {
+          experience: { label: 'Experience', type: String },
+        });
+      }
+      return _.merge(keys, this.preferenceKeys);
     },
     preferenceGroups() {
       const groups = [];

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -420,7 +420,7 @@ export default {
           keys: ['locationPreferences'],
         });
       }
-      if (Array.isArray(this.exercise.additionalWorkingPreferences) && this.exercise.additionalWorkingPreferences && !isNewAdditionalWorkingPreferencesQuestionType(this.exercise)) {
+      if (this.exercise?.additionalWorkingPreferences?.length && !isNewAdditionalWorkingPreferencesQuestionType(this.exercise)) {
         const keys = [];
         this.exercise.additionalWorkingPreferences.forEach((question, i) => {
           keys.push(`additionalWorkingPreferences ${i}`);

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -359,8 +359,9 @@ export default {
       columns: ['referenceNumber', 'personalDetails.fullName', 'status'],
       warnings: '',
       warningTimeout: null,
-      groups: customReportConstants.groups,
-      keys: customReportConstants.keys,
+      defaultGroups: customReportConstants.groups,
+      defaultKeys: customReportConstants.keys,
+      workingPreferences: ['locationPreferences', 'jurisdictionPreferences',  'additionalWorkingPreferences'],
     };
   },
   computed: {
@@ -378,6 +379,40 @@ export default {
       if (this.selectedStage === 'all') return null;
       const statuses = availableStatuses(this.exercise, this.selectedStage);
       return statuses;
+    },
+    groups() {
+      return this.defaultGroups.concat(this.preferenceGroups);
+    },
+    keys() {
+      return _.merge(this.defaultKeys, this.preferenceKeys);
+    },
+    preferenceGroups() {
+      const groups = [];
+
+      for (const preference of this.workingPreferences) {
+        const questions = this.exercise[preference] || [];
+        if (questions.length) {
+          const keys = questions.map((q) => `${preference}.${q.id}`);
+          groups.push({
+            name: _.startCase(preference),
+            keys,
+          });
+        }
+      }
+      return groups;
+    },
+    preferenceKeys() {
+      const keys = {};
+
+      for (const preference of this.workingPreferences) {
+        const questions = this.exercise[preference] || [];
+        if (questions.length) {
+          for (const question of questions) {
+            keys[`${preference}.${question.id}`] = { label: question.question, type: String };
+          }
+        }
+      }
+      return keys;
     },
   },
   watch: {

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -321,7 +321,10 @@
 import { httpsCallable } from '@firebase/functions';
 import { functions } from '@/firebase';
 import draggable from 'vuedraggable';
-import _ from 'lodash';
+import _clone from 'lodash/clone';
+import _merge from 'lodash/merge';
+import _startCase from 'lodash/startCase';
+import _includes from 'lodash/includes';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
 import { customReportConstants } from '@/helpers/customReportConstants';
 import LoadingMessage from '@jac-uk/jac-kit/draftComponents/LoadingMessage.vue';
@@ -396,13 +399,13 @@ export default {
       return groups;
     },
     keys() {
-      let keys = _.clone(this.defaultKeys);
+      let keys = _clone(this.defaultKeys);
       if (this.exercise.typeOfExercise === 'non-legal') {
-        keys = _.merge(keys, {
+        keys = _merge(keys, {
           experience: { label: 'Experience', type: String },
         });
       }
-      return _.merge(keys, this.preferenceKeys);
+      return _merge(keys, this.preferenceKeys);
     },
     preferenceGroups() {
       const groups = [];
@@ -440,7 +443,7 @@ export default {
         if (questions.length) {
           const keys = questions.map((q) => `${preference}.${q.id}`);
           groups.push({
-            name: _.startCase(preference),
+            name: _startCase(preference),
             keys,
           });
         }
@@ -550,7 +553,7 @@ export default {
       this.isLoading = false;
     },
     selectColumn(event) {
-      if (!_.includes(this.columns, event.target.value)) {
+      if (!_includes(this.columns, event.target.value)) {
         this.columns.push(event.target.value);
       }
       this.selectedColumn = '';

--- a/src/views/InformationReview/PreferencesSummary.vue
+++ b/src/views/InformationReview/PreferencesSummary.vue
@@ -44,7 +44,7 @@
       class="govuk-!-margin-top-9"
     >
       <h2 class="govuk-heading-l">
-        Location preferences 123
+        Location preferences
       </h2>
 
       <dl

--- a/src/views/InformationReview/PreferencesSummary.vue
+++ b/src/views/InformationReview/PreferencesSummary.vue
@@ -44,7 +44,7 @@
       class="govuk-!-margin-top-9"
     >
       <h2 class="govuk-heading-l">
-        Location preferences
+        Location preferences 123
       </h2>
 
       <dl


### PR DESCRIPTION
## What's included?
closes #2320 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Working preferences
  - Go to the preview link: https://jac-admin-develop--pr2650-feat-2320-latest-wor-uenvqol7.web.app/exercise/oxz5BfzoJFMKWrvHHpBP/reports/custom
  - Select working preference fields.
  
<img width="1007" alt="Screenshot 2025-01-02 at 09 36 25" src="https://github.com/user-attachments/assets/fc95bafb-de13-4bdb-af90-4501c227674c" />

   - Generate custom report.
- Non legal exercise experience
  - Go to the preview link: https://jac-admin-develop--pr2650-feat-2320-latest-wor-uenvqol7.web.app/exercise/qxYX2i69L7k8pbzqRHyq/reports/custom
  - Select experience field.
  
<img width="968" alt="Screenshot 2025-01-02 at 09 40 20" src="https://github.com/user-attachments/assets/539a0d5e-4c06-4cdf-a9eb-75b1ea596556" />

  - Generate custom report. 
## Risk - how likely is this to impact other areas?

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:PRODUCTION
_can be OFF, DEVELOP or STAGING_
