### PR TITLE
Feat/admin 2679 UI amendments to pre sd workflow

### DIFF
--- a/src/views/Exercise/Details/Timeline/Edit.vue
+++ b/src/views/Exercise/Details/Timeline/Edit.vue
@@ -234,13 +234,11 @@
           id="selection-day-questionnaire-send-date"
           v-model="formData.preSelectionDayQuestionnaireSendDate"
           label="Pre Selection Day Questionnaire - send date"
-          required
         />
         <DateInput
           id="selection-day-questionnaire-send-date"
           v-model="formData.preSelectionDayQuestionnaireReturnDate"
           label="Pre Selection Day Questionnaire - return date"
-          required
         />
         <RepeatableFields
           v-model="formData.selectionDays"

--- a/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
+++ b/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
@@ -24,7 +24,13 @@
         Please finalise selection day interview dates and panellist details below
       </p>
 
-      <div v-if="formData.parts.indexOf('candidateAvailability') >= 0 && formData.candidateAvailabilityDates">
+      <Checkbox
+        id="ask-candidate-availability"
+        v-model="askCandidateAvailability"
+      >
+        Do you want to ask candidate's about their availability?
+      </Checkbox>
+      <div v-if="askCandidateAvailability && formData.candidateAvailabilityDates">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
           Which dates would you like to check for candidate availability?
         </h2>
@@ -73,10 +79,12 @@ import { functions } from '@/firebase';
 import RepeatableFields from '@jac-uk/jac-kit/draftComponents/RepeatableFields.vue';
 import LocationDate from './LocationDate.vue';
 import { shallowRef } from 'vue';
