### PR TITLE
Feature/DP 1222 Change of panel packs location

### DIFF
--- a/src/views/Exercise/Tasks/Task/Panel/View.vue
+++ b/src/views/Exercise/Tasks/Task/Panel/View.vue
@@ -65,6 +65,18 @@
           </div>
         </div>
       </div>
+
+      <div
+        v-if="panel.error"
+        class="govuk-grid-row govuk-!-margin-bottom-6"
+      >
+        <div class="govuk-grid-column-full">
+          <strong class="govuk-error-message">
+            {{ panel.error }}
+          </strong>
+        </div>
+      </div>
+
       <TabsList
         v-model:active-tab="activeTab"
         :tabs="tabs"


### PR DESCRIPTION
## What's included?

Related PR: [Feature/1222 Change of panel packs location #1315](https://github.com/jac-uk/digital-platform/pull/1315)

- Display an error message on panel packs if the exercise folder can not be found in Google Drive.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

### [Exercise with a folder created in Google Drive](https://jac-admin-develop--pr2686-feature-dp-1222-chan-plv6qoaj.web.app/exercise/qoK8qlBRaolsKHf4xAl7/tasks/all/sift/panel/tXkgW1gNCHPEX1fk9iYq)
1. Go to a panel and click the "Export to google drive" button.
2. Go to Google Drive and check if the panel packs are generated in the location `JAC00082`.
3. Click the "Export to google drive" button again and check if the panel packs are generated in the new folder.

https://github.com/user-attachments/assets/d1c310c2-d97c-4877-b6a0-42c526681e3f

### [Exercise without a folder created in Google Drive](https://jac-admin-develop--pr2686-feature-dp-1222-chan-plv6qoaj.web.app/exercise/ZiKOtMNm46Yphs36vLL2/tasks/all/sift/panel/cc7XoENFx4Y8aLgBMtAD)
1. Go to a panel and click the "Export to google drive" button.
2. Check if the error message `Folder not found - please rename root exercise folder according to the reference number of the exercise, i.e. JAC00XXX` appears on the screen.

https://github.com/user-attachments/assets/a8fdec7f-14ce-47e0-b0cc-c747183728eb

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
