### PR TITLE
#2710 Add Questions To Pre-Existing Exercise

### DIFF
--- a/src/components/QuestionConfig/View.vue
+++ b/src/components/QuestionConfig/View.vue
@@ -4,10 +4,14 @@
     class="govuk-summary-list__row"
   >
     <dt
-      class="govuk-summary-list__key"
+      :class="{'govuk-summary-list__key': !isHTMLValue}"
     >
       <span v-if="currentItem.topic">{{ currentItem.topic }}<br></span>
-      {{ currentItem.question }}
+      <CustomHTML
+        v-if="currentItem.question"
+        :value="currentItem.question"
+        style="margin-top: 20px;"
+      />
       <span
         class="govuk-hint"
       >
@@ -78,9 +82,12 @@
 </template>
 
 <script>
-
+import CustomHTML from '@jac-uk/jac-kit/components/CustomHTML.vue';
 export default {
   name: 'QuestionConfigView',
+  components: {
+    CustomHTML,
+  },
   props: {
     section: {
       type: String,
@@ -129,6 +136,9 @@ export default {
       } else {
         return false;
       }
+    },
+    isHTMLValue() {
+      return this.currentItem.question && this.currentItem.question.trim().charAt(0) === '<';
     },
   },
   methods: {

--- a/src/components/RepeatableFields/QuestionConfig.vue
+++ b/src/components/RepeatableFields/QuestionConfig.vue
@@ -76,10 +76,12 @@
       </div>
     </div>
 
-    <TextField
+    <RichTextInput
       id="working-preference-${type}-question"
       v-model="row.question"
       label="What question would you like to ask?"
+      hint=""
+      class="custom-html"
       required
     />
 
@@ -253,6 +255,7 @@ import AnswerGroup from '@/components/RepeatableFields/AnswerGroup.vue';
 import Answer from '@/components/RepeatableFields/Answer.vue';
 import { shallowRef } from 'vue';
 import { getRandomString } from '@/helpers/helpers';
+import RichTextInput from '@jac-uk/jac-kit/draftComponents/Form/RichTextInput.vue';
 
 export default {
   name: 'QuestionConfig',
@@ -263,6 +266,7 @@ export default {
     RadioItem,
     Checkbox,
     Select,
+    RichTextInput,
   },
   props: {
     row: {

--- a/src/views/InformationReview/PreferencesSummary.vue
+++ b/src/views/InformationReview/PreferencesSummary.vue
@@ -341,8 +341,10 @@
         class="govuk-summary-list"
       >
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key widerColumn">
-            {{ exercise.additionalWorkingPreferences[index].question }}
+          <dt :class="{'govuk-summary-list__key': !isHTMLValue(exercise.yesSalaryDetails), 'widerColumn': true}">
+            <CustomHTML
+              :value="exercise.additionalWorkingPreferences[index].question"
+            />
             <span
               v-if="!exercise.additionalWorkingPreferences[index].hasOwnProperty('groupAnswers')"
               class="govuk-body govuk-!-font-size-19"
@@ -415,12 +417,14 @@
 import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer.vue';
 import Banner from '@jac-uk/jac-kit/components/Banner/Banner.vue';
 import { isApplicationPartAsked } from '@/helpers/exerciseHelper';
+import CustomHTML from '@jac-uk/jac-kit/components/CustomHTML.vue';
 
 export default {
   name: 'PreferencesSummary',
   components: {
     InformationReviewRenderer,
     Banner,
+    CustomHTML,
   },
   props: {
     application: {
@@ -450,6 +454,9 @@ export default {
     },
   },
   methods: {
+    isHTMLValue(value) {
+      return value && value.trim().charAt(0) === '<';
+    },
     shouldRenderQuestion(item, section) {
       // If there's a linked question and its answer doesn't match this question's linked answer, do not render the question
       if (item.linkedQuestion && item.linkedAnswer) {

--- a/src/views/InformationReview/PreferencesSummary.vue
+++ b/src/views/InformationReview/PreferencesSummary.vue
@@ -341,7 +341,7 @@
         class="govuk-summary-list"
       >
         <div class="govuk-summary-list__row">
-          <dt :class="{'govuk-summary-list__key': !isHTMLValue(exercise.yesSalaryDetails), 'widerColumn': true}">
+          <dt :class="{'govuk-summary-list__key': !isHTMLValue(exercise.additionalWorkingPreferences[index].question), 'widerColumn': true}">
             <CustomHTML
               :value="exercise.additionalWorkingPreferences[index].question"
             />


### PR DESCRIPTION
## What's included?
The 'First-tier Tribunal Medical Members SEC' exercise needs a couple of questions added to it.
We have modified the Additional Working Preferences Questions so that they use rich html inputs to give more control over the appearance of the questions.

- Make the additional working prefs questions use a rich html input
- Ensure questions display correctly.
- Ensure the text isnt bold when the input is html.

Closes #2710 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the following exercise: https://jac-admin-develop--pr2711-feature-2710-add-que-tndi9x2j.web.app/exercise/oMVaKLPbEzR89VoJl6yi/dashboard
- Add/Modify the Additional Working Preferences Questions and ensure they display correctly on any relevant screen in admin
- Go to the associated ticket in Apply and check the url there to  ensure the questions display correctly there too: https://github.com/jac-uk/apply/pull/1298

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:PRODUCTION
_can be OFF, DEVELOP or STAGING_
