### PR TITLE
#2692 Bugfix: Selection set-up appearing twice

### DIFF
--- a/src/views/Exercise/Details/Overview.vue
+++ b/src/views/Exercise/Details/Overview.vue
@@ -342,7 +342,6 @@ export default {
           data.push({ title: 'Assessment options', id: 'exercise-details-assessments', done: this.exerciseProgress.assessmentOptions, approved: this.approvalProgress['assessmentOptions'] });
           data.push({ title: 'Exercise downloads', id: 'exercise-details-downloads', done: this.exerciseProgress.downloads, approved: this.approvalProgress['downloads'] });
           data.push({ title: 'Application process', id: 'exercise-details-application-content', done: this.exerciseProgress.applicationProcess, approved: this.approvalProgress['applicationProcess'] });
-          data.push({ title: 'Selection set-up', id: 'exercise-details-selection-setup', done: this.exerciseProgress.additionalSettings, approved: this.approvalProgress['additionalSettings'] });
           if (this.exercise.inviteOnly) {
             data.splice(1, 0, { title: 'Exercise invitations', id: 'exercise-details-invitations' , done: this.exerciseProgress.invitations, approved: this.approvalProgress['invitations'] });
           }
@@ -364,7 +363,8 @@ export default {
         && this.exerciseProgress.workingPreferences
         && this.exerciseProgress.assessmentOptions
         && this.exerciseProgress.downloads
-        && this.exerciseProgress.applicationProcess;
+        && this.exerciseProgress.applicationProcess
+        && (this.exercise._processingVersion < 2 || this.exerciseProgress.additionalSettings);
     },
     approveErrorMessage() {
       const msg = `You can only approve exercises with the advertType '${ lookup(ADVERT_TYPES.FULL) }' or '${ lookup(ADVERT_TYPES.EXTERNAL) }'.`;


### PR DESCRIPTION
Closes #2692

## Describe the bug
The `Selection set-up` option appears twice in the list onscreen:

<img width="1140" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeVRXQ0E9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--ee54bcc55c1ebfb51f86084b192b4fad1819f10d/image.png" alt="image.png" />

## To Reproduce
Steps to reproduce the behaviour:
1. Create a new exercise
2. Go to the Overview page and scroll down to the bottom of the list
3. See duplicate entry

## Expected behaviour
`Selection set-up` should only appear once in the list onscreen.


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