+import Checkbox from '@jac-uk/jac-kit/draftComponents/Form/Checkbox.vue';
 
 export default {
   components: {
     ErrorSummary,
+    Checkbox,
     CheckboxGroup,
     CheckboxItem,
     FullScreenButton,
@@ -121,7 +129,8 @@ export default {
       repeatableFields: shallowRef({
         LocationDate,
       }),
-      CandidateFormParts: candidateFormParts,
+      candidateFormParts,
+      askCandidateAvailability: true,
     };
   },
   computed: {
@@ -137,6 +146,15 @@ export default {
     },
     panellists() {
       return this.$store.state.panellists.records.map(item => ({ id: item.id, fullName: item.fullName }));
+    },
+  },
+  watch: {
+    askCandidateAvailability(newValue) {
+      if (newValue === true) {
+        this.formData.candidateFormParts = this.candidateFormParts;
+      } else {
+        this.formData.candidateFormParts = this.candidateFormParts.filter(part => part !== APPLICATION_FORM_PARTS.CANDIDATE_AVAILABILITY);
+      }
     },
   },
   async created() {

--- a/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
+++ b/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
@@ -28,7 +28,7 @@
         id="ask-candidate-availability"
         v-model="askCandidateAvailability"
       >
-        Do you want to ask candidate's about their availability?
+        Do you want to ask candidates about their availability?
       </Checkbox>
       <div v-if="askCandidateAvailability && formData.candidateAvailabilityDates">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-2">

--- a/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
+++ b/src/views/Exercise/Tasks/Task/CandidateForm/Configure.vue
@@ -171,7 +171,6 @@ export default {
         ...this.formData,
       };
 
-      console.log('save', saveData);
       await this.$store.dispatch('candidateForm/update', { saveData, formId: this.task.formId });
       await this.btnContinue();
     },

--- a/src/views/Exercise/Tasks/Task/CandidateForm/Panellist.vue
+++ b/src/views/Exercise/Tasks/Task/CandidateForm/Panellist.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="panellist-form">
+    <TextField
+      :id="`panellist_${index}`"
+      v-model="row.name"
+      input-class="govuk-input--width-20"
+      label=""
+      class="panellist"
+      required
+    />
+    <slot name="removeButton" />
+  </div>
+</template>
+
+<script>
+import TextField from '@jac-uk/jac-kit/draftComponents/Form/TextField.vue';
+import { getRandomString } from '@/helpers/helpers';
+
+export default {
+  name: 'Panellist',
+  components: {
+    TextField,
+  },
+  props: {
+    row: {
+      required: true,
+      type: Object,
+    },
+    index: {
+      required: true,
+      type: Number,
+    },
+    id: {
+      required: false,
+      type: String,
+      default: '',
+    },
+  },
+  created() {
+    if (!this.row.hasOwnProperty('id')) this.row.id = getRandomString(3);
+  },
+};
+</script>
+
+<style lang="scss">
+.panellist-form {
+  .jac-add-another__remove-button {
+    position: relative !important;
+    vertical-align: bottom !important;
+    margin-bottom: 32px !important;
+    margin-left: 20px !important;
+  }
+  .govuk-form-group {
+    display: inline-block;
+  }
+  .panellist > label {
+    font-size: 19px;
+    margin-bottom: 5px !important;
+    font-weight: normal;
+  }
+}
+</style>


### PR DESCRIPTION
## What's included?
closes #2679 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the preview link: https://jac-admin-develop--pr2698-feat-admin-2679-ui-a-6hpryh1n.web.app/
- Test 1. The `Pre Selection Day Questionnaire` dates on of timeline should be optional:
   - Go to the preview link: https://jac-admin-develop--pr2698-feat-admin-2679-ui-a-6hpryh1n.web.app/exercise/vFQI4CMwzhFwV7OzDxUX/details/timeline/?referrer=exercise-show-overview
   - This preview link is only for testing `Pre Selection Day Questionnaire` dates, do not use it to test other PSDQ functions.
   - The fields should be optional.
   - If the dates are not set, the Pre Selection Day Questionnaire should not appear in task menu.
   
<img width="621" alt="Screenshot 2025-03-10 at 13 17 56" src="https://github.com/user-attachments/assets/80dccd4a-0beb-4b69-900f-00d51fc56a74" />
<img width="850" alt="Screenshot 2025-03-10 at 13 23 13" src="https://github.com/user-attachments/assets/e36ebc73-8fe9-431c-8a4c-f0661e632eff" />

- Test 2. The set up of `candidate availability` in `Pre Selection Day Questionnaire` task:
  - Go to the preview link: https://jac-admin-develop--pr2698-feat-admin-2679-ui-a-6hpryh1n.web.app/exercise/AWXQYnNXFxutISQS8BvS/tasks/all/preSelectionDayQuestionnaire/configure-candidate-form
   - This preview link is only for testing PSDQ task set up, do not click save and continue.
  - The `Do you want to ask candidates about their availability?` should be added
    - The tickbox is ticked as default.
        - If it's ticked, it should show the `candidate availability` list that can be edited.
        - If it's unticked, it should remove the `candidate availability` list.
        
<img width="889" alt="Screenshot 2025-03-10 at 13 12 36" src="https://github.com/user-attachments/assets/7dd58c75-76a2-4a8a-adcd-53bf0a0422b9" />

- Test 3. The set up of `panellists` in `Pre Selection Day Questionnaire` task:
  - Go to the preview link: https://jac-admin-develop--pr2698-feat-admin-2679-ui-a-6hpryh1n.web.app/exercise/AWXQYnNXFxutISQS8BvS/tasks/all/preSelectionDayQuestionnaire/configure-candidate-form
   - This preview link is only for testing PSDQ task set up, do not click save and continue.
   - It should can add and delete panellists
       
<img width="909" alt="Screenshot 2025-03-10 at 13 15 18" src="https://github.com/user-attachments/assets/845f2a61-4efa-4028-8151-ad9fe0879f0f" />

- Test  4. The `candidate availability` and `panellists` should appear on the Apply site:
  - Go the Apply site: https://apply-develop.judicialappointments.digital/
  - Login with this candidate account:
  
```
kowei.hung@gmail.com
udiPBj99u8YCdK9eGc4F@
```

  - Go to Applications and click `Pre Selection Day Questionnaire` button
  ![Screenshot 2025-03-11 at 15 16 27](https://github.com/user-attachments/assets/caabf639-8de4-497c-84cf-74520339a66d)
  - It should can fill `candidate availability` and `panellists`
  - This preview link is only for testing `candidate availability` and `panellists` form, do not submit the application.
![Screenshot 2025-03-11 at 15 16 40](https://github.com/user-attachments/assets/e3bc6622-000e-4058-87e7-df84f0767341)


   
    
## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas


## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
