### PR TITLE
#2703 Amendment To Custom Report Default Fields

### DIFF
--- a/src/components/QuestionConfig/View.vue
+++ b/src/components/QuestionConfig/View.vue
@@ -4,10 +4,14 @@
     class="govuk-summary-list__row"
   >
     <dt
-      class="govuk-summary-list__key"
+      :class="{'govuk-summary-list__key': !isHTMLValue}"
     >
       <span v-if="currentItem.topic">{{ currentItem.topic }}<br></span>
-      {{ currentItem.question }}
+      <CustomHTML
+        v-if="currentItem.question"
+        :value="currentItem.question"
+        style="margin-top: 20px;"
+      />
       <span
         class="govuk-hint"
       >
@@ -78,9 +82,12 @@
 </template>
 
 <script>
-
+import CustomHTML from '@jac-uk/jac-kit/components/CustomHTML.vue';
 export default {
   name: 'QuestionConfigView',
+  components: {
+    CustomHTML,
+  },
   props: {
     section: {
       type: String,
@@ -129,6 +136,9 @@ export default {
       } else {
         return false;
       }
+    },
+    isHTMLValue() {
+      return this.currentItem.question && this.currentItem.question.trim().charAt(0) === '<';
     },
   },
   methods: {

--- a/src/components/RepeatableFields/QuestionConfig.vue
+++ b/src/components/RepeatableFields/QuestionConfig.vue
@@ -76,10 +76,12 @@
       </div>
     </div>
 
-    <TextField
+    <RichTextInput
       id="working-preference-${type}-question"
       v-model="row.question"
       label="What question would you like to ask?"
+      hint=""
+      class="custom-html"
       required
     />
 
@@ -253,6 +255,7 @@ import AnswerGroup from '@/components/RepeatableFields/AnswerGroup.vue';
 import Answer from '@/components/RepeatableFields/Answer.vue';
 import { shallowRef } from 'vue';
 import { getRandomString } from '@/helpers/helpers';
+import RichTextInput from '@jac-uk/jac-kit/draftComponents/Form/RichTextInput.vue';
 
 export default {
   name: 'QuestionConfig',
@@ -263,6 +266,7 @@ export default {
     RadioItem,
     Checkbox,
     Select,
+    RichTextInput,
   },
   props: {
     row: {

--- a/src/views/Exercise/Reports/Custom.vue
+++ b/src/views/Exercise/Reports/Custom.vue
@@ -372,7 +372,7 @@ export default {
       customReportName: null,
       selectedColumn: '',
       whereClauses: [],
-      columns: ['referenceNumber', 'personalDetails.fullName', 'status'],
+      columns: ['referenceNumber', 'personalDetails.fullName', '_processing.status'],
       warnings: '',
       warningTimeout: null,
       defaultGroups: customReportConstants.groups,

--- a/src/views/InformationReview/PreferencesSummary.vue
+++ b/src/views/InformationReview/PreferencesSummary.vue
@@ -341,8 +341,10 @@
         class="govuk-summary-list"
       >
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key widerColumn">
-            {{ exercise.additionalWorkingPreferences[index].question }}
+          <dt :class="{'govuk-summary-list__key': !isHTMLValue(exercise.yesSalaryDetails), 'widerColumn': true}">
+            <CustomHTML
+              :value="exercise.additionalWorkingPreferences[index].question"
+            />
             <span
               v-if="!exercise.additionalWorkingPreferences[index].hasOwnProperty('groupAnswers')"
               class="govuk-body govuk-!-font-size-19"
@@ -415,12 +417,14 @@
 import InformationReviewRenderer from '@/components/Page/InformationReviewRenderer.vue';
 import Banner from '@jac-uk/jac-kit/components/Banner/Banner.vue';
 import { isApplicationPartAsked } from '@/helpers/exerciseHelper';
+import CustomHTML from '@jac-uk/jac-kit/components/CustomHTML.vue';
 
 export default {
   name: 'PreferencesSummary',
   components: {
     InformationReviewRenderer,
     Banner,
+    CustomHTML,
   },
   props: {
     application: {
@@ -450,6 +454,9 @@ export default {
     },
   },
   methods: {
+    isHTMLValue(value) {
+      return value && value.trim().charAt(0) === '<';
+    },
     shouldRenderQuestion(item, section) {
       // If there's a linked question and its answer doesn't match this question's linked answer, do not render the question
       if (item.linkedQuestion && item.linkedAnswer) {

--- a/src/views/InformationReview/PreferencesSummary.vue
+++ b/src/views/InformationReview/PreferencesSummary.vue
@@ -341,7 +341,7 @@
         class="govuk-summary-list"
       >
         <div class="govuk-summary-list__row">
-          <dt :class="{'govuk-summary-list__key': !isHTMLValue(exercise.yesSalaryDetails), 'widerColumn': true}">
+          <dt :class="{'govuk-summary-list__key': !isHTMLValue(exercise.additionalWorkingPreferences[index].question), 'widerColumn': true}">
             <CustomHTML
               :value="exercise.additionalWorkingPreferences[index].question"
             />


### PR DESCRIPTION
## What's included?
Remove the status field and replace it with the Status (Admin) field as a default

Closes #2703 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Ensure the Status(Admin) field appears in the default fields instead of the Status field (see screenshot below).
Press the Generate Report button and ensure the fields display ok.
Press the Download Report button and ensure the fields display correctly in the downloaded file.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
<img width="1186" alt="Screenshot 2025-03-26 at 12 15 23" src="https://github.com/user-attachments/assets/6ee6ddca-4d2b-43c9-83bb-3cbcee5894f4" />

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
