### PR TITLE
#2707 Permission: can view panellists

### DIFF
--- a/src/permissions.js
+++ b/src/permissions.js
@@ -159,6 +159,10 @@ const PERMISSIONS = {
         label: 'Can manage panellist data',
         value: 'pa1',
       },
+      canViewPanellists: {
+        label: 'Can view panellists',
+        value: 'pa2',
+      },
     },
   },
   panels: {


### PR DESCRIPTION
## What's included?
Adds a new permission to allow SETs to view panellist data. The panellist permissions are now:

**Can manage panellist data**
Allows user to view the panellist database and add, edit and delete panellists

**Can view panellists** 
Allows user to view panellist data but not manage it. For example the user will be able to view a dropdown of panellists when creating/editing Panels

Closes #2707 

## Who should test?
✅ Product owner
✅ Developers

## How to test?

Login as a user with the new 'Can view panellists' permission and without the 'Can manage panellist data' permission
Locate an exercise with a panel task (e.g. sift, selection day)
Edit a panel and try to update panellists

**Before** (use admin-develop)
Unable to update panellists

**Now** (use preview URL provided in comments of this PR)
Able to update panellists

Also please try the same steps with a user without 'Can view panellists' permission and without the 'Can manage panellist data' permission. Check that they are unable to update panellists

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work


https://github.com/user-attachments/assets/3920a76d-2dce-4a53-8bd7-a7600713d53c



---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
