### PR TITLE
#2700 Identify duplicate applications on an exercise

### DIFF
--- a/src/components/ModalViews/DuplicateApplications.vue
+++ b/src/components/ModalViews/DuplicateApplications.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <div class="modal__title govuk-!-padding-2 govuk-heading-m">
+      Duplicate Applications By NI Numnber
+    </div>
+    <div class="modal__content govuk-!-margin-6">
+      <div class="govuk-grid-row">
+        <div
+          v-if="applications.length === 0"
+          class="govuk-!-margin-bottom-5"
+        >
+          <span class="govuk-body-m">There are no applications with the same NI Nmber.</span>
+        </div>
+
+        <div v-else>
+          <div
+            class="govuk-!-margin-bottom-5"
+          >
+            <span class="govuk-body-m">See the list of applications below that have duplicate NI Numbers.</span>
+          </div>
+          <Table
+            data-key="referenceNumber"
+            :data="applications"
+            :columns="tableColumns"
+            local-data
+          >
+            <template #row="{row}">
+              <TableCell :title="tableColumns[0].title">
+                {{ row.referenceNumber }}
+              </TableCell>
+              <TableCell :title="tableColumns[1].title">
+                {{ row.name }}
+              </TableCell>
+              <TableCell :title="tableColumns[2].title">
+                {{ row.niNumber }}
+              </TableCell>
+            </template>
+          </Table>
+        </div>
+        <button
+          class="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+          @click.prevent="closeModal"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Table from '@jac-uk/jac-kit/components/Table/Table.vue';
+import TableCell from '@jac-uk/jac-kit/components/Table/TableCell.vue';
+export default {
+  name: 'DuplicateApplications',
+  components: {
+    Table,
+    TableCell,
+  },
+  props: {
+    applications: {
+      type: Array,
+      required: false,
+      default: () => [],
+    },
+  },
+  emits: ['close'],
+  computed: {
+    tableColumns() {
+      const cols = [];
+      cols.push({ title: 'Reference number' });
+      cols.push({ title: 'Name' });
+      cols.push({ title: 'NI Number' });
+      return cols;
+    },
+  },
+  methods: {
+    closeModal() {
+      this.$emit('close');
+    },
+  },
+};
+</script>

--- a/src/views/Exercise/Applications/List.vue
+++ b/src/views/Exercise/Applications/List.vue
@@ -25,6 +25,15 @@
               Send reminders
             </button>
             <ActionButton
+              v-if="isClosed && hasPermissions([
+                PERMISSIONS.applications.permissions.canReadApplications.value
+              ])"
+              class="govuk-!-margin-bottom-0 govuk-!-margin-right-2"
+              :action="checkDuplicateApplications"
+            >
+              Check Duplicate Applications
+            </ActionButton>
+            <ActionButton
               v-if="hasPermissions([
                 PERMISSIONS.exercises.permissions.canReadExercises.value,
                 PERMISSIONS.applications.permissions.canReadApplications.value
@@ -114,6 +123,13 @@
         @close="closeConfirmationModal()"
       />
     </Modal>
+
+    <Modal ref="duplicateApplicationmModal">
+      <DuplicateApplications
+        :applications="duplicateApplications"
+        @close="closeDuplicateApplicationModal()"
+      />
+    </Modal>
   </div>
 </template>
 
@@ -130,6 +146,7 @@ import LateApplicationConfirmation from '@/components/ModalViews/LateApplication
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal.vue';
 import ModalInner from '@jac-uk/jac-kit/components/Modal/ModalInner.vue';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton.vue';
+import DuplicateApplications from '@/components/ModalViews/DuplicateApplications.vue';
 
 export default {
   name: 'ApplicationsList',
@@ -141,6 +158,7 @@ export default {
     LateApplicationRequest,
     LateApplicationConfirmation,
     ActionButton,
+    DuplicateApplications,
   },
   mixins: [permissionMixin],
   props: {
@@ -148,6 +166,11 @@ export default {
       type: String,
       required: true,
     },
+  },
+  data() {
+    return {
+      duplicateApplications: [],
+    };
   },
   computed: {
     tableColumns() {
@@ -195,6 +218,10 @@ export default {
     },
     closeConfirmationModal() {
       this.$refs.lateApplicationRequestConfirmModal.closeModal();
+    },
+
+    closeDuplicateApplicationModal() {
+      this.$refs.duplicateApplicationmModal.closeModal();
     },
     getTableData(params) {
       this.$store.dispatch(
@@ -269,6 +296,16 @@ export default {
     },
     closeApplicationReminderModal() {
       this.$refs.applicationReminderModal.closeModal();
+    },
+    async checkDuplicateApplications() {
+      try {
+        const response = await httpsCallable(functions, 'checkDuplicateApplications')({ exerciseId: this.exercise.id });
+        this.duplicateApplications = response.data?.duplicates || [];
+        this.$refs.duplicateApplicationmModal.openModal();
+        return true;
+      } catch (error) {
+        return;
+      }
     },
   },
 };


### PR DESCRIPTION
## What's included?

### THIS PR IS ASSOCIATED WITH A DIGITAL PLATFORM PR: 

Identify duplicate applications (with the same NI Number) and display them in a modal.

Closes #2700 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the applications page of an exercise.
If the exercise is closed then you will see a button saying 'Check Duplicate Applications'.
Press this button and a modal will appear.
It will either say that there are no duplicate applications or it will show a table listing them. The list is grouped by reference number and ordered by name.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

<img width="1725" alt="Screenshot 2025-04-01 at 02 49 02" src="https://github.com/user-attachments/assets/6e641554-60f7-4e01-b505-3addd35ca12d" />

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
