### PR TITLE
Feat/admin 2672 address merit list issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "admin",
       "version": "1.88.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "4.1.50",
+        "@jac-uk/jac-kit": "4.1.54",
         "@ministryofjustice/frontend": "0.2.4",
         "@sentry/tracing": "^7.61.1",
         "@sentry/vue": "^7.61.1",
@@ -1772,13 +1772,14 @@
       }
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "4.1.50",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.50/5afa85989b60ef5c90f8c8020bf9907fd46ce6f0",
-      "integrity": "sha512-uMzb+dVQnfKWV9QV5m/Oi/ONqLiJTFC9mO4w63WDirrhUMIhffRuZFy3w/8c7N6S3h5YzYaUHgVhFSsbcQxb8Q==",
+      "version": "4.1.54",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.54/d913697bcb92bc775142b121643385ad1a93b6e7",
+      "integrity": "sha512-ixZog0l4VEZCStTEo1btgQG06P/wupmJYkKcJ0BzvEfSLjiuYsjxdwyqTmryNgerRwlshqPR34KCopYv5aFKiw==",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",
         "floating-vue": "^5.2.2",
+        "libphonenumber-js": "^1.11.16",
         "save-file": "^2.3.1",
         "stream-browserify": "^3.0.0",
         "uid": "^2.0.2",
@@ -6286,9 +6287,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.11.15",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.15.tgz",
-      "integrity": "sha512-M7+rtYi9l5RvMmHyjyoF3BHHUpXTYdJ0PezZGHNs0GyW1lO+K7jxlXpbdIb7a56h0nqLYdjIw+E+z0ciGaJP7g=="
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.6.tgz",
+      "integrity": "sha512-PJiS4ETaUfCOFLpmtKzAbqZQjCCKVu2OhTV4SVNNE7c2nu/dACvtCqj4L0i/KWNnIgRv7yrILvBj5Lonv5Ncxw=="
     },
     "node_modules/lie": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "4.1.50",
+    "@jac-uk/jac-kit": "4.1.54",
     "@ministryofjustice/frontend": "0.2.4",
     "@sentry/tracing": "^7.61.1",
     "@sentry/vue": "^7.61.1",

--- a/src/helpers/meritListHelper.js
+++ b/src/helpers/meritListHelper.js
@@ -545,6 +545,7 @@ function xlsxData(scoreGroups, task, diversityData, type) {
     }
     headers.push('Rank');
     headers.push('Z_Overall');
