### PR TITLE
DP 1310 Updates To handover Report To Align With JO 

### DIFF
--- a/src/views/Exercise/Reports/Handover.vue
+++ b/src/views/Exercise/Reports/Handover.vue
@@ -187,7 +187,7 @@ export default {
     },
     async refreshReport() {
       try {
-        await httpsCallable(functions, 'generateHandoverReport')({ exerciseId: this.exercise.id }, true);
+        await httpsCallable(functions, 'generateHandoverReport')({ exerciseId: this.exercise.id });
         return true;
       } catch (error) {
         return;

--- a/src/views/Exercise/Reports/Handover.vue
+++ b/src/views/Exercise/Reports/Handover.vue
@@ -153,6 +153,7 @@ export default {
       return this.report && this.report.headers;
     },
   },
+
   created() {
     this.unsubscribe = onSnapshot(
       doc(firestore, `exercises/${this.exercise.id}/reports/handover`),
@@ -186,7 +187,7 @@ export default {
     },
     async refreshReport() {
       try {
-        await httpsCallable(functions, 'generateHandoverReport')({ exerciseId: this.exercise.id });
+        await httpsCallable(functions, 'generateHandoverReport')({ exerciseId: this.exercise.id }, true);
         return true;
       } catch (error) {
         return;
@@ -207,12 +208,10 @@ export default {
     },
     async exportData() {
       const title = 'Handover Report';
-      const data = this.gatherReportData();
-      /**
-       * Make the 'Judicial experience' (column S) can display multiple lines.
-       *
-       * @link: https://github.com/dtjohnson/xlsx-populate?tab=readme-ov-file#styles-1
-       */
+
+      // Strip the first four columns of data as they aren't needed for export (only for display in the table above)
+      const data = this.gatherReportData().map(row => row.slice(4));
+
       const styles = {
         row: {
           1: {
@@ -220,11 +219,11 @@ export default {
             fill: 'eeeeee',
           },
         },
-        column: {
-          'S': {
-            wrapText: true,
-          },
-        },
+        // column: {
+        //   'S': {
+        //     wrapText: true,  // display multiple lines
+        //   },
+        // },
       };
       const freezePanes = [
         {


### PR DESCRIPTION
### THIS SHOULD BE DEPLOYED WITH THE ASSOCIATED DP PULL REQUEST: 
https://github.com/jac-uk/digital-platform/pull/1311

## What's included?
Ensure table displays columns not intended for download. Strip the columns out for the download.
This is connected to the DP PR: https://github.com/jac-uk/digital-platform/pull/1311

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the handover report page.
Ensure the table displays the application reference and applicant's full name.
When the report is downloaded ensure the application id and reference and also the candidate fullname is not in the report.
The report format should match that of the JO Handover report.
See the parent ticket: https://github.com/jac-uk/digital-platform/issues/1310
## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
🟠 Medium risk - this does change code that is shared with other areas
🔴 High risk - this includes a lot of changes to shared code

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
