### PR TITLE
Bugfix: Permissions for 'Create demo applications'

### DIFF
--- a/src/views/Exercise.vue
+++ b/src/views/Exercise.vue
@@ -57,7 +57,7 @@
             class="govuk-!-margin-top-1"
           >
             <button
-              v-if="isReadyForTesting && !isArchived"
+              v-if="isReadyForTesting && !isArchived && hasPermissions([PERMISSIONS.applications.permissions.canCreateTestApplications.value])"
               class="govuk-button govuk-button--secondary"
               @click="changeNoOfTestApplications()"
             >


### PR DESCRIPTION
## What's included?
Recent changes to tighten user permissions on cloud functions and UI features had introduced, or highlighted, a bug with the 'Create demo applications' buttons. There are two buttons with this label and only one had been updated with the correct permissions. This small PR fixes that.

The 'Create demo applications' button should only be displayed for user who have the `canCreateTestApplications` permission in their user role:

<img width="297" alt="image" src="https://github.com/user-attachments/assets/6c3c194a-18b3-4ea6-bd79-f0acaa0c6be5" />

## Who should test?
✅ Product owner
✅ Developers

## How to test?
You'll need a published approved exercise which does not have any applications. This one might work (for a while until someone creates applications!): 
https://jac-admin-develop--pr2678-bugfix-permissions-c-gxp3i72z.web.app/exercise/irlE2FKZJnFLOYAIsRHx/dashboard

Check the following:
 - If the logged in user does not have permission to create applications, you cannot see the 'Create demo applications' button
 - If the logged in user does have permission to create applications, you can see the 'Create demo applications' button


Compare this with the same checks on admin develop (i.e. without this fix) where the button displays if the user doesn't have permission and then disappears:
https://admin-develop.judicialappointments.digital/exercise/irlE2FKZJnFLOYAIsRHx/dashboard

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
