### PR TITLE
#2663 Bugfix: PSDQ completed. Remove merit list, show stats

### DIFF
--- a/src/views/Exercise/Tasks/Task/Completed.vue
+++ b/src/views/Exercise/Tasks/Task/Completed.vue
@@ -25,6 +25,7 @@
     <ProgressBar :steps="taskSteps" />
 
     <MeritList
+      v-if="hasMeritList"
       :exercise-id="exercise.id"
       :task="task"
       :scores="scores"
@@ -32,6 +33,39 @@
       :score-type="scoreType"
       :show-diversity="false"
     />
+
+    <div v-else class="panel govuk-!-margin-bottom-6 govuk-!-padding-bottom-2">
+      <span class="govuk-caption-m">
+        Applications
+      </span>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <span class="govuk-body-s govuk-!-margin-bottom-0">
+            Total
+          </span>
+          <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
+            {{ task._stats.totalApplications }}
+          </h2>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <span class="govuk-body-s govuk-!-margin-bottom-0">
+            Completed
+          </span>
+          <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
+            {{ task._stats.completed }}
+          </h2>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <span class="govuk-body-s govuk-!-margin-bottom-0">
+            Not completed
+          </span>
+          <h2 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-padding-0">
+            {{ task._stats.notCompleted }}
+          </h2>
+        </div>
+      </div>
+    </div>
+
   </div>
 </template>
 
@@ -96,6 +130,9 @@ export default {
         TASK_TYPE.SCENARIO,
         TASK_TYPE.SITUATIONAL_JUDGEMENT,
       ].includes(this.type);
+    },
+    hasMeritList() {
+      return this.task?.finalScores;
     },
   },
   async created() {


### PR DESCRIPTION
## What's included?
Tidies up the PSDQ completed screen. 

**Before**
It was trying to display a merit list, even though PSDQ task does not involve merit.
<img width="531" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM2RwQ0E9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--a476fc2cfab64f85a8f2f01d43fe08ab76398466/image.png" alt="image.png" />

**Now**
The page shows headline stats only, not the merit list.
<img width="731" alt="image" src="https://github.com/user-attachments/assets/7555701b-5c94-45da-bef9-ea48cd384013" />


Closes #2663

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
[Preview URL](https://jac-admin-develop--pr2664-feature-2663-guwxiqxq.web.app/)

Note: You will need an exercise with a completed PSDQ

Check that the PSDQ completed screen displays as described above, and does not include a merit list.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