+    headers.push('Percentile');
   } else {
     if (type === DOWNLOAD_TYPES.full.value) {
       headers.push('Full name');
@@ -584,6 +585,7 @@ function xlsxData(scoreGroups, task, diversityData, type) {
       }
       row.push(item.rank);
       row.push(formatScore(item.zScore));
+      row.push(formatPercentile(item.percentileRank));
     } else {
       if (type === DOWNLOAD_TYPES.full.value) {
         row.push(item.fullName);
@@ -653,6 +655,7 @@ function xlsxData(scoreGroups, task, diversityData, type) {
           }
           row.push(formatScore(item.rank));
           row.push(formatScore(item.zScore));
+          row.push(formatPercentile(item.percentileRank));
         } else {
           if (type === DOWNLOAD_TYPES.full.value) {
             row.push(item.fullName);
@@ -708,4 +711,9 @@ function getDownloadTypes(task) {
 function formatScore(score, acceptZero = true) {
   if (score === null || score === undefined || (!acceptZero && score === 0)) return 'n/a';
   return score;
+}
+
+function formatPercentile(value, acceptZero = true) {
+  if (value === null || value === undefined || (!acceptZero && value === 0)) return 'n/a';
+  return `${value}%`;
 }

--- a/src/helpers/meritListHelper.js
+++ b/src/helpers/meritListHelper.js
@@ -136,6 +136,8 @@ function scores(task, scoreType, exerciseDiversity) {
       scoreMap[scoreData[scoreType]] = {
         applicationIds: [],
         count: 0,
+        cumulativeCount: 0,
+        percentileRank: 0,
         rank: 0,
         diversity: {
           female: 0,
@@ -231,6 +233,22 @@ function scores(task, scoreType, exerciseDiversity) {
       }
     });
   }
+
+  // Add cumulative count by count
+  let prevCumulativeCount = 0;
+  let scoreCount = 0;
+  scoresInDescendingOrder.forEach(key => {
+    const cumulativeCount = prevCumulativeCount + scoreMap[key].count;
+    scoreMap[key].cumulativeCount = cumulativeCount;
+    prevCumulativeCount = cumulativeCount;
+    scoreCount += scoreMap[key].count;
+  });
+
+  // Calculate percentile rank
+  scoresInDescendingOrder.forEach(key => {
+    const lowerScoreCount = scoreCount - (scoreMap[key].cumulativeCount - scoreMap[key].count);
+    scoreMap[key].percentileRank = ((lowerScoreCount / scoreCount) * 100).toFixed(2);
+  });
 
   // return
   return scoresInDescendingOrder.map(key => {

--- a/src/helpers/meritListHelper.js
+++ b/src/helpers/meritListHelper.js
@@ -163,6 +163,7 @@ function scores(task, scoreType, exerciseDiversity) {
     }
     scoreMap[scoreData[scoreType]].applicationIds.push(scoreData.id);
     scoreMap[scoreData[scoreType]].count += 1;
+    scoreMap[scoreData[scoreType]].percentileRank = scoreData?.percentileRank || null;
     const ref = scoreData.ref.split('-')[1];
     if (exerciseDiversity[ref]) {
       if (hasDiversityCharacteristic(exerciseDiversity[ref], DIVERSITY_CHARACTERISTICS.GENDER_FEMALE)) scoreMap[scoreData[scoreType]].diversity.female += 1;
@@ -233,22 +234,6 @@ function scores(task, scoreType, exerciseDiversity) {
       }
     });
   }
-
-  // Add cumulative count by count
-  let prevCumulativeCount = 0;
-  let scoreCount = 0;
-  scoresInDescendingOrder.forEach(key => {
-    const cumulativeCount = prevCumulativeCount + scoreMap[key].count;
-    scoreMap[key].cumulativeCount = cumulativeCount;
-    prevCumulativeCount = cumulativeCount;
-    scoreCount += scoreMap[key].count;
-  });
-
-  // Calculate percentile rank
-  scoresInDescendingOrder.forEach(key => {
-    const lowerScoreCount = scoreCount - (scoreMap[key].cumulativeCount - scoreMap[key].count);
-    scoreMap[key].percentileRank = ((lowerScoreCount / scoreCount) * 100).toFixed(2);
-  });
 
   // return
   return scoresInDescendingOrder.map(key => {

--- a/src/helpers/meritListHelper.js
+++ b/src/helpers/meritListHelper.js
@@ -564,7 +564,7 @@ function xlsxData(scoreGroups, task, diversityData, type) {
     }
     headers.push('Rank');
     headers.push('Z_Overall');
-    headers.push('Z_Overall %');
+    headers.push('Percentile %');
   } else {
     if (type === DOWNLOAD_TYPES.full.value) {
       headers.push('Full name');

--- a/src/helpers/meritListHelper.js
+++ b/src/helpers/meritListHelper.js
@@ -545,7 +545,7 @@ function xlsxData(scoreGroups, task, diversityData, type) {
     }
     headers.push('Rank');
     headers.push('Z_Overall');
-    headers.push('Percentile');
+    headers.push('Z_Overall %');
   } else {
     if (type === DOWNLOAD_TYPES.full.value) {
       headers.push('Full name');
@@ -585,7 +585,7 @@ function xlsxData(scoreGroups, task, diversityData, type) {
       }
       row.push(item.rank);
       row.push(formatScore(item.zScore));
-      row.push(formatPercentile(item.percentileRank));
+      row.push(formatScore(item.percentileRank));
     } else {
       if (type === DOWNLOAD_TYPES.full.value) {
         row.push(item.fullName);
@@ -655,7 +655,7 @@ function xlsxData(scoreGroups, task, diversityData, type) {
           }
           row.push(formatScore(item.rank));
           row.push(formatScore(item.zScore));
-          row.push(formatPercentile(item.percentileRank));
+          row.push(formatScore(item.percentileRank));
         } else {
           if (type === DOWNLOAD_TYPES.full.value) {
             row.push(item.fullName);
@@ -711,9 +711,4 @@ function getDownloadTypes(task) {
 function formatScore(score, acceptZero = true) {
   if (score === null || score === undefined || (!acceptZero && score === 0)) return 'n/a';
   return score;
-}
-
-function formatPercentile(value, acceptZero = true) {
-  if (value === null || value === undefined || (!acceptZero && value === 0)) return 'n/a';
-  return `${value}%`;
 }

--- a/src/helpers/meritListHelper.js
+++ b/src/helpers/meritListHelper.js
@@ -519,6 +519,19 @@ function downloadMeritList(title, scoreGroups, task, diversityData, type, fileNa
         title: title,
         sheetName: DOWNLOAD_TYPES[type].sheetName,
         fileName: `${fileName}.xlsx`,
+        merges: ['A1:I1'], // For merge the cells of the note on the top
+        styles: {
+          row: {
+            1: { // Add yellow background for the note on the top
+              bold: true,
+              fill: 'FFFF00',
+            },
+            2: { // Add grey background and bold for the headers
+              bold: true,
+              fill: 'eeeeee',
+            },
+          },
+        },
       }
     );
     return true;
@@ -530,6 +543,12 @@ function downloadMeritList(title, scoreGroups, task, diversityData, type, fileNa
 function xlsxData(scoreGroups, task, diversityData, type) {
   // const taskScoreType = scoreType(task);
   const rows = [];
+
+  // add note on the top of table
+  const note = ['Diversity stats reflect total representation when each band is included, descending from the top'];
+  rows.push(note);
+
+  // add headers
   const headers = [];
   headers.push('Ref');
   if (task.type === TASK_TYPE.QUALIFYING_TEST) {
@@ -567,6 +586,10 @@ function xlsxData(scoreGroups, task, diversityData, type) {
   headers.push('Solicitor');
   headers.push('Disability');
   rows.push(headers);
+
+  // add empty columns for note according to headers
+  note.push(...Array(headers.length - 1).fill(''));
+
   scoreData(task, scoreType(task), diversityData).forEach(item => {
     const row = [];
     row.push(item.ref);

--- a/src/helpers/meritListHelper.js
+++ b/src/helpers/meritListHelper.js
@@ -519,19 +519,6 @@ function downloadMeritList(title, scoreGroups, task, diversityData, type, fileNa
         title: title,
         sheetName: DOWNLOAD_TYPES[type].sheetName,
         fileName: `${fileName}.xlsx`,
-        merges: ['A1:I1'], // For merge the cells of the note on the top
-        styles: {
-          row: {
-            1: { // Add yellow background for the note on the top
-              bold: true,
-              fill: 'FFFF00',
-            },
-            2: { // Add grey background and bold for the headers
-              bold: true,
-              fill: 'eeeeee',
-            },
-          },
-        },
       }
     );
     return true;
@@ -543,10 +530,6 @@ function downloadMeritList(title, scoreGroups, task, diversityData, type, fileNa
 function xlsxData(scoreGroups, task, diversityData, type) {
   // const taskScoreType = scoreType(task);
   const rows = [];
-
-  // add note on the top of table
-  const note = ['Diversity stats reflect total representation when each band is included, descending from the top'];
-  rows.push(note);
 
   // add headers
   const headers = [];
@@ -586,9 +569,6 @@ function xlsxData(scoreGroups, task, diversityData, type) {
   headers.push('Solicitor');
   headers.push('Disability');
   rows.push(headers);
-
-  // add empty columns for note according to headers
-  note.push(...Array(headers.length - 1).fill(''));
 
   scoreData(task, scoreType(task), diversityData).forEach(item => {
     const row = [];

--- a/src/views/Exercise/Tasks/Task/Finalised/List.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/List.vue
@@ -92,6 +92,13 @@
             {{ $filters.formatNumber(row.score, 2) }}
           </template>
         </TableCell>
+        <!-- Percentile Rank -->
+        <template v-if="showPercentileRank">
+          <TableCell :title="tableColumns[3].title">
+            {{ row.percentileRank }}%
+          </TableCell>
+        </template>
+
         <template v-if="showDiversity">
           <TableCell :title="tableColumns[3].title">
             {{ $filters.formatNumber(100 * (row.cumulativeDiversity.female / (row.rank + row.count - 1)), 2) }}%
@@ -305,10 +312,14 @@ export default {
     },
   },
   data() {
+    const showPercentileRank = this.task.type === TASK_TYPE.QUALIFYING_TEST;
     const tableColumns = [];
     tableColumns.push({ title: 'Rank' });
     tableColumns.push({ title: 'Count' });
     tableColumns.push({ title: this.$filters.lookup(this.scoreType) });
+    if (showPercentileRank) {
+      tableColumns.push({ title: 'Percent' });
+    }
     if (this.showDiversity) {
       tableColumns.push({ title: 'Female' });
       tableColumns.push({ title: 'Ethnic Minority' });
@@ -318,6 +329,7 @@ export default {
     tableColumns.push({ title: 'Outcome' });
     tableColumns.push({ title: '' });
     return {
+      showPercentileRank,
       tableColumns: tableColumns,
       expandedScores: [],
       selectedItem: null,

--- a/src/views/Exercise/Tasks/Task/Finalised/List.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/List.vue
@@ -43,6 +43,10 @@
       </div>
     </div>
 
+    <div class="govuk-grid-row govuk-!-margin-bottom-1">
+      <span class="govuk-body-s govuk-!-margin-left-3">* Diversity stats reflect total representation when each band is included, descending from the top</span>
+    </div>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <a

--- a/src/views/Exercise/Tasks/Task/Finalised/List.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/List.vue
@@ -98,8 +98,8 @@
         </TableCell>
         <!-- Percentile Rank -->
         <template v-if="showPercentileRank">
-          <TableCell :title="titleLookup('percent')">
-            {{ row.percentileRank }}
+          <TableCell :title="titleLookup('percentile')">
+            {{ row.percentileRank }}%
           </TableCell>
         </template>
 
@@ -324,7 +324,7 @@ export default {
     tableColumns.push({ title: this.titleLookup('count') });
     tableColumns.push({ title: this.$filters.lookup(this.scoreType) });
     if (showPercentileRank) {
-      tableColumns.push({ title: this.titleLookup('percent') });
+      tableColumns.push({ title: this.titleLookup('percentile') });
     }
     if (this.showDiversity) {
       tableColumns.push({ title: this.titleLookup('female') });
@@ -532,7 +532,7 @@ export default {
         rank: 'Rank',
         count: 'Count',
         score: this.$filters.lookup(this.scoreType),
-        percent: 'Percent',
+        percentile: 'Percentile',
         female: 'Female',
         ethnicMinority: 'Ethnic Minority',
         solicitor: 'Solicitor',

--- a/src/views/Exercise/Tasks/Task/Finalised/List.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/List.vue
@@ -44,7 +44,7 @@
     </div>
 
     <div class="govuk-grid-row govuk-!-margin-bottom-1">
-      <span class="govuk-body-s govuk-!-margin-left-3">* Diversity stats reflect total representation when each band is included, descending from the top</span>
+      <span class="govuk-!-margin-left-3 govuk-heading-s">Diversity stats reflect total representation when each band is included, descending from the top</span>
     </div>
 
     <div class="govuk-grid-row">

--- a/src/views/Exercise/Tasks/Task/Finalised/List.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/List.vue
@@ -94,7 +94,7 @@
         </TableCell>
         <!-- Percentile Rank -->
         <template v-if="showPercentileRank">
-          <TableCell :title="tableColumns[3].title">
+          <TableCell>
             {{ row.percentileRank }}%
           </TableCell>
         </template>
@@ -161,6 +161,14 @@
             <TableCell colspan="3">
               {{ item.fullName || item.ref }}
             </TableCell>
+
+            <!-- Percentile Rank -->
+            <template v-if="showPercentileRank">
+              <TableCell>
+                {{ row.percentileRank }}%
+              </TableCell>
+            </template>
+
             <template v-if="showDiversity">
               <TableCell :title="tableColumns[3].title">
                 {{ $filters.toYesNo(item.diversity.female) }}

--- a/src/views/Exercise/Tasks/Task/Finalised/List.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/List.vue
@@ -95,7 +95,7 @@
         <!-- Percentile Rank -->
         <template v-if="showPercentileRank">
           <TableCell :title="titleLookup('percent')">
-            {{ row.percentileRank }}%
+            {{ row.percentileRank }}
           </TableCell>
         </template>
 
@@ -320,7 +320,7 @@ export default {
     tableColumns.push({ title: this.titleLookup('count') });
     tableColumns.push({ title: this.$filters.lookup(this.scoreType) });
     if (showPercentileRank) {
-      tableColumns.push({ title: this.titleLookup('percentile') });
+      tableColumns.push({ title: this.titleLookup('percent') });
     }
     if (this.showDiversity) {
       tableColumns.push({ title: this.titleLookup('female') });
@@ -528,7 +528,7 @@ export default {
         rank: 'Rank',
         count: 'Count',
         score: this.$filters.lookup(this.scoreType),
-        percentile: 'Percent',
+        percent: 'Percent',
         female: 'Female',
         ethnicMinority: 'Ethnic Minority',
         solicitor: 'Solicitor',

--- a/src/views/Exercise/Tasks/Task/Finalised/List.vue
+++ b/src/views/Exercise/Tasks/Task/Finalised/List.vue
@@ -78,13 +78,13 @@
       class="merit-list"
     >
       <template #row="{row}">
-        <TableCell :title="tableColumns[0].title">
+        <TableCell :title="titleLookup('rank')">
           <span class="govuk-body">{{ row.rank }}</span>
         </TableCell>
-        <TableCell :title="tableColumns[1].title">
+        <TableCell :title="titleLookup('count')">
           {{ row.count }}
         </TableCell>
-        <TableCell :title="tableColumns[2].title">
+        <TableCell :title="titleLookup(scoreType)">
           <template v-if="scoreType == 'gradeScore'">
             {{ row.score }}
           </template>
@@ -94,26 +94,26 @@
         </TableCell>
         <!-- Percentile Rank -->
         <template v-if="showPercentileRank">
-          <TableCell>
+          <TableCell :title="titleLookup('percent')">
             {{ row.percentileRank }}%
           </TableCell>
         </template>
 
         <template v-if="showDiversity">
-          <TableCell :title="tableColumns[3].title">
+          <TableCell :title="titleLookup('female')">
             {{ $filters.formatNumber(100 * (row.cumulativeDiversity.female / (row.rank + row.count - 1)), 2) }}%
           </TableCell>
-          <TableCell :title="tableColumns[4].title">
+          <TableCell :title="titleLookup('bame')">
             {{ $filters.formatNumber(100 * (row.cumulativeDiversity.bame / (row.rank + row.count - 1)), 2) }}%
           </TableCell>
-          <TableCell :title="tableColumns[5].title">
+          <TableCell :title="titleLookup('solicitor')">
             {{ $filters.formatNumber(100 * (row.cumulativeDiversity.solicitor / (row.rank + row.count - 1)), 2) }}%
           </TableCell>
-          <TableCell :title="tableColumns[6].title">
+          <TableCell :title="titleLookup('disability')">
             {{ $filters.formatNumber(100 * (row.cumulativeDiversity.disability / (row.rank + row.count - 1)), 2) }}%
           </TableCell>
         </template>
-        <TableCell :title="showDiversity ? tableColumns[7].title : tableColumns[3].title">
+        <TableCell :title="titleLookup('outcome')">
           <template v-if="!isScoreExpanded(row.score)">
             <div
               v-if="row.outcome.pass"
@@ -158,32 +158,25 @@
             class="govuk-table__row extra-row"
             :class="{ 'highlight': item.ref == selectedApplication}"
           >
-            <TableCell colspan="3">
+            <TableCell colspan="4">
               {{ item.fullName || item.ref }}
             </TableCell>
 
-            <!-- Percentile Rank -->
-            <template v-if="showPercentileRank">
-              <TableCell>
-                {{ row.percentileRank }}%
-              </TableCell>
-            </template>
-
             <template v-if="showDiversity">
-              <TableCell :title="tableColumns[3].title">
+              <TableCell :title="titleLookup('female')">
                 {{ $filters.toYesNo(item.diversity.female) }}
               </TableCell>
-              <TableCell :title="tableColumns[4].title">
+              <TableCell :title="titleLookup('bame')">
                 {{ $filters.toYesNo(item.diversity.bame) }}
               </TableCell>
-              <TableCell :title="tableColumns[5].title">
+              <TableCell :title="titleLookup('solicitor')">
                 {{ $filters.toYesNo(item.diversity.solicitor) }}
               </TableCell>
-              <TableCell :title="tableColumns[6].title">
+              <TableCell :title="titleLookup('disability')">
                 {{ $filters.toYesNo(item.diversity.disability) }}
               </TableCell>
             </template>
-            <TableCell :title="showDiversity ? tableColumns[7].title : tableColumns[3].title">
+            <TableCell :title="titleLookup('outcome')">
               <strong
                 v-if="passMark && isPass(item)"
                 class="govuk-tag govuk-tag--green"
@@ -280,6 +273,7 @@ import { isPass, totalApplications, totalPassed, totalFailed, totalDidNotPartici
 import { TASK_TYPE } from '@/helpers/exerciseHelper';
 import _deepClone from 'lodash/cloneDeep';
 import _isEmpty from 'lodash/isEmpty';
+import _startCase from 'lodash/startCase';
 
 export default {
   components: {
@@ -322,19 +316,19 @@ export default {
   data() {
     const showPercentileRank = this.task.type === TASK_TYPE.QUALIFYING_TEST;
     const tableColumns = [];
-    tableColumns.push({ title: 'Rank' });
-    tableColumns.push({ title: 'Count' });
+    tableColumns.push({ title: this.titleLookup('rank') });
+    tableColumns.push({ title: this.titleLookup('count') });
     tableColumns.push({ title: this.$filters.lookup(this.scoreType) });
     if (showPercentileRank) {
-      tableColumns.push({ title: 'Percent' });
+      tableColumns.push({ title: this.titleLookup('percentile') });
     }
     if (this.showDiversity) {
-      tableColumns.push({ title: 'Female' });
-      tableColumns.push({ title: 'Ethnic Minority' });
-      tableColumns.push({ title: 'Solicitor' });
-      tableColumns.push({ title: 'Disability' });
+      tableColumns.push({ title: this.titleLookup('female') });
+      tableColumns.push({ title: this.titleLookup('ethnicMinority') });
+      tableColumns.push({ title: this.titleLookup('solicitor') });
+      tableColumns.push({ title: this.titleLookup('disability') });
     }
-    tableColumns.push({ title: 'Outcome' });
+    tableColumns.push({ title: this.titleLookup('outcome') });
     tableColumns.push({ title: '' });
     return {
       showPercentileRank,
@@ -528,6 +522,21 @@ export default {
       };
       downloadMeritList(title, scoreGroups, task, this.exerciseDiversity, saveData.type, fileName);
       this.$refs['exportModal'].closeModal();
+    },
+    titleLookup(key) {
+      const titleMap = {
+        rank: 'Rank',
+        count: 'Count',
+        score: this.$filters.lookup(this.scoreType),
+        percentile: 'Percent',
+        female: 'Female',
+        ethnicMinority: 'Ethnic Minority',
+        solicitor: 'Solicitor',
+        disability: 'Disability',
+        outcome: 'Outcome',
+      };
+
+      return titleMap[key] || _startCase(key);
     },
   },
 };

--- a/tests/unit/helpers/meritListHelper.test.js
+++ b/tests/unit/helpers/meritListHelper.test.js
@@ -24,24 +24,6 @@ import { downloadXLSX } from '@jac-uk/jac-kit/helpers/export';
 import { TASK_TYPE } from '@/helpers/constants';
 import { vi } from 'vitest';
 
-const xlsxOptions = {
-  merges: ['A1:I1'], // For merge the cells of the note on the top
-  styles: {
-    row: {
-      1: { // Add yellow background for the note on the top
-        bold: true,
-        fill: 'FFFF00',
-      },
-      2: { // Add grey background and bold for the headers
-        bold: true,
-        fill: 'eeeeee',
-      },
-    },
-  },
-};
-
-const note = 'Diversity stats reflect total representation when each band is included, descending from the top';
-
 describe('getOverrideReasons', () => {
   it('should return override reasons', () => {
     expect(getOverrideReasons()).toEqual(Object.values(OVERRIDE_REASON));
@@ -937,7 +919,6 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
-        ...xlsxOptions,
       }
     );
   });
@@ -956,7 +937,6 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.emp.sheetName,
         fileName: `${fileName}.xlsx`,
-        ...xlsxOptions,
       }
     );
 
@@ -996,18 +976,6 @@ describe('downloadMeritList', () => {
     expect(downloadXLSX).toHaveBeenCalledWith(
       [
         [
-          note,
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-        ],
-        [
           'Ref',
           'Full name',
           'Email',
@@ -1024,7 +992,6 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
-        ...xlsxOptions,
       }
     );
 
@@ -1039,16 +1006,6 @@ describe('downloadMeritList', () => {
     downloadMeritList(title, {}, task, diversityData, DOWNLOAD_TYPES.emp.value, fileName);
 
     expect(downloadXLSX).toHaveBeenCalledWith([
-      [
-              note,
-              '',
-              '',
-              '',
-              '',
-              '',
-              '',
-              '',
-            ],
         [
           'Ref',
           'Score',
@@ -1064,7 +1021,6 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.emp.sheetName,
         fileName: `${fileName}.xlsx`,
-        ...xlsxOptions,
       }
     );
 
@@ -1084,18 +1040,6 @@ describe('downloadMeritList', () => {
 
     expect(downloadXLSX).toHaveBeenCalledWith(
       [
-        [
-                note,
-                '',
-                '',
-                '',
-                '',
-                '',
-                '',
-                '',
-                '',
-                '',
-              ],
         [
           'Ref',
           'Full name',
@@ -1137,7 +1081,6 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
-        ...xlsxOptions,
       }
     );
   });
@@ -1155,18 +1098,6 @@ describe('downloadMeritList', () => {
 
     expect(downloadXLSX).toHaveBeenCalledWith(
       [
-        [
-                 note,
-                 '',
-                 '',
-                 '',
-                 '',
-                 '',
-                 '',
-                 '',
-                 '',
-                 '',
-               ],
         [
           'Ref',
           'Full name',
@@ -1196,7 +1127,6 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
-        ...xlsxOptions,
       }
     );
   });
@@ -1213,18 +1143,6 @@ describe('downloadMeritList', () => {
 
     expect(downloadXLSX).toHaveBeenCalledWith(
       [
-        [
-          note,
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-        ],
         [
           'Ref',
           'Full name',
@@ -1254,7 +1172,6 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
-        ...xlsxOptions,
       }
     );
   });

--- a/tests/unit/helpers/meritListHelper.test.js
+++ b/tests/unit/helpers/meritListHelper.test.js
@@ -24,6 +24,24 @@ import { downloadXLSX } from '@jac-uk/jac-kit/helpers/export';
 import { TASK_TYPE } from '@/helpers/constants';
 import { vi } from 'vitest';
 
+const xlsxOptions = {
+  merges: ['A1:I1'], // For merge the cells of the note on the top
+  styles: {
+    row: {
+      1: { // Add yellow background for the note on the top
+        bold: true,
+        fill: 'FFFF00',
+      },
+      2: { // Add grey background and bold for the headers
+        bold: true,
+        fill: 'eeeeee',
+      },
+    },
+  },
+};
+
+const note = 'Diversity stats reflect total representation when each band is included, descending from the top';
+
 describe('getOverrideReasons', () => {
   it('should return override reasons', () => {
     expect(getOverrideReasons()).toEqual(Object.values(OVERRIDE_REASON));
@@ -919,6 +937,7 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
+        ...xlsxOptions,
       }
     );
   });
@@ -937,6 +956,7 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.emp.sheetName,
         fileName: `${fileName}.xlsx`,
+        ...xlsxOptions,
       }
     );
 
@@ -976,6 +996,18 @@ describe('downloadMeritList', () => {
     expect(downloadXLSX).toHaveBeenCalledWith(
       [
         [
+          note,
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+        ],
+        [
           'Ref',
           'Full name',
           'Email',
@@ -992,6 +1024,7 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
+        ...xlsxOptions,
       }
     );
 
@@ -1006,6 +1039,16 @@ describe('downloadMeritList', () => {
     downloadMeritList(title, {}, task, diversityData, DOWNLOAD_TYPES.emp.value, fileName);
 
     expect(downloadXLSX).toHaveBeenCalledWith([
+      [
+              note,
+              '',
+              '',
+              '',
+              '',
+              '',
+              '',
+              '',
+            ],
         [
           'Ref',
           'Score',
@@ -1021,6 +1064,7 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.emp.sheetName,
         fileName: `${fileName}.xlsx`,
+        ...xlsxOptions,
       }
     );
 
@@ -1040,6 +1084,18 @@ describe('downloadMeritList', () => {
 
     expect(downloadXLSX).toHaveBeenCalledWith(
       [
+        [
+                note,
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+              ],
         [
           'Ref',
           'Full name',
@@ -1081,6 +1137,7 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
+        ...xlsxOptions,
       }
     );
   });
@@ -1098,6 +1155,18 @@ describe('downloadMeritList', () => {
 
     expect(downloadXLSX).toHaveBeenCalledWith(
       [
+        [
+                 note,
+                 '',
+                 '',
+                 '',
+                 '',
+                 '',
+                 '',
+                 '',
+                 '',
+                 '',
+               ],
         [
           'Ref',
           'Full name',
@@ -1127,6 +1196,7 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
+        ...xlsxOptions,
       }
     );
   });
@@ -1143,6 +1213,18 @@ describe('downloadMeritList', () => {
 
     expect(downloadXLSX).toHaveBeenCalledWith(
       [
+        [
+          note,
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+        ],
         [
           'Ref',
           'Full name',
@@ -1172,6 +1254,7 @@ describe('downloadMeritList', () => {
         title: title,
         sheetName: DOWNLOAD_TYPES.full.sheetName,
         fileName: `${fileName}.xlsx`,
+        ...xlsxOptions,
       }
     );
   });


### PR DESCRIPTION
## What's included?
closes #2672 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Remove apostrophe in front of the score
    - Go to the preview link: https://jac-admin-develop--pr2721-feat-admin-2672-addr-d3ylvr8b.web.app/exercise/pvP1C5XCCfPTZZNFAPGu/tasks/all/qualifyingTest/finalised/
    - Download the merit lis.t
    - Any of the z-score columns (H, I, K) with a negative value should without an apostrophe in front of the score.
    
<img width="283" alt="Screenshot 2025-04-03 at 09 15 25" src="https://github.com/user-attachments/assets/321d16bd-7e62-4e4f-bb6e-c39e9050346c" />

- Diversity columns display yes/no
   - Go to the preview link: https://jac-admin-develop--pr2721-feat-admin-2672-addr-d3ylvr8b.web.app/exercise/QWXzmysQXBzpAngOGz7a/tasks/all/qualifyingTest/finalised/
   - Download the merit list, the columns Diversity columns  should be  display yes/no.
   
<img width="409" alt="Screenshot 2025-04-03 at 09 21 31" src="https://github.com/user-attachments/assets/d773cd4f-e0ea-429e-a3e8-82f8acdd0552" />

   
- Add a note at the top of the table
    - Go to the preview link: https://jac-admin-develop--pr2721-feat-admin-2672-addr-d3ylvr8b.web.app/exercise/pvP1C5XCCfPTZZNFAPGu/tasks/all/qualifyingTest/finalised/
    - On the screen, it should have a note at the top of the table: 
       'Diversity stats reflect total representation when each band is included, descending from the top'.
       
<img width="1249" alt="Screenshot 2025-04-04 at 14 44 54" src="https://github.com/user-attachments/assets/c3659123-54ae-4dc1-9b37-454a611505d1" />

-  Add a percentile column to QT merit list
    - Go to the preview link: https://jac-admin-develop--pr2721-feat-admin-2672-addr-d3ylvr8b.web.app/exercise/pvP1C5XCCfPTZZNFAPGu/tasks/all/qualifyingTest/finalised/
     - On the screen, it should have a percentile column displaying percentile rank.
     - In the download, it should have a percentile column displaying percentile rank. 
       
![Screenshot 2025-04-03 at 09 15 03](https://github.com/user-attachments/assets/d6514994-1f1f-41d8-afa8-634be9238196)

<img width="283" alt="Screenshot 2025-04-03 at 09 15 25" src="https://github.com/user-attachments/assets/d6f65069-bb9e-4d07-b92e-74b1a64fa43a" />


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
