### PR TITLE
Feat/admin 2671 add withdrawn candidates option to custom report

### DIFF
--- a/src/components/Page/EditableField.vue
+++ b/src/components/Page/EditableField.vue
@@ -146,7 +146,7 @@
                 v-for="(answer, sortedAnswerIndex) in sortedAnswers.answers"
                 :key="answer"
               >
-                {{ `${config.answers.find(ans => ans.id === answer).answer}${(sortedAnswerIndex + 1 < sortedAnswers.answers.length) ? ', ' : ''}` }}
+                {{ `${config?.answers?.find(ans => ans.id === answer)?.answer}${(sortedAnswerIndex + 1 < sortedAnswers.answers.length) ? ', ' : ''}` }}
               </span>
             </p>
           </div>
@@ -155,7 +155,7 @@
           v-else-if="isSingleChoice"
         >
           <!-- Render single-choice answer -->
-          {{ config.answers.find(ans => ans.id === value).answer }}
+          {{ config?.answers?.find && config?.answers?.find(ans => ans.id === value)?.answer }}
         </div>
         <div
           v-else-if="isMultipleChoice"
@@ -660,7 +660,7 @@ export default {
       }
     },
     getConfigAnswer(answerId) {
-      const match = this.config.answers.find(ans => ans.id === answerId);
+      const match = this.config?.answers?.find(ans => ans.id === answerId);
       return match ? match.answer : '';
     },
   },

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -67,6 +67,16 @@
         </p>
       </div>
       <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half govuk-!-margin-bottom-0">
+          <Checkbox
+            id="include-withdrawn-candidates"
+            v-model="includeWithdrawnCandidates"
+          >
+            Include withdrawn candidates
+          </Checkbox>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
           <div class="panel govuk-!-margin-bottom-3">
             <span class="govuk-caption-m govuk-!-margin-bottom-2"> Select a column to display: </span>
@@ -333,7 +343,7 @@ import { STATUS } from '@jac-uk/jac-kit/helpers/constants';
 import { applicationRecordCounts, availableStages, availableStatuses } from '@/helpers/exerciseHelper';
 import permissionMixin from '@/permissionMixin';
 import { isNewAdditionalWorkingPreferencesQuestionType } from '../../../helpers/exerciseHelper';
-
+import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox.vue';
 // Prevents warnings and errors associated with using @vue/compat
 draggable.compatConfig = { MODE: 3 };
 
@@ -344,6 +354,7 @@ export default {
     draggable,
     LoadingMessage,
     Banner,
+    Checkbox,
   },
   mixins: [permissionMixin],
   data() {
@@ -366,6 +377,7 @@ export default {
       defaultGroups: customReportConstants.groups,
       defaultKeys: customReportConstants.keys,
       workingPreferences: ['locationPreferences', 'jurisdictionPreferences',  'additionalWorkingPreferences'],
+      includeWithdrawnCandidates: false,
     };
   },
   computed: {
@@ -488,6 +500,13 @@ export default {
         this.getApplicationRecords();
       },
       deep: true,
+    },
+    includeWithdrawnCandidates: function (newValue) {
+      if (newValue) {
+        this.statuses.push(STATUS.WITHDRAWN);
+      } else {
+        this.statuses = this.statuses.filter(status => status !== STATUS.WITHDRAWN);
+      }
     },
     selectedStage: function () {
       this.selectedStageStatus = 'all';

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -222,7 +222,7 @@
             <tr
               v-for="(row, rowIndex) of data.data"
               :key="rowIndex"
-              class="govuk-table__row"
+              :class="['govuk-table__row', isWithdrawn(row) ? 'withdrawn' : '']"
             >
               <td
                 v-for="(column, columnIndex) in columns"
@@ -344,6 +344,7 @@ import { applicationRecordCounts, availableStages, availableStatuses } from '@/h
 import permissionMixin from '@/permissionMixin';
 import { isNewAdditionalWorkingPreferencesQuestionType } from '../../../helpers/exerciseHelper';
 import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox.vue';
+import { downloadXLSX } from '@jac-uk/jac-kit/helpers/export';
 // Prevents warnings and errors associated with using @vue/compat
 draggable.compatConfig = { MODE: 3 };
 
@@ -643,30 +644,30 @@ export default {
     },
     downloadReport() {
       const header = [...this.columns].map(col => this.keys[col].label);
-      const csv = [[...header]];
-
-      for (let i = 0; i < this.data.data.length; i++) {
-        csv.push([...this.columns.map(col => this.data.data[i][col])]);
-      }
-
-      // Convert the 2D array to CSV, ensuring values are properly escaped
-      const escapeValue = value => {
-        if (value == null) return ''; // Handle null or undefined
-        const escaped = String(value).replace(/"/g, '""'); // Escape double quotes
-        return `"${escaped}"`; // Enclose in double quotes
+      const xlsxData = [[...header]];
+      const highlightStyle = {
+        fill: 'eeeeee',
+      };
+      const styles = {
+        row: {},
       };
 
-      const mappedCSV = csv
-        .map(row => row.map(escapeValue).join(',')) // Escape each value and join with commas
-        .join('\n'); // Join rows with a newline
+      for (let i = 0; i < this.data.data.length; i++) {
+        xlsxData.push([...this.columns.map(col => this.data.data[i][col])]);
+        if (this.data.data[i]?._status === STATUS.WITHDRAWN) {
+          styles.row[i + 2] = highlightStyle;
+        }
+      }
 
-      const csvContent = `data:text/csv;charset=utf-8,${mappedCSV}`;
-      const encodedUri = encodeURI(csvContent);
-      const link = document.createElement('a');
-      link.setAttribute('href', encodedUri);
-      link.setAttribute('download', 'custom_report.csv');
-      document.body.appendChild(link);
-      link.click();
+      downloadXLSX(
+        xlsxData,
+        {
+          title: 'Custom report',
+          sheetName: 'Custom report',
+          fileName: 'custom-report.xlsx',
+          styles,
+        }
+      );
     },
 
     getDraggableKey(item) {
@@ -678,6 +679,9 @@ export default {
     isUsingFilter(key) {
       // return true if the column is a filter column
       return ['_processing.stage', '_processing.status'].includes(key);
+    },
+    isWithdrawn(application) {
+      return application._status === STATUS.WITHDRAWN;
     },
   },
 };
@@ -692,5 +696,8 @@ td:first-letter {
 }
 .moj-filter__tag {
   cursor: pointer;
+}
+.withdrawn {
+  background-color: govuk-colour("light-grey");
 }
 </style>


### PR DESCRIPTION
## What's included?
closes #2671 
## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://jac-admin-develop--pr2673-feat-admin-2671-add-u0glbedo.web.app/exercise/oxz5BfzoJFMKWrvHHpBP/reports/custom
- Tick the `Include withdrawn candidates`, the withdrawn applications should be included.
    - The withdrawn candidates should be highlighted with light grey.
    - Download the report, the withdrawn candidates should be highlighted with light grey.
    <img width="1286" alt="Screenshot 2025-01-20 at 18 21 57" src="https://github.com/user-attachments/assets/5a344c8f-eaec-4497-abbc-85dd05ec3249" />
<img width="518" alt="Screenshot 2025-01-20 at 18 18 53" src="https://github.com/user-attachments/assets/ec35e815-c912-4abe-b3e2-4fb49ab3bb68" />

- Tick off the `Include withdrawn candidates`, the withdrawn applications should not be included.


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
